### PR TITLE
增加对chatglm-6B最初版本的支持

### DIFF
--- a/include/models/chatglm.h
+++ b/include/models/chatglm.h
@@ -15,8 +15,10 @@ namespace fastllm {
 	public:
         ChatGLMModel (); // 构造函数
 
+        virtual void InitParams(); // 初始化参数信息
+
         // 推理
-		virtual int Forward(
+        virtual int Forward(
                 const Data &inputIds,
                 const Data &attentionMask,
                 const Data &positionIds,
@@ -56,7 +58,7 @@ namespace fastllm {
                                         const std::vector <std::map <std::string, int> > &params,
                                         Data &inputIds, Data &attentionMask, Data &positionIds);
 
-		virtual void WarmUp(); // 预热
+        virtual void WarmUp(); // 预热
 
         virtual std::string MakeInput(const std::string &history, int round, const std::string &input); // 根据历史信息和当前输入生成prompt
 
@@ -66,7 +68,9 @@ namespace fastllm {
 
         void UpdateSinCos(float rope);
     private:
-		virtual void CausalMask(Data &data, int start) {}; // 因果mask？
+        virtual void CausalMask(Data &data, int start) {}; // 因果mask？
+
+        int gmask_token_id;
 
         float rope = 1.0f;
     };

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -21,6 +21,12 @@
 
 #ifdef __AVX__
 #include "immintrin.h"
+#ifdef __GNUC__
+#if __GNUC__ < 8
+#define _mm256_set_m128i(/* __m128i */ hi, /* __m128i */ lo) \
+    _mm256_insertf128_si256(_mm256_castsi128_si256(lo), (hi), 0x1)
+#endif
+#endif
 #endif
 
 namespace fastllm {

--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -76,7 +76,7 @@ namespace fastllm {
         return true;
     }
 
-#ifdef __AVX__
+
 #ifdef __AVX2__
     int DotU8U8(uint8_t *a, uint8_t *b, int n) {
         __m256i acc = _mm256_setzero_si256();
@@ -104,32 +104,31 @@ namespace fastllm {
 
         return ans + I32sum(acc);
     };
-#else
-    int DotU8U8(uint8_t *a, uint8_t *b, int n) {
-        __m256i acc = _mm256_setzero_si256();
+//#else
+//    int DotU8U8(uint8_t *a, uint8_t *b, int n) {
+//        __m256i acc = _mm256_setzero_si256();
 
-        int i = 0;
-        int ans = 0;
-        for (; i + 31 < n; i += 32) {
-            __m256i bx = _mm256_loadu_si256((const __m256i *) (a + i));
-            __m256i by = _mm256_loadu_si256((const __m256i *) (b + i));
+//        int i = 0;
+//        int ans = 0;
+//        for (; i + 31 < n; i += 32) {
+//            __m256i bx = _mm256_loadu_si256((const __m256i *) (a + i));
+//            __m256i by = _mm256_loadu_si256((const __m256i *) (b + i));
 
-            __m256i mx0 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(bx, 0));
-            __m256i mx1 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(bx, 1));
+//            __m256i mx0 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(bx, 0));
+//            __m256i mx1 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(bx, 1));
 
-            __m256i my0 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(by, 0));
-            __m256i my1 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(by, 1));
+//            __m256i my0 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(by, 0));
+//            __m256i my1 = _mm256_cvtepu8_epi16(_mm256_extractf128_si256(by, 1));
 
-            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(mx0, my0));
-            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(mx1, my1));
-        }
-        for (; i < n; i++) {
-            ans += a[i] * b[i];
-        }
+//            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(mx0, my0));
+//            //acc = _mm256_add_epi32(acc, _mm256_madd_epi16(mx1, my1));
+//        }
+//        for (; i < n; i++) {
+//            ans += a[i] * b[i];
+//        }
 
-        return ans + I32sum(acc);
-    };
-#endif
+//        return ans + I32sum(acc);
+//    };
     int DotU4U8(uint8_t *a, uint8_t *b, int n) {
         __m256i acc = _mm256_setzero_si256();
 
@@ -803,7 +802,7 @@ namespace fastllm {
                 c[block * kstride + i] = value;
             }
         }
