### PR TITLE
兼容chatglm3-6b-32k，修复model.save()保存的模型tokenizer未对齐问题。

### DIFF
--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -1481,7 +1481,7 @@ void * FastllmCudaDirectMalloc(size_t size) {
     void * ret;
     cudaError_t state = cudaMalloc(&ret, size);
     if (cudaSuccess != state) {
-        printf("Error: CUDA error when allocating %d kB memory! maybe there's no enough memory left on device.", size >> 10);
+        printf("Error: CUDA error when allocating %lu kB memory! maybe there's no enough memory left on device.", size >> 10);
         checkCudaErrors("", state);
         return nullptr;
     }
@@ -1517,7 +1517,7 @@ void * FastllmCudaMalloc(size_t size) {
         void * ret;
         state = cudaMalloc(&ret, size);
         if (cudaSuccess != state) {
-            printf("Error: CUDA error when allocating %d MB memory! maybe there's no enough memory left on device.", size >> 20);
+            printf("Error: CUDA error when allocating %lu MB memory! maybe there's no enough memory left on device.", size >> 20);
             checkCudaErrors("", state);
             return nullptr;
         }
@@ -1535,7 +1535,7 @@ void * FastllmCudaMalloc(size_t size) {
     void * ret;
     state = cudaMalloc(&ret, size);
     if (cudaSuccess != state) {
-        printf("Error: CUDA error when allocating %d KB memory! maybe there's no enough memory left on device.", size >> 10);
+        printf("Error: CUDA error when allocating %lu KB memory! maybe there's no enough memory left on device.", size >> 10);
         checkCudaErrors("", state);
         return nullptr;
     }
@@ -1600,7 +1600,7 @@ void FastllmCudaMallocBigBuffer(size_t size) {
     cudaMalloc(&ret, size);
     auto state = cudaMalloc(&ret, size);
     if (cudaSuccess != state)
-        printf("Error: CUDA error when allocating %d MB memory! maybe there's no enough memory left on device.", size >> 20);
+        printf("Error: CUDA error when allocating %lu MB memory! maybe there's no enough memory left on device.", size >> 20);
     checkCudaErrors("", state);
     bigBuffers.push_back(CudaMemoryBuffer(ret, size, false));
 }

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -801,6 +801,7 @@ namespace fastllm {
         now->tokenId = tokenId;
         now->score = score;
         tokenToStringDict[tokenId] = s;
+        tokenToScoreDict[tokenId] = score;
         stringToTokenDict[s] = tokenId;
     }
 
@@ -846,9 +847,10 @@ namespace fastllm {
             }
             for (int i = 0; i < ori.size(); i++) {
                 if (ori[i] == ' ') {
-                    if (i != 0 && ori[i - 1] != ' ') {
-                        s += blank;
-                    }
+                    // if (i != 0 && ori[i - 1] != ' ') {
+                        // s += blank;
+                    // }
+                    s += blank;
                 } else {
                     s += ori[i];
                 }

--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -34,14 +34,16 @@ namespace fastllm {
         cos.resize(max_positions);
         std::vector <float> invFreq;
         for (int i = 0; i < rotary_dim; i += 2) {
-            invFreq.push_back(1.0 / pow(10000, (float)i / rotary_dim));
+            int base = this->bot_role.empty() ? 10000 : 10000 * rope;
+            invFreq.push_back(1.0 / pow(base, (float)i / rotary_dim));
         }
         for (int i = 0; i < max_positions; i++) {
             sin[i].resize(rotary_dim);
             cos[i].resize(rotary_dim);
             for (int j = 0; j < invFreq.size(); j++) {
-                sin[i][j] = ::sin((float)i / rope * invFreq[j]);
-                cos[i][j] = ::cos((float)i / rope * invFreq[j]);
+                float scale = this->bot_role.empty() ? rope : 1.0f;
+                sin[i][j] = ::sin((float)i / scale * invFreq[j]);
+                cos[i][j] = ::cos((float)i / scale * invFreq[j]);
             }
         }
 

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -51,7 +51,7 @@ def create(model,
     if (modelInfo["model_type"] == "chatglm" and hasattr(tokenizer, "build_chat_input")):
         # chatglm3
         modelInfo["pre_prompt"] = "";
-        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|user|>")) + ">\n");
+        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|user|>")) + "> \n");
         modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|assistant|>")) + ">");
         modelInfo["history_sep"] = "";
 

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -55,6 +55,7 @@ def create(model,
         modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|assistant|>")) + ">");
         modelInfo["history_sep"] = "";
 
+    modelInfo["tokenizer_use_score"] = "1" # 分词带分数
 
     weight_type_dict = {};
     module_dict = {};

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -113,10 +113,9 @@ def tofile(exportPath,
             modelInfo["im_end_id"] = tokenizer.im_end_id
             modelInfo["im_start_id"] = tokenizer.im_start_id
     if (modelInfo["model_type"] == "chatglm" and hasattr(tokenizer, "build_chat_input")):
-        print("into here")
         # chatglm3
         modelInfo["pre_prompt"] = "";
-        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|user|>")) + ">\n");
+        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|user|>")) + "> \n");
         modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(tokenizer.get_command("<|assistant|>")) + ">");
         modelInfo["history_sep"] = "";
 


### PR DESCRIPTION
1. 兼容chatglm3-6b-32k 和 chatglm2-6b-32k的位置编码差异，尝试修复 #374 ；
   - 目前判断chatglm3逻辑比较简单，GetVersion()版本依然是2，后续如果有了更多chatglm版本，还得继续优化。
3. 修复 `llm.from_hf()` + `model.save()` 模式下，保存的模型中 sentencepiece tokenizer 没有包含score的问题；
    见 #397。
4. tokenizer对齐优化，
   - 测试发现，transformsers每调用一次 `tokenizer.encode()` 方法，都会在encode的文本前面插入一个空格，因此修改了ChatGLM3中的prompt；
   - 实测tokenizer下多个空格并不合并 （#380），暂时注释掉了空格合并逻辑。这块还需进一步跟sentencepiece对齐。