### PR TITLE
fix #175 修复ChatGLMModel构造函数判断版本的逻辑错误，支持低内存模式加载ChatGLM2模型

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -52,7 +52,7 @@ namespace fastllm {
     }
 
     fastllm::basellm *CreateModelWithType(const std::string &modelType) {
-        basellm *model;
+        basellm *model = nullptr;
         if (modelType == "chatglm") {
             model = (basellm*)(new ChatGLMModel());
         } else if (modelType == "moss") {

--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -53,11 +53,8 @@ namespace fastllm {
         }
         sinData.CopyFrom(Data(DataType::FLOAT32, {(int)this->sin.size(), (int)this->sin[0].size()}, fsin));
         cosData.CopyFrom(Data(DataType::FLOAT32, {(int)this->cos.size(), (int)this->cos[0].size()}, fcos));
-        if (GetVersion() == 1) {
-            weight.embeddingNames.insert("transformer.word_embeddings.weight");
-        } else if (GetVersion() == 2) {
-            weight.embeddingNames.insert("transformer.embedding.word_embeddings.weight");
-        }
+        weight.embeddingNames.insert("transformer.word_embeddings.weight");
+        weight.embeddingNames.insert("transformer.embedding.word_embeddings.weight");
     }
 
     int ChatGLMModel::Forward(const fastllm::Data &inputIds, const fastllm::Data &attentionMask,


### PR DESCRIPTION
修复ChatGLMModel构造函数判断版本的逻辑错误，支持使用低内存模式( -l | --low )加载ChatGLM2模型。

测试·：

     /main -p ./chatglm2-6b-int4.flm -l