-#elif defined(__AVX__)
+#elif defined(__AVX2__)
         int block = 0;
         for (; block < n; block++) {
             uint8_t *weightWalk = b;
@@ -877,7 +876,7 @@ namespace fastllm {
                     sum0 = vpadalq_u16(sum0, vmull_u8(vb, in.val[0]));
                 }
                 value += sum0[0] + sum0[1] + sum0[2] + sum0[3];
-#elif defined(__AVX__)
+#elif defined(__AVX2__)
                 value += DotU4U8(weightWalk + i * m / 2, inputWalk, m);
                 j += m;
 #endif
@@ -948,7 +947,7 @@ namespace fastllm {
                     sum0 = vpadalq_u16(sum0, vmull_u8(vb, in.val[0]));
                 }
                 value += sum0[0] + sum0[1] + sum0[2] + sum0[3];
-#elif defined(__AVX__)
+#elif defined(__AVX2__)
                 value += DotU4U8(weightWalk + i * m / 2, inputWalk, m);
                 j += m;
 #endif

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -1265,19 +1265,21 @@ void FastllmCudaFree(void *ret) {
     if (ret == nullptr) {
         return;
     }
-    for (auto &it : cudaBuffersMap) {
-        auto &cudaBuffers = it.second;
-        for (int i = 0; i < cudaBuffers.size(); i++) {
-            if (cudaBuffers[i].data == ret) {
-                cudaBuffers[i].busy = false;
-                return;
+    if (!cudaBuffersMap.empty()) {
+        for (auto &it : cudaBuffersMap) {
+            auto &cudaBuffers = it.second;
+            for (int i = 0; i < cudaBuffers.size(); i++) {
+                if (cudaBuffers[i].data == ret) {
+                    cudaBuffers[i].busy = false;
+                    return;
+                }
             }
-        }
-        auto &bigBuffers = bigBuffersMap[it.first];
-        for (int i = 0; i < bigBuffers.size(); i++) {
-            if (bigBuffers[i].data == ret) {
-                bigBuffers[i].busy = false;
-                return;
+            auto &bigBuffers = bigBuffersMap[it.first];
+            for (int i = 0; i < bigBuffers.size(); i++) {
+                if (bigBuffers[i].data == ret) {
+                    bigBuffers[i].busy = false;
+                    return;
+                }
             }
         }
     }

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -545,7 +545,7 @@ namespace fastllm {
             weightSum.resize(n);
             for (int i = 0; i < n; i++) {
                 int j = 0;
-#ifdef __AVX__
+#ifdef __AVX2__
                 __m256i acc = _mm256_setzero_si256();
                 const __m256i ones = _mm256_set1_epi16(1);
                 for (; j + 31 < m; j += 32) {
@@ -591,7 +591,7 @@ namespace fastllm {
                 }
                 weightSum[i] += sum0[0] + sum0[1] + sum0[2] + sum0[3];
 #endif
-#ifdef __AVX__
+#ifdef __AVX2__
 	            __m256i acc = _mm256_setzero_si256();
 	            const __m256i lowMask = _mm256_set1_epi8(0xf);
 	            const __m256i ones = _mm256_set1_epi16(1);

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -140,10 +140,10 @@ def tofile(exportPath,
             for v in vocab.keys():
                 if (modelInfo['model_type'] == "qwen"):
                     s = v
+                elif (modelInfo["model_type"] == "moss"):
+                    s = [(ord(c) if c not in tokenizer.byte_decoder else tokenizer.byte_decoder[c]) for c in v]
                 else:
                     s = v.encode()
-                if (modelInfo["model_type"] == "moss"):
-                    s = [(ord(c) if c not in tokenizer.byte_decoder else tokenizer.byte_decoder[c]) for c in v]
                 fo.write(struct.pack('i', len(s)))
                 for c in s:
                     fo.write(struct.pack('i', c))


### PR DESCRIPTION
1. ChatGLM-6B最初发布的版本vocab_size为150528，且config.jsom中没有gmask_token_id。后来的更新版本和1.1版本去掉了20000个预留token。本次修改对最初版本做了兼容，
2 .同时根据ChatGLM2的[tokenization_chatglm.py](https://huggingface.co/THUDM/chatglm2-6b/blob/main/tokenization_chatglm.py)，ChatGLM2的magic number 64790和64792的意义分别是gmask_token_id 和 bos_token_id。因此做了修改。