### PR TITLE
修复一个因repeat_penalty大于1导致的segmentation fault错误

### DIFF
--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -274,13 +274,12 @@ namespace fastllm {
                 int base = (maxLen - 1) * batch + b;
                 lastRet.push_back((int) (((float *) topk.cpuData)[base * 2] + 1e-3));
             }
-        } else {
+        } else if (!lastTokens.units.empty()) {
             for (int b = 0; b < batch; b++) {
                 int base = (maxLen - 1) * batch + b;
                 lastRet.push_back(LLMSampling(logits, base, generationConfig, lastTokens.units[b]));
             }
         }
-
         return lastRet;
     }
 

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -203,7 +203,7 @@ namespace fastllm {
         Linear(hiddenStates, weight["lm_head.weight"], Data(), logits);
         logits.ToDevice(DataDevice::CPU);
 
-        int lastRet;
+        int lastRet = -1;
         if (generationConfig.IsSimpleGreedy()) {
             std::pair <float, int> ret = std::make_pair(-1e9, -1);
             int base = logits.dims[1] - 1;
@@ -211,7 +211,7 @@ namespace fastllm {
                 ret = max(ret, std::make_pair(((float*)logits.cpuData)[base * logits.dims.back() + i], i));
             }
             lastRet = ret.second;
-        } else {
+        } else if (!lastTokens.units.empty()) {
             lastRet = LLMSampling(logits, logits.dims[1] - 1, generationConfig, lastTokens.units[0]);
         }
 

--- a/src/models/moss.cpp
+++ b/src/models/moss.cpp
@@ -186,7 +186,7 @@ namespace fastllm {
             std::sort(v.begin(), v.end());
             std::reverse(v.begin(), v.end());
             ret = v[0].second;
-        } else {
+        } else if (!lastTokens.units.empty()) {
             ret = LLMSampling(logits, logits.dims[logits.dims.size() - 2] - 1, generationConfig, lastTokens.units[0]);
         }
 


### PR DESCRIPTION
在GenerationConfig中将repeat_penalty设置为大于1.0的值时，在WarmUp中进行Forward时会因为lastTokens.units为空导致LLMSampling抛出Segmentation Fault，已修复此问题。