### PR TITLE
pytools 增加tokenizer接口，与stream_response_v2

### DIFF
--- a/tools/src/pytools.cpp
+++ b/tools/src/pytools.cpp
@@ -117,6 +117,32 @@ extern "C" {
         return;
     }
 
+    DLL_EXPORT int token_decode(int modelId, int tokenId, int output_buffer_len, char *output_buffer) {
+        if(tokenId == -1)
+            return -1;
+        auto model = models.GetModel(modelId);
+        std::string s = model->weight.tokenizer.DecodeTokens(std::vector <int> {tokenId});
+        if(s.length() + 1 > output_buffer_len) {
+            return 1;
+        }
+        memcpy(output_buffer, s.c_str(), s.length() + 1);
+        return 0;
+    }
+
+    DLL_EXPORT int token_encode_string(int modelId, char *content, int output_buffer_len, int *output_buffer) {
+        // 返回写入到output_buffer中的数量
+        auto model = models.GetModel(modelId);
+        auto v = model->weight.tokenizer.Encode(content);
+        int i = 0;
+        for (; i < v.Count(0); i++) {
+            if(i >= output_buffer_len) {
+                break;
+            }
+            output_buffer[i] = (int)((float*)v.cpuData)[i];
+        }
+        return i;
+    }
+
     DLL_EXPORT void add_dict_llm_model(int modelId, char *key, char *value) {
         auto model = models.GetModel(modelId);
         model->weight.AddDict(key, value);


### PR DESCRIPTION
增加stream_response_v2：
* 基于token输入输出（而不是string输入输出）的接口。为了能够更好的控制输入token序列，例如支持像baichuan那样system是先encode到token再拼接的，或其他想要干预token的功能。
* 输出改成使用fetch_response_llm_model，并自适应的做utf8解码成char之后再yield返回。为了更好的支持长尾char被编码为多个token的情况。并绕过了 #326 中提到的内存泄露问题。

顺带增加了tokenizer的接口：
* tokenizer_encode_string：将一个输入字符串进行encode
* tokenizer_decode_token：将单个token 进行decode，没做token序列decode是因为懒，以及暂时没有直接需要的场景。

tokenizer已经存储在模型中，之前没有暴露给上层，不方便做某些基于token的计算。
现在同时暴露出来，并方便应用方因为其他原因调用。

tokenizer的两个接口在跨语言传输上并没有做的足够高效，使用了动态申请的比较大的buffer，主要还是为了省事。