### PR TITLE
修复ChatGLM模型导出bug

### DIFF
--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -2,12 +2,12 @@ import struct
 import numpy as np
 
 def writeString(fo, s):
-    fo.write(struct.pack('i', len(s)));
-    fo.write(s.encode());
+    fo.write(struct.pack('i', len(s)))
+    fo.write(s.encode())
 
 def writeKeyValue(fo, key, value):
-    writeString(fo, key);
-    writeString(fo, value);
+    writeString(fo, key)
+    writeString(fo, value)
 
 def tofile(exportPath,
            model,
@@ -16,74 +16,74 @@ def tofile(exportPath,
            user_role = None,
            bot_role = None,
            history_sep = None):
-    dict = model.state_dict();
-    fo = open(exportPath, "wb");
+    dict = model.state_dict()
+    fo = open(exportPath, "wb")
 
     # 0. version id
-    fo.write(struct.pack('i', 2));
+    fo.write(struct.pack('i', 2))
 
     # 0.1 model info
     modelInfo = model.config.__dict__
     if ("model_type" not in modelInfo):
-        print("unknown model_type.");
-        exit(0);
+        print("unknown model_type.")
+        exit(0)
 
     if (pre_prompt):
-        modelInfo["pre_prompt"] = pre_prompt;
+        modelInfo["pre_prompt"] = pre_prompt
     if (user_role):
-        modelInfo["user_role"] = user_role;
+        modelInfo["user_role"] = user_role
     if (bot_role):
-        modelInfo["bot_role"] = bot_role;
+        modelInfo["bot_role"] = bot_role
     if (history_sep):
-        modelInfo["history_sep"] = history_sep;
+        modelInfo["history_sep"] = history_sep
     if (modelInfo["model_type"] == "baichuan" and hasattr(model, "model") and hasattr(model.model, "get_alibi_mask")):
         # Baichuan 2代
-        modelInfo["use_alibi"] = "1";
-        modelInfo["pre_prompt"] = "";
-        modelInfo["user_role"] = tokenizer.decode([model.generation_config.user_token_id]);
-        modelInfo["bot_role"] = tokenizer.decode([model.generation_config.assistant_token_id]);
-        modelInfo["history_sep"] = "";
+        modelInfo["use_alibi"] = "1"
+        modelInfo["pre_prompt"] = ""
+        modelInfo["user_role"] = tokenizer.decode([model.generation_config.user_token_id])
+        modelInfo["bot_role"] = tokenizer.decode([model.generation_config.assistant_token_id])
+        modelInfo["history_sep"] = ""
 
-    fo.write(struct.pack('i', len(modelInfo)));
+    fo.write(struct.pack('i', len(modelInfo)))
     for it in modelInfo.keys():
-        writeKeyValue(fo, str(it), str(modelInfo[it]));
+        writeKeyValue(fo, str(it), str(modelInfo[it]))
 
     # 1. vocab
     if (tokenizer):
         if (hasattr(tokenizer, "sp_model")):
-            piece_size = tokenizer.sp_model.piece_size();
-            fo.write(struct.pack('i', piece_size));
+            piece_size = tokenizer.sp_model.piece_size()
+            fo.write(struct.pack('i', piece_size))
             for i in range(piece_size):
-                s = tokenizer.sp_model.id_to_piece(i).encode();
-                fo.write(struct.pack('i', len(s)));
+                s = tokenizer.sp_model.id_to_piece(i).encode()
+                fo.write(struct.pack('i', len(s)))
                 for c in s:
-                    fo.write(struct.pack('i', c));
-                fo.write(struct.pack('i', i));
+                    fo.write(struct.pack('i', c))
+                fo.write(struct.pack('i', i))
         else:
-            vocab = tokenizer.get_vocab();
-            fo.write(struct.pack('i', len(vocab)));
+            vocab = tokenizer.get_vocab()
+            fo.write(struct.pack('i', len(vocab)))
             for v in vocab.keys():
-                s = v.encode();
-                fo.write(struct.pack('i', len(s)));
+                s = v.encode()
+                fo.write(struct.pack('i', len(s)))
                 for c in s:
-                    fo.write(struct.pack('i', c));
-                fo.write(struct.pack('i', vocab[v]));
+                    fo.write(struct.pack('i', c))
+                fo.write(struct.pack('i', vocab[v]))
     else:
-        fo.write(struct.pack('i', 0));
+        fo.write(struct.pack('i', 0))
 
     # 2. weight
-    fo.write(struct.pack('i', len(dict)));
+    fo.write(struct.pack('i', len(dict)))
     tot = 0;
     for key in dict:
-        cur = dict[key].numpy().astype(np.float32);
-        fo.write(struct.pack('i', len(key)));
-        fo.write(key.encode());
-        fo.write(struct.pack('i', len(cur.shape)));
+        cur = dict[key].numpy().astype(np.float32)
+        fo.write(struct.pack('i', len(key)))
+        fo.write(key.encode())
+        fo.write(struct.pack('i', len(cur.shape)))
         for i in cur.shape:
-            fo.write(struct.pack('i', i));
-        fo.write(struct.pack('i', 0));
-        fo.write(cur.data);
-        tot += 1;
-        print("output (", tot, "/", len(dict), end = " )\r");
-    print("\nfinish.");
-    fo.close();
+            fo.write(struct.pack('i', i))
+        fo.write(struct.pack('i', 0))
+        fo.write(cur.data)
+        tot += 1
+        print("output (", tot, "/", len(dict), end = " )\r")
+    print("\nfinish.")
+    fo.close()

--- a/tools/scripts/chatglm_export.py
+++ b/tools/scripts/chatglm_export.py
@@ -7,5 +7,5 @@ if __name__ == "__main__":
     model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).float()
     model = model.eval()
 
-    exportPath = sys.argv[1] if (sys.argv[1] is not None) else "chatglm-6b-fp32.flm";
+    exportPath = sys.argv[1] if len(sys.argv) >= 2 else "chatglm-6b-fp32.flm";
     torch2flm.tofile(exportPath, model, tokenizer)


### PR DESCRIPTION
修复ChatGLM模型导出的bug，当不传参数时，由于sys.argv小于2，导致sys.argv[1]会抛出索引序号异常