### PR TITLE
修复时间戳重复的问题

### DIFF
--- a/pyfastllm/demo/web_api.py
+++ b/pyfastllm/demo/web_api.py
@@ -7,7 +7,8 @@ from copy import deepcopy
 import traceback
 from typing import List
 sys.path.append('../../build-py')
-import pyfastllm # 或fastllm
+import pyfastllm
+import uuid
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 import threading, queue, uvicorn, json, time
@@ -106,8 +107,8 @@ def dynamic_batch_stream_func():
             
 
 def chat_stream(prompt: str, config: pyfastllm.GenerationConfig, uid:int=0, time_out=200):
-    global g_model, g_msg_dict
-    time_stamp = round(time.time() * 1000)
+    global  g_msg_dict
+    time_stamp = str(uuid.uuid1())
     hash_id = str(pyfastllm.std_hash(f"{prompt}time_stamp:{time_stamp}"))
     thread = threading.Thread(target = batch_response_stream, args = (f"{prompt}time_stamp:{time_stamp}", config))
     thread.start()

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -60,8 +60,8 @@ namespace fastllm {
 #endif
         std::string prompt = input;
 #ifdef PY_API
-        size_t pos = input.find_last_of("time_stamp:");
-        prompt = (generationConfig.enable_hash_id && pos != std::string::npos) ? input.substr(0, pos - 10) : input;
+        size_t pos = input.rfind("time_stamp:");
+        prompt = (generationConfig.enable_hash_id && pos != -1) ? input.substr(0, pos) : input;
         size_t hash_id = std::hash<std::string>{}(input);
 #endif
         Data inputIds, attentionMask, positionIds;
@@ -150,8 +150,8 @@ namespace fastllm {
             size_t hash_id = std::hash<std::string>{}(_input);
             hash_ids.push_back(hash_id);
 
-            size_t pos = _input.find_last_of("time_stamp:");
-            std::string prompt = (generationConfig.enable_hash_id && pos != std::string::npos) ? _input.substr(0, pos - 10) : _input;
+            size_t pos = _input.rfind("time_stamp:");
+            std::string prompt = (generationConfig.enable_hash_id && pos != -1) ? _input.substr(0, pos) : _input;
             prompts.push_back(prompt);
         }
 #else

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -564,8 +564,8 @@ namespace fastllm {
 #endif
 //auto st = std::chrono::system_clock::now();
 #ifdef PY_API
-		size_t pos = input.find_last_of("time_stamp:");
-		std::string prompt = (generationConfig.enable_hash_id && pos != std::string::npos)?  input.substr(0, pos-10):input;
+		size_t pos = input.rfind("time_stamp:");
+		std::string prompt = (generationConfig.enable_hash_id && pos != -1)?  input.substr(0, pos):input;
 		size_t hash_id = std::hash<std::string>{}(input);
         Data inputIds = this->weight.tokenizer.Encode(prompt);
 #else
@@ -681,8 +681,8 @@ namespace fastllm {
             size_t hash_id = std::hash<std::string>{}(_input);
             hash_ids.push_back(hash_id);
 
-            size_t pos = _input.find_last_of("time_stamp:");
-            std::string prompt = (generationConfig.enable_hash_id && pos != std::string::npos) ? _input.substr(0, pos - 10) : _input;
+            size_t pos = _input.rfind("time_stamp:");
+            std::string prompt = (generationConfig.enable_hash_id && pos != -1) ? _input.substr(0, pos) : _input;
             prompts.push_back(prompt);
         }
 #else

--- a/src/models/moss.cpp
+++ b/src/models/moss.cpp
@@ -207,8 +207,8 @@ namespace fastllm {
                                     RuntimeResult retCb,
                                     const GenerationConfig &generationConfig) {
 #ifdef PY_API
-		size_t pos = input.find_last_of("time_stamp:");
-		std::string prompt = (generationConfig.enable_hash_id && pos != std::string::npos)?  input.substr(0, pos-10):input;
+		size_t pos = input.rfind("time_stamp:");
+		std::string prompt = (generationConfig.enable_hash_id && pos != -1)?  input.substr(0, pos):input;
 		size_t hash_id = std::hash<std::string>{}(input);
         Data inputIds = this->weight.tokenizer.Encode(prompt);
 #else


### PR DESCRIPTION
原先使用time.time（）时间戳，可能会在并发高的时候时间戳相同，如果文本也相同，那么hash也会相同，会导致推理完成后，重复删除 hash 报错。

现在使用uuid，可以避免时间戳相同的问题，同时c++代码中find_last_of方法与 rfind 是有区别的，uuid中的字母可能会触发find_last_of，换成rfind就没有这个问题了 。

代码已经编译成功，并在我的机器上测试，没有问题。