### PR TITLE
修复输出数据超长，且使用stream_response_raw的时候报错。

### DIFF
--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -116,8 +116,8 @@ class model:
 
         # 为了减少重复申请释放buffer对象而使用的线程局部存储区对象池
         self.thread_local_obj = threading.local()
-        self.thread_local_obj.tokenizer_encode_string__output_buffer = None
-        self.thread_local_obj.tokenizer_decode_token__output_buffer = None
+        #self.thread_local_obj.tokenizer_encode_string__output_buffer = None
+        #self.thread_local_obj.tokenizer_decode_token__output_buffer = None
 
         # tokenizer_decode_token 输出结果的静态缓存，手工触发构建
         # 由于token数量有限且不太多，所以缓存该结果来减少调用较为适合。
@@ -154,7 +154,7 @@ class model:
 
     def tokenizer_encode_string(self, content: str) -> List[int]:
         output_buffer_init_len = 1024
-        if self.thread_local_obj.tokenizer_encode_string__output_buffer is None:
+        if "tokenizer_encode_string__output_buffer" not in self.thread_local_obj or self.thread_local_obj.tokenizer_encode_string__output_buffer is None:
             self.thread_local_obj.tokenizer_encode_string__output_buffer = (ctypes.c_int * output_buffer_init_len)()
 
         buffer = self.thread_local_obj.tokenizer_encode_string__output_buffer

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -182,7 +182,7 @@ class model:
                 return cache_result
 
         output_buffer_init_len = 256
-        if self.thread_local_obj.tokenizer_decode_token__output_buffer is None:
+        if "tokenizer_decode_token__output_buffer" not in dir(self.thread_local_obj) or self.thread_local_obj.tokenizer_decode_token__output_buffer is None:
             self.thread_local_obj.tokenizer_decode_token__output_buffer = ctypes.create_string_buffer(output_buffer_init_len)
 
         buffer = self.thread_local_obj.tokenizer_decode_token__output_buffer


### PR DESCRIPTION
## 报错的原因
当调用以下代码生成较长的内容的时候报错，特别是比如用Python写一个贪吃蛇，就会报错。
```
stream_generate = model.stream_response_raw(input_tokens=inputs["input_ids"][0], **gen_kwargs, stop_token_ids=stop_token_ids)
```
## 报错的原因
不是特别的清楚，好像是self.thread_local_obj中的内存被释放了。

## 解决的思路
只是判断了tokenizer_decode_token__output_buffer在self.thread_local_obj是否存在，经过反复测试不再报错