### PR TITLE
修复 pybind11 submodule 被破坏导致pyfastllm构建失败

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
 	url = https://github.com/pybind/pybind11.git
+	branch = v2.10.5


### PR DESCRIPTION
 修复 @wildkid1024  修改 pyfastllm 时不小心造成的破坏，且将 [pybind/pybind11](https://github.com/pybind/pybind11) 定位到稳定版本 v2.10.5。