### PR TITLE
提升torch2flm转换时4bit模型的量化精度

### DIFF
--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -39,10 +39,18 @@ def write_int8(fo, v):
     fo.write(v.data)
 
 def write_int4(fo, v):
-    c_min = np.expand_dims(-np.abs(v).max(axis = -1), -1)
-    c_max = np.expand_dims(np.abs(v).max(axis = -1), -1)
-    c_scale = c_max / 7.0
-    c_min = c_scale * -8.0
+    # c_min = np.expand_dims(-np.abs(v).max(axis = -1), -1)
+    # c_max = np.expand_dims(np.abs(v).max(axis = -1), -1)
+    # c_scale = c_max / 7.0
+    # c_min = c_scale * -8.0
+
+    c_min = np.expand_dims(v.min(axis = -1), -1)
+    c_max = np.expand_dims(v.max(axis = -1), -1)
+    c_scale = (c_max - c_min) / 15.0
+    c_zero = np.round(0.0 - c_min / c_scale)
+    c_zero = c_zero.clip(0, 15)
+    c_min = -c_scale * c_zero
+
     v = (v - c_min) / c_scale
     v = (v + 0.5).astype(np.int8).clip(0, 15).astype(np.uint8)
     v = v[:, 0::2] * 16 + v[:, 1::2]


### PR DESCRIPTION
将torch2flm.py中量化权重为4bit时的策略改为非对称量化，以提升4bit模型精度