### PR TITLE
LLaMA类模型优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ python3 tools/moss_export.py moss-int4.flm int4 #导出int4模型
 # 修改build/tools/alpaca2flm.py程序进行导出
 # 不同llama模型使用的指令相差很大，需要参照torch2flm.py中的参数进行配置
 ```
+一些模型的转换可以[参考这里的例子](docs/llama_cookbook.md)
 
 #### QWEN模型导出
 ```sh

--- a/docs/llama_cookbook.md
+++ b/docs/llama_cookbook.md
@@ -2,15 +2,15 @@
 
 这个文档提供了了转换LLaMA同结构模型的方法。
 
-Llama类模型有着基本相同的结构，但权重和prompt构造有差异。在fastllm中，通过转转模型时修改部分配置，实现对这些变体模型的支持、
+LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。在fastllm中，通过转转模型时修改部分配置，实现对这些变体模型的支持、
 
 ## 声明
 
-以下配置方案收集于网友整理，本项目不保证模型推理结果与原版完全一致。
+以下配置方案根据模型的源代码整理，不保证模型推理结果与原版完全一致。
 
-## 修改方案
+## 修改脚本并转换
 
-这里以支持推理各类Llama结构的基座模型为例，介绍如何应用本教程。
+这里以支持推理各类Llama结构的基座模型为例，介绍如何应用本文档。
 
 * 方案一：修改转换脚本
 
@@ -26,6 +26,7 @@ Llama类模型有着基本相同的结构，但权重和prompt构造有差异。
                      user_role = "", bot_role = "", history_sep = "", 
                      dtype = dtype)
 ```
+其中，`pre_prompt` 、`user_role` 、`bot_role` 、`history_sep`分别为“开始的系统提示词（第一轮对话之前）”，“用户角色标志”，“用户话语结束标志及模型回复开始标志”，“两轮对话之间的分隔符”。
 
 * 方案二：修改config.json
 在下载的模型目录下，修改配置文件`config.json`中，修改"model_type"为`llama`，并增加下面的键-值对：
@@ -37,11 +38,19 @@ Llama类模型有着基本相同的结构，但权重和prompt构造有差异。
     "history_sep":  "",
 ```
 
-如需添加Token ID而非字符串（类似baichuan-chat模型），可以使用“<<FLM_FIX_TOKEN_{ID}>”的格式添加。
+如需添加Token ID而非字符串（类似baichuan-chat模型），可以使用“<FLM_FIX_TOKEN_{ID}>”的格式添加。
 
 ## Base Model
 
 见上方“[修改方案](#修改方案)”。
+
+一部分模型需要制定bos_token_id，假设bos_token_id为1则可以配置如下：
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<FLM_FIX_TOKEN_1>", 
+                     user_role = "", bot_role = "", history_sep = "", 
+                     dtype = dtype)
+```
 
 ## Chat Model
 
@@ -59,10 +68,12 @@ Llama类模型有着基本相同的结构，但权重和prompt构造有差异。
                      history_sep = "<eoa>\n<s>", dtype = dtype)
 ```
 
