### PR TITLE
修复py api中将非unicode字符传给callback导致的退出问题

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,11 +3,11 @@ import sys
 import platform
 import logging
 import argparse
+sys.path.append('./build-py')
 import pyfastllm # 或fastllm
 
 logging.info(f"python gcc version:{platform.python_compiler()}")
 
-sys.path.append('./build-py')
 
 def args_parser():
     parser = argparse.ArgumentParser(description='pyfastllm')
@@ -19,11 +19,12 @@ def args_parser():
     return args
 
 LLM_TYPE = ""
-def print_back(idx:int, content: str):
+def print_back(idx:int, content: bytearray):
+    content = content.decode(encoding="utf-8", errors="replace")
     if idx == 0:
         print(f"{LLM_TYPE}:{content}", end='')
     elif idx > 0:
-        print(f"{content}", end='')
+        print(f"{content}", end='\n')
     elif idx == -1:
         print()
 

--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -1,7 +1,13 @@
 #pragma once
 #include "fastllm.h"
 
+#ifdef PY_API
+#include "Python.h"
+#include <pybind11/pytypes.h>
+using RuntimeResult = std::function<void(int index, pybind11::bytes content)>;
+#else
 using RuntimeResult = std::function<void(int index, const char* content)>;
+#endif
 using RuntimeResultBatch = std::function<void(int index, std::vector <std::string> &contents)>;
 
 namespace fastllm {

--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -280,7 +280,11 @@ TimeRecord batchRecord;
             std::string curString = weight.tokenizer.Decode(Data(DataType::FLOAT32, {(int)results.size()}, results)).c_str();
             retString += curString;
 			if (retCb)
+#ifdef PY_API
+				retCb(index++, pybind11::bytes(retString));
+#else
 				retCb(index++, curString.c_str());
+#endif
             fflush(stdout);
             results.clear();
 
@@ -298,7 +302,11 @@ TimeRecord batchRecord;
             // printf("len = %d, spend %f s.\n", len, GetSpan(st, std::chrono::system_clock::now()));
         }
 		if (retCb)
+#ifdef PY_API
+			retCb(-1, pybind11::bytes(retString));
+#else
 			retCb(-1, retString.c_str());
+#endif
         return retString;
     }
 

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -225,7 +225,11 @@ namespace fastllm {
             std::string curString = weight.tokenizer.Decode(Data(DataType::FLOAT32, {(int)results.size()}, results)).c_str();
             retString += curString;
             if (retCb)
+#ifdef PY_API
+				retCb(index++, pybind11::bytes(retString));
+#else
                 retCb(index++, curString.c_str());
+#endif
             fflush(stdout);
             results.clear();
 
@@ -242,7 +246,11 @@ namespace fastllm {
             //printf("spend %f s.\n", GetSpan(st, std::chrono::system_clock::now()));
         }
         if (retCb)
+#ifdef PY_API
+			retCb(-1, pybind11::bytes(retString));
+#else
             retCb(-1, retString.c_str());
+#endif
 
         return retString;
     }

--- a/src/models/moss.cpp
+++ b/src/models/moss.cpp
@@ -213,7 +213,11 @@ namespace fastllm {
                     Data(DataType::FLOAT32, {(int) results.size()}, results)).c_str();
             retString += current;
 			if (retCb)
+#ifdef PY_API
+				retCb(index++, pybind11::bytes(retString));
+#else
 				retCb(index++, current.c_str());
+#endif
             fflush(stdout);
             results.clear();
 
@@ -224,7 +228,11 @@ namespace fastllm {
         }
 
 		if (retCb)
+#ifdef PY_API
+			retCb(-1, pybind11::bytes(retString));
+#else
 			retCb(-1, retString.c_str());
+#endif
         // printf("%s\n", weight.tokenizer.Decode(Data(DataType::FLOAT32, {(int)results.size()}, results)).c_str());
         return retString;
     }


### PR DESCRIPTION
如题，已在最新主分支上修复py api中将非unicode字符（如emoji）传给callback导致的退出问题
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf0 in position 0: unexpected end of data
