### PR TITLE
修复transformers>=4.33.0时，activate_adapter作为方法出现在model中的问题

### DIFF
--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -67,7 +67,8 @@ def create(model,
     active_adapter = ""
     if hasattr(model, "peft_config"):
         peft_config = model.peft_config
-    if hasattr(model, "active_adapter"):
+    if hasattr(model, "active_adapter") and isinstance(model.active_adapter, str):
+        # in transformers >= 4.33.0, active_adapter is a funtion in model, ignore it now
         active_adapter = model.active_adapter
 
     model = model.cpu();


### PR DESCRIPTION
transformers>=4.33.0时, model类中会自动包含一个名为active_adapter的方法，但在未加载peft model时调用无效，因此暂时忽略这个方法，仅在其type为string时读取