-### XVERSE-13B
+
+### XVERSE
 
 * xverse/[XVERSE-13B-Chat](https://huggingface.co/xverse/XVERSE-13B-Chat)
-* xverse/[XVERSE-13B-Chat](https://huggingface.co/xverse/XVERSE-7B-Chat)
+* xverse/[XVERSE-7B-Chat](https://huggingface.co/xverse/XVERSE-7B-Chat)
+
 ```python
     conf = model.config.__dict__
     conf["model_type"] = "llama"
@@ -71,14 +82,31 @@ Llama类模型有着基本相同的结构，但权重和prompt构造有差异。
                      history_sep = "<FLM_FIX_TOKEN_3>", dtype = dtype)
 ```
 
+### 其他 llama1 系列
+
+* Vicuna v1.1 v1.3
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, 
+                     pre_prompt="A chat between a curious user and an artificial intelligence assistant. "
+                                "The assistant gives helpful, detailed, and polite answers to the user's questions. "
+                     user_role="USER: ", bot_role=" ASSISTANT:",  history_sep="<s>", dtype=dtype)
+```
+
+* BiLLa 
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "\n", 
+                     user_role = "Human: ", bot_role = "\nAssistant: ", 
+                     history_sep = "\n", dtype = dtype)
+```
+
 ### llama2-chat
 
 * meta-llama/Llama-2-chat
 
 |Model|Llama2-chat|Llama2-chat-hf|
-|---|---|---|
-|7B| [meta-llama/Llama-2-7b-chat](https://huggingface.co/meta-llama/Llama-2-7b-chat) | [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) |
-|13B| [meta-llama/Llama-2-13b-chat](https://huggingface.co/meta-llama/Llama-2-13b-chat) | [meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf) |
+|-----|-----|-----|
+|  7B | [meta-llama/Llama-2-7b-chat](https://huggingface.co/meta-llama/Llama-2-7b-chat) | [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) |
+| 13B | [meta-llama/Llama-2-13b-chat](https://huggingface.co/meta-llama/Llama-2-13b-chat) | [meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf) |
 
 官方示例代码中，可以不用系统提示语：
 
@@ -104,13 +132,41 @@ Llama类模型有着基本相同的结构，但权重和prompt构造有差异。
 * ymcui/Chinese-Alpaca-2
 
 |Model|Chinese-Alpaca-2|Chinese-Alpaca-2-16K|
-|---|---|---|
-|7B | [ziqingyang/chinese-alpaca-2-7b](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b) | [ziqingyang/chinese-alpaca-2-7b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b-16k) |
-|13B | [ziqingyang/chinese-alpaca-2-13b](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b) | [ziqingyang/chinese-alpaca-2-13b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b-16k) |
+|-----|-----|-----|
+|  7B | [ziqingyang/chinese-alpaca-2-7b](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b) | [ziqingyang/chinese-alpaca-2-7b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b-16k) |
+| 13B | [ziqingyang/chinese-alpaca-2-13b](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b) | [ziqingyang/chinese-alpaca-2-13b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b-16k) |
 
 ```python
     torch2flm.tofile(exportPath, model, tokenizer, 
                      pre_prompt = "<FLM_FIX_TOKEN_1>[INST] <<SYS>>\nYou are a helpful assistant. 你是一个乐于助人的助手。\n<</SYS>>\n\n"
                      user_role = " ", bot_role = " [/INST]", 
                      history_sep = " <FLM_FIX_TOKEN_2><FLM_FIX_TOKEN_1>", dtype = dtype)
+```
+
+### RUC-GSAI/YuLan-Chat
+
+  * Full
+    * [YuLan-Chat-2-13B](https://huggingface.co/yulan-team/YuLan-Chat-2-13b-fp16)
+  * Delta (需要原始LLaMA)
+    * [YuLan-Chat-1-65B-v2](https://huggingface.co/yulan-team/YuLan-Chat-1-65B-v2-delta) 
+    * [YuLan-Chat-1-65B-v1](https://huggingface.co/RUCAIBox/YuLan-Chat-65b-delta) 
+    * [YuLan-Chat-1-13B-v1](https://huggingface.co/RUCAIBox/YuLan-Chat-13b-delta) 
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, 
+                     pre_prompt="The following is a conversation between a human and an AI assistant namely YuLan, developed by GSAI, Renmin University of China. " \
+                                "The AI assistant gives helpful, detailed, and polite answers to the user's questions.\n"
+                     user_role="[|Human|]:", bot_role="\n[|AI|]:", history_sep="\n", dtype=dtype)
+```
+
+### WizardCoder
+
+  * [WizardCoder-Python-7B-V1.0](https://huggingface.co/WizardLM/WizardCoder-Python-7B-V1.0)
+  * [WizardCoder-Python-13B-V1.0](https://huggingface.co/WizardLM/WizardCoder-Python-13B-V1.0)
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, 
+                     pre_prompt="Below is an instruction that describes a task. "
+                                "Write a response that appropriately completes the request.\n\n"
+                     user_role="### Instruction:\n", bot_role="\n\n### Response:", history_sep="\n", dtype=dtype)
 ```

--- a/docs/llama_cookbook.md
+++ b/docs/llama_cookbook.md
@@ -1,0 +1,116 @@
+# LLaMA 类模型转换参考
+
+这个文档提供了了转换LLaMA同结构模型的方法。
+
+Llama类模型有着基本相同的结构，但权重和prompt构造有差异。在fastllm中，通过转转模型时修改部分配置，实现对这些变体模型的支持、
+
+## 声明
+
+以下配置方案收集于网友整理，本项目不保证模型推理结果与原版完全一致。
+
+## 修改方案
+
+这里以支持推理各类Llama结构的基座模型为例，介绍如何应用本教程。
+
+* 方案一：修改转换脚本
+
+以alpaca2flm.py为模板修改。在创建model之后添加：
+
+```python
+    model = LlamaForCausalLM.from_pretrained(model_name).float()
+    # config.json中定义了自己的model_type的需要添加
+    conf = model.config.__dict__
+    conf["model_type"] = "llama"
+    # 接下来的部分各个Chat模型有差别，Base模型有的需要添加pre_prompt。
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "", 
+                     user_role = "", bot_role = "", history_sep = "", 
+                     dtype = dtype)
+```
+
+* 方案二：修改config.json
+在下载的模型目录下，修改配置文件`config.json`中，修改"model_type"为`llama`，并增加下面的键-值对：
+
+```json
+    "pre_prompt": "",
+    "user_role": "",
+    "bot_role": "",
+    "history_sep":  "",
+```
+
+如需添加Token ID而非字符串（类似baichuan-chat模型），可以使用“<<FLM_FIX_TOKEN_{ID}>”的格式添加。
+
+## Base Model
+
+见上方“[修改方案](#修改方案)”。
+
+## Chat Model
+
+对Chat Model，同样是修改转换脚本，或修改模型的config.json，以下是目前常见的chat model的配置：
+
+### InternLM（书生）
+
+* internlm/[internlm-chat-20b](https://huggingface.co/internlm/internlm-chat-20b)
+
+```python
+    conf = model.config.__dict__
+    conf["model_type"] = "llama"
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<s><s>", 
+                     user_role = "<|User|>:", bot_role = "<eoh>\n<|Bot|>:", 
+                     history_sep = "<eoa>\n<s>", dtype = dtype)
+```
+
+### XVERSE-13B
+
+* xverse/[XVERSE-13B-Chat](https://huggingface.co/xverse/XVERSE-13B-Chat)
+* xverse/[XVERSE-13B-Chat](https://huggingface.co/xverse/XVERSE-7B-Chat)
+```python
+    conf = model.config.__dict__
+    conf["model_type"] = "llama"
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "", 
+                     user_role = "Human: ", bot_role = "\n\nAssistant: ", 
+                     history_sep = "<FLM_FIX_TOKEN_3>", dtype = dtype)
+```
+
+### llama2-chat
+
+* meta-llama/Llama-2-chat
+
+|Model|Llama2-chat|Llama2-chat-hf|
+|---|---|---|
+|7B| [meta-llama/Llama-2-7b-chat](https://huggingface.co/meta-llama/Llama-2-7b-chat) | [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) |
+|13B| [meta-llama/Llama-2-13b-chat](https://huggingface.co/meta-llama/Llama-2-13b-chat) | [meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf) |
+
+官方示例代码中，可以不用系统提示语：
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<FLM_FIX_TOKEN_1>", 
+                     user_role = "[INST] ", bot_role = " [/INST]", 
+                     history_sep = " <FLM_FIX_TOKEN_2><FLM_FIX_TOKEN_1>", dtype = dtype)
+```
+
+**Llama-2系列支持系统提示语需要修改代码**，单轮可以使用以下带有系统提示语的版本：
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, 
+                     pre_prompt = "<FLM_FIX_TOKEN_1>[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, " \
+        "while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. " \
+        "Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, " \
+        "or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, " \
+        "please don't share false information.\n<</SYS>>\n\n", 
+                     user_role = " ", bot_role = " [/INST]", 
+                     history_sep = " <FLM_FIX_TOKEN_2><FLM_FIX_TOKEN_1>", dtype = dtype)
+```
+
+* ymcui/Chinese-Alpaca-2
+
+|Model|Chinese-Alpaca-2|Chinese-Alpaca-2-16K|
+|---|---|---|
+|7B | [ziqingyang/chinese-alpaca-2-7b](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b) | [ziqingyang/chinese-alpaca-2-7b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-7b-16k) |
+|13B | [ziqingyang/chinese-alpaca-2-13b](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b) | [ziqingyang/chinese-alpaca-2-13b-16k](https://huggingface.co/ziqingyang/chinese-alpaca-2-13b-16k) |
+
+```python
+    torch2flm.tofile(exportPath, model, tokenizer, 
+                     pre_prompt = "<FLM_FIX_TOKEN_1>[INST] <<SYS>>\nYou are a helpful assistant. 你是一个乐于助人的助手。\n<</SYS>>\n\n"
+                     user_role = " ", bot_role = " [/INST]", 
+                     history_sep = " <FLM_FIX_TOKEN_2><FLM_FIX_TOKEN_1>", dtype = dtype)
+```

--- a/docs/llama_cookbook.md
+++ b/docs/llama_cookbook.md
@@ -40,6 +40,14 @@ LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。
 
 如需添加Token ID而非字符串（类似baichuan-chat模型），可以使用“<FLM_FIX_TOKEN_{ID}>”的格式添加。
 
+### 两行加速
+
+```python
+    llm.from_hf(model, tokenizer, pre_prompt = "", 
+                user_role = "", bot_role = "", history_sep = "", 
+                dtype = dtype)
+```
+
 ## Base Model
 
 见上方“[修改方案](#修改方案)”。

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -98,15 +98,15 @@ namespace fastllm {
             retString += curString;
             if (retCb)
 #ifdef PY_API
-                {
-                    if (generationConfig.enable_hash_id) {
-                        std::stringstream ss;
-                        ss << retString << "hash_id:" << hash_id;
-                        retCb(index, pybind11::bytes(ss.str()));
-                    } else {
-                        retCb(index, pybind11::bytes(retString));
-                    }
+            {
+                if (generationConfig.enable_hash_id) {
+                    std::stringstream ss;
+                    ss << retString << "hash_id:"<<hash_id;
+                    retCb(index, pybind11::bytes(ss.str()));
+                } else {
+                    retCb(index, pybind11::bytes(retString));
                 }
+            }
 #else
                 retCb(index, curString.c_str());
 #endif
@@ -123,15 +123,15 @@ namespace fastllm {
         }
         if (retCb)
 #ifdef PY_API
-            {
-                if (generationConfig.enable_hash_id) {
-                    std::stringstream ss;
-                    ss << retString << "hash_id:" << hash_id;
-                    retCb(-1, pybind11::bytes(ss.str()));
-                } else {
-                    retCb(-1, pybind11::bytes(retString));
-                }
+        {
+            if(generationConfig.enable_hash_id){
+                std::stringstream ss;
+                ss << retString << "hash_id:"<<hash_id;
+                retCb(-1, pybind11::bytes(ss.str()));
+            }else{
+                retCb(-1, pybind11::bytes(retString));
             }
+        }
 #else
             retCb(-1, retString.c_str());
 #endif
@@ -143,7 +143,6 @@ namespace fastllm {
 #ifdef USE_CUDA
         FastllmCudaClearBigBuffer();
 #endif
-        
 #ifdef PY_API
         std::vector<std::string> prompts;
         std::vector < size_t > hash_ids;
@@ -232,25 +231,25 @@ namespace fastllm {
             }
             if (retCb)
 #ifdef PY_API
-                {
-                    if (generationConfig.enable_hash_id) {
-                        std::vector<pybind11::bytes> rtnStrings;
-                        for (size_t i=0; i<batch; i++){
-                            std::stringstream ss;
-                            ss << curStrings[i] << "hash_id:" << hash_ids[i];
-                            rtnStrings.push_back(pybind11::bytes(ss.str()));
-                        }
-                        retCb(index, rtnStrings);
-                    } else {
-                        std::vector<pybind11::bytes> rtnStrings;
-                        for (size_t i=0; i<batch; i++){
-                            std::stringstream ss;
-                            ss << curStrings[i];
-                            rtnStrings.push_back(pybind11::bytes(ss.str()));
-                        }
-                        retCb(index, rtnStrings);
+            {
+                if (generationConfig.enable_hash_id) {
+                    std::vector<pybind11::bytes> rtnStrings;
+                    for (size_t i=0; i<batch; i++){
+                        std::stringstream ss;
+                        ss << curStrings[i] << "hash_id:" << hash_ids[i];
+                        rtnStrings.push_back(pybind11::bytes(ss.str()));
                     }
+                    retCb(index, rtnStrings);
+                } else {
+                    std::vector<pybind11::bytes> rtnStrings;
+                    for (size_t i=0; i<batch; i++){
+                        std::stringstream ss;
+                        ss << curStrings[i];
+                        rtnStrings.push_back(pybind11::bytes(ss.str()));
+                    }
+                    retCb(index, rtnStrings);
                 }
+            }
 #else
                 retCb(index, curStrings);
 #endif
@@ -265,27 +264,27 @@ namespace fastllm {
         }
         if (retCb)
 #ifdef PY_API
-                {
-                    if (generationConfig.enable_hash_id) {
-                        std::vector<pybind11::bytes> rtnStrings;
-                        for (size_t i=0; i<batch; i++){
-                            std::stringstream ss;
-                            ss << outputs[i] << "hash_id:" << hash_ids[i];
-                            rtnStrings.push_back(pybind11::bytes(ss.str()));
-                        }
-                        retCb(-1, rtnStrings);
-                    } else {
-                        std::vector<pybind11::bytes> rtnStrings;
-                        for (size_t i=0; i<batch; i++){
-                            std::stringstream ss;
-                            ss << outputs[i];
-                            rtnStrings.push_back(pybind11::bytes(ss.str()));
-                        }
-                        retCb(-1, rtnStrings);
-                    }
+        {
+            if (generationConfig.enable_hash_id) {
+                std::vector<pybind11::bytes> rtnStrings;
+                for (size_t i=0; i<batch; i++){
+                    std::stringstream ss;
+                    ss << outputs[i] << "hash_id:" << hash_ids[i];
+                    rtnStrings.push_back(pybind11::bytes(ss.str()));
                 }
+                retCb(-1, rtnStrings);
+            } else {
+                std::vector<pybind11::bytes> rtnStrings;
+                for (size_t i=0; i<batch; i++){
+                    std::stringstream ss;
+                    ss << outputs[i];
+                    rtnStrings.push_back(pybind11::bytes(ss.str()));
+                }
+                retCb(-1, rtnStrings);
+            }
+        }
 #else
-                retCb(-1, outputs);
+            retCb(-1, outputs);
 #endif
     }
 

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -653,11 +653,11 @@ namespace fastllm {
             if (retCb)
 #ifdef PY_API
 			{
-				if(generationConfig.enable_hash_id){
+				if (generationConfig.enable_hash_id) {
 					std::stringstream ss;
-					ss << retString << "hash_id:"<<hash_id;
+					ss << retString << "hash_id:" << hash_id;
 					retCb(index, pybind11::bytes(ss.str()));
-				}else{
+				} else {
 					retCb(index, pybind11::bytes(retString));
 				}
 			}
@@ -689,11 +689,11 @@ namespace fastllm {
         if (retCb)
 #ifdef PY_API
 		{
-			if(generationConfig.enable_hash_id){
+			if (generationConfig.enable_hash_id) {
 				std::stringstream ss;
-				ss << retString << "hash_id:"<<hash_id;
+				ss << retString << "hash_id:" << hash_id;
 				retCb(-1, pybind11::bytes(ss.str()));
-			}else{
+			} else {
 				retCb(-1, pybind11::bytes(retString));
 			}
 		}
@@ -814,7 +814,7 @@ namespace fastllm {
             if (endingCount == batch) {
                 break;
             }
-            if (retCb) 
+            if (retCb)
 #ifdef PY_API
             {
                 if (generationConfig.enable_hash_id) {
@@ -975,12 +975,16 @@ namespace fastllm {
                         }
 
                         if (seqLens.size() > 0) {
+                            model->dictLocker.unlock();
 #ifdef USE_CUDA
                             FastllmCudaClearBigBuffer();
 #endif
                             Data inputIds = Data(DataType::FLOAT32, {1, (int) ids.size()}, ids);
-                            std::vector<int> ret = model->ForwardBatch(seqLens.size(), inputIds, attentionMasks,
-                                                                       positionIds, seqLens, pastKeyValues, generationConfigs, tokensManager, &logits);
+                            std::vector<int> ret;
+                            ret = model->ForwardBatch(seqLens.size(), inputIds, attentionMasks,
+                                                      positionIds, seqLens, pastKeyValues, generationConfigs,
+                                                      tokensManager, &logits);
+                            model->dictLocker.lock();
                             int idx = 0;
                             for (auto &it: model->responseContextDict.dicts) {
                                 if (it.second->isEnding) {

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -22,26 +22,32 @@ def create(model,
            history_sep = None,
            dtype = "float16"):
     if (dtype not in fastllm_data_type_dict):
-        print("dtype should in ", list(fastllm_data_type_dict.keys()));
-        exit(0);
+        print("dtype should be one of ", list(fastllm_data_type_dict.keys()))
+        exit(0)
 
     # 0.1 model info
     modelInfo = model.config.__dict__
     if model.generation_config is not None:
         modelInfo.update(model.generation_config.__dict__)
     if (pre_prompt):
-        modelInfo["pre_prompt"] = pre_prompt;
+        modelInfo["pre_prompt"] = pre_prompt
     if (user_role):
-        modelInfo["user_role"] = user_role;
+        modelInfo["user_role"] = user_role
     if (bot_role):
-        modelInfo["bot_role"] = bot_role;
+        modelInfo["bot_role"] = bot_role
     if (history_sep):
-        modelInfo["history_sep"] = history_sep;
-    if (modelInfo["model_type"] == "baichuan" and hasattr(model, "model") and hasattr(model.model, "get_alibi_mask")):
-        # Baichuan 2代
-        modelInfo["use_alibi"] = "1";
-        modelInfo["pre_prompt"] = "";
-        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + "> ") if hasattr(model.generation_config, "user_token_id") else "";
+        modelInfo["history_sep"] = history_sep
+    if (modelInfo["model_type"] == "baichuan"):
+        if (hasattr(model, "model") and hasattr(model.model, "get_alibi_mask")):
+            # Baichuan / Baichuan2 13B
+            modelInfo["use_alibi"] = "1"
+        modelInfo["pre_prompt"] = ""
+        if (modelInfo["vocab_size"] == 125696):
+            # Baichuan 2代
+            modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + ">") if hasattr(model.generation_config, "user_token_id") else "";
+        else:
+            # Baichuan-13B-chat
+            modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + "> ") if hasattr(model.generation_config, "user_token_id") else "";
         modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.assistant_token_id) + ">") if hasattr(model.generation_config, "assistant_token_id") else "";
         modelInfo["history_sep"] = "";
     if (modelInfo["model_type"] == "qwen"):

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -29,11 +29,11 @@ def create(model,
     modelInfo = model.config.__dict__
     if model.generation_config is not None:
         modelInfo.update(model.generation_config.__dict__)
-    if (pre_prompt):
+    if (pre_prompt is not None):
         modelInfo["pre_prompt"] = pre_prompt
-    if (user_role):
+    if (user_role is not None):
         modelInfo["user_role"] = user_role
-    if (bot_role):
+    if (bot_role is not None):
         modelInfo["bot_role"] = bot_role
     if (history_sep):
         modelInfo["history_sep"] = history_sep

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -99,11 +99,17 @@ def set_device_map(device_map):
                                (ctypes.c_int * len(device_len))(*device_len),
                                device_str.encode(),
                                (ctypes.c_int * len(values))(*values));
+
 def from_hf(model,
             tokenizer = None,
+            pre_prompt = None,
+            user_role = None,
+            bot_role = None,
+            history_sep = None,
             dtype = "float16"):
     from fastllm_pytools import hf_model;
-    return hf_model.create(model, tokenizer, dtype = dtype);
+    return hf_model.create(model, tokenizer, pre_prompt = pre_prompt, user_role = user_role,
+                           bot_role = bot_role, history_sep = history_sep, dtype = dtype);
 
 class model:
     def __init__ (self, path : str,

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -70,7 +70,7 @@ def tofile(exportPath,
            history_sep = None,
            dtype = "float16"):
     if (dtype not in fastllm_data_type_dict):
-        print("dtype should in ", list(fastllm_data_type_dict.keys()))
+        print("dtype should be one of ", list(fastllm_data_type_dict.keys()))
         exit(0)
 
     dict = model.state_dict()
@@ -95,17 +95,17 @@ def tofile(exportPath,
         modelInfo["bot_role"] = bot_role
     if (history_sep):
         modelInfo["history_sep"] = history_sep
-    if (modelInfo["model_type"] == "baichuan" and hasattr(model, "model") and hasattr(model.model, "get_alibi_mask")):
-        # Baichuan 2代
-        modelInfo["use_alibi"] = "1"
+    if (modelInfo["model_type"] == "baichuan"):
+        if (hasattr(model, "model") and hasattr(model.model, "get_alibi_mask")):
+            # Baichuan / Baichuan2 13B
+            modelInfo["use_alibi"] = "1"
         modelInfo["pre_prompt"] = ""
-        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + ">") if hasattr(model.generation_config, "user_token_id") else "";
-        modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.assistant_token_id) + ">") if hasattr(model.generation_config, "assistant_token_id") else "";
-        modelInfo["history_sep"] = ""
-    if (modelInfo["model_type"] == "baichuan" and modelInfo["vocab_size"] == 125696):
-        # Baichuan 2代 7B
-        modelInfo["pre_prompt"] = ""
-        modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + ">") if hasattr(model.generation_config, "user_token_id") else "";
+        if (modelInfo["vocab_size"] == 125696):
+            # Baichuan 2代
+            modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + ">") if hasattr(model.generation_config, "user_token_id") else "";
+        else:
+            # Baichuan-13B-chat
+            modelInfo["user_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.user_token_id) + "> ") if hasattr(model.generation_config, "user_token_id") else "";
         modelInfo["bot_role"] = ("<FLM_FIX_TOKEN_" + str(model.generation_config.assistant_token_id) + ">") if hasattr(model.generation_config, "assistant_token_id") else "";
         modelInfo["history_sep"] = ""
     if modelInfo["model_type"] == "qwen":

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -87,11 +87,11 @@ def tofile(exportPath,
         print("unknown model_type.")
         exit(0)
 
-    if (pre_prompt):
+    if (pre_prompt is not None):
         modelInfo["pre_prompt"] = pre_prompt
-    if (user_role):
+    if (user_role is not None):
         modelInfo["user_role"] = user_role
-    if (bot_role):
+    if (bot_role is not None):
         modelInfo["bot_role"] = bot_role
     if (history_sep):
         modelInfo["history_sep"] = history_sep

--- a/tools/scripts/alpaca2flm.py
+++ b/tools/scripts/alpaca2flm.py
@@ -3,9 +3,12 @@ from transformers import LlamaTokenizer, LlamaForCausalLM
 from fastllm_pytools import torch2flm
 
 if __name__ == "__main__":
-    exportPath = sys.argv[1] if (sys.argv[1] is not None) else "alpaca-fp32.flm";
-    tokenizer = LlamaTokenizer.from_pretrained('minlik/chinese-alpaca-33b-merged');
-    model = LlamaForCausalLM.from_pretrained('minlik/chinese-alpaca-33b-merged').float();
+    model_name = sys.argv[3] if len(sys.argv) >= 4 else 'minlik/chinese-alpaca-33b-merged'
+    tokenizer = LlamaTokenizer.from_pretrained(model_name)
+    model = LlamaForCausalLM.from_pretrained(model_name).float()
+    conf = model.config.__dict__
+    conf["model_type"] = "llama"
     dtype = sys.argv[2] if len(sys.argv) >= 3 else "float16"
     exportPath = sys.argv[1] if len(sys.argv) >= 2 else "alpaca-33b-' + dtype + '.flm"
+    # add custom code here
     torch2flm.tofile(exportPath, model, tokenizer, dtype = dtype)


### PR DESCRIPTION
1. 修复llama类模型流式输出token卡顿的问题 (#403)；
2. 分别对齐Baichuan-13B-Chat，Baichuan2-13B-Chat模型chat的tokenize结果(#396 #402)，支持两行加速；
3. 增加《LLaMA 类模型转换参考》文档，代码也做了适配。

以上代码基于Baichuan系列测试。