### PR TITLE
修复 USE_MMAP=ON 模型加载过程中发生段错误 #193

### DIFF
--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -186,7 +186,7 @@ namespace fastllm {
     };
 
     struct ModelLoader {
-        ModelLoader(std::string buffer) : data(buffer.data()), size(buffer.size()), ptr(buffer.data()) {}
+        ModelLoader(const char *buffer, size_t size) : data(buffer), size(size), ptr(buffer) {}
 
         int64_t tell() const { return ptr - data; }
 

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -693,7 +693,7 @@ namespace fastllm {
         std::string ret = "unknown";
     #ifdef USE_MMAP
         std::unique_ptr<FileMmap> mapped_file = std::make_unique<FileMmap>(fileName);
-        ModelLoader buffer(std::string((char *)mapped_file->data, mapped_file->size));
+        ModelLoader buffer((char *)mapped_file->data, mapped_file->size);
     #else
         FileBuffer buffer(fileName);
     #endif
@@ -1005,7 +1005,7 @@ namespace fastllm {
     void WeightMap::LoadFromFile(const std::string &fileName) {
     #ifdef USE_MMAP
         std::shared_ptr<FileMmap> mapped_file = std::make_shared<FileMmap>(fileName);
-        ModelLoader buffer(std::string((char *)mapped_file->data, mapped_file->size));
+        ModelLoader buffer((char *)mapped_file->data, mapped_file->size);
     #else
         FileBuffer buffer(fileName);
     #endif


### PR DESCRIPTION
看起来是ModelLoader的构造函数的buffer参数从std::string_view修改成std::string导致的。
https://github.com/ztxz16/fastllm/commit/530afacc5223d9f1b6007267cef84e0b720314f1
buffer是右值，buffer.data()的指针在buffer对象析构后会失效。