### PR TITLE
完全对齐Tokenizer，支持InternLM-7B和XVERSE-7B

### DIFF
--- a/docs/llama_cookbook.md
+++ b/docs/llama_cookbook.md
@@ -66,6 +66,8 @@ LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。
 
 ### InternLM（书生）
 
+* internlm/[internlm-chat-7b](https://huggingface.co/internlm/internlm-chat-7b)
+* internlm/[internlm-chat-7b v1.1](https://huggingface.co/internlm/internlm-chat-7b-v1_1)
 * internlm/[internlm-chat-20b](https://huggingface.co/internlm/internlm-chat-20b)
 
 ```python
@@ -76,6 +78,15 @@ LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。
                      history_sep = "<eoa>\n<s>", dtype = dtype)
 ```
 
+可以直接使用`internlm2flm.py`脚本转换：
+
+``` sh
+cd build
+python3 tools/internlm2flm.py internlm-7b-fp16.flm float16 #导出float16模型
+python3 tools/internlm2flm.py internlm-7b-int8.flm int8 #导出int8模型
+python3 tools/internlm2flm.py internlm-7b-int4.flm int4 #导出int4模型
+python3 tools/internlm2flm.py internlm-7b-int4.flm float16 internlm/internlm-chat-7b #导出internlm-chat-7b float16模型
+```
 
 ### XVERSE
 

--- a/docs/llama_cookbook.md
+++ b/docs/llama_cookbook.md
@@ -8,7 +8,13 @@ LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。
 
 以下配置方案根据模型的源代码整理，不保证模型推理结果与原版完全一致。
 
-## 修改脚本并转换
+## 修改方式
+
+目前，转换脚本和两行加速方式均可用于llama类模型。但无论采用哪一种方式，都需要预留足够的内存（可以用swap空间）。
+
+在float16模式下，转换时约需要4×参数量+1GB的空闲内存。
+
+### 转换脚本
 
 这里以支持推理各类Llama结构的基座模型为例，介绍如何应用本文档。
 
@@ -40,17 +46,36 @@ LLaMA类模型有着基本相同的结构，但权重和prompt构造有差异。
 
 如需添加Token ID而非字符串（类似baichuan-chat模型），可以使用“<FLM_FIX_TOKEN_{ID}>”的格式添加。
 
+* 执行脚本
+
+```shell
+python3 tools/alpaca2flm.py [输出文件名] [精度] [原始模型名称或路径]
+```
+
 ### 两行加速
 
 ```python
+    conf = model.config.__dict__
+    conf["model_type"] = "llama"
     llm.from_hf(model, tokenizer, pre_prompt = "", 
                 user_role = "", bot_role = "", history_sep = "", 
                 dtype = dtype)
 ```
 
+## 对齐
+
+如果想使fastllm模型和原版transformers模型基本一致，最主要的操作是对齐tokenizer。
+如果模型使用了huggingface 加速版本的Tokenizers（即模型目录中包含`tokenizer.json`并优先使用），目前的转换脚本**仅在从本地文件转换时，能够对齐tokenizer**。
+
+注意检查原始tokenizer的`encode()`方法返回的结果前面是否会加空格。如果原始tokenizer没有加空格，则需要设置：
+
+```python
+    conf["tokenizer_add_dummy_prefix"] = False
+```
+
 ## Base Model
 
-见上方“[修改方案](#修改方案)”。
+见上方“[修改方案](#修改方式)”。
 
 一部分模型需要制定bos_token_id，假设bos_token_id为1则可以配置如下：
 
@@ -96,10 +121,12 @@ python3 tools/internlm2flm.py internlm-7b-int4.flm float16 internlm/internlm-cha
 ```python
     conf = model.config.__dict__
     conf["model_type"] = "llama"
+    conf["tokenizer_add_dummy_prefix"] = False
     torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "", 
                      user_role = "Human: ", bot_role = "\n\nAssistant: ", 
                      history_sep = "<FLM_FIX_TOKEN_3>", dtype = dtype)
 ```
+XVERSE-13B-Chat V1 版本需要对输入做NFKC规范化，fastllm暂不支持，因此需要使用原始tokenizer. 
 
 ### 其他 llama1 系列
 
@@ -174,7 +201,7 @@ python3 tools/internlm2flm.py internlm-7b-int4.flm float16 internlm/internlm-cha
 ```python
     torch2flm.tofile(exportPath, model, tokenizer, 
                      pre_prompt="The following is a conversation between a human and an AI assistant namely YuLan, developed by GSAI, Renmin University of China. " \
-                                "The AI assistant gives helpful, detailed, and polite answers to the user's questions.\n"
+                                "The AI assistant gives helpful, detailed, and polite answers to the user's questions.\n",
                      user_role="[|Human|]:", bot_role="\n[|AI|]:", history_sep="\n", dtype=dtype)
 ```
 
@@ -185,7 +212,7 @@ python3 tools/internlm2flm.py internlm-7b-int4.flm float16 internlm/internlm-cha
 
 ```python
     torch2flm.tofile(exportPath, model, tokenizer, 
-                     pre_prompt="Below is an instruction that describes a task. "
-                                "Write a response that appropriately completes the request.\n\n"
+                     pre_prompt="Below is an instruction that describes a task. " \
+                                "Write a response that appropriately completes the request.\n\n",
                      user_role="### Instruction:\n", bot_role="\n\n### Response:", history_sep="\n", dtype=dtype)
 ```

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -361,11 +361,13 @@ namespace fastllm {
 
         TrieNode *root;
 
+        TrieNode *specialRoot = nullptr;
+
         TokenizerType type = TokenizerType::BPE;
 
-        bool add_dummy_prefix = true;   // 是否在首位添加空格
-        bool remove_extra_whitespaces = true;   // 是否将多个空格合并为一个
-        bool byte_as_char = false;  // 是否将byte变为展示字符
+        bool addDummyPrefix = true;   // 是否在首位添加空格
+        bool removeExtraWhitespaces = true;   // 是否将多个空格合并为一个
+        bool byteAsChar = false;  // 是否将byte变为展示字符
 
         std::unordered_map <int, std::string> tokenToStringDict;
         std::unordered_map <int, float> tokenToScoreDict;
@@ -389,6 +391,8 @@ namespace fastllm {
         int GetRank(std::vector<Symbol> &symbols,  std::vector<std::pair<int, int>> &partitions, int idx, int skip);
 
         void Insert(const std::string &s, int tokenId, float score = 1.0f); // 插入一个token
+
+        void SetSpecialTokens(const std::map <std::string, int> &specialTokens); // 设置需要优先处理的特殊token
 
         std::string Normalize(const std::string &ori); // 字符规范化
 

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -43,7 +43,7 @@ namespace fastllm {
         float top_p = 1.0; // top_p采样
         float temperature = 1.0; // 温度参数，一般在0.1 ~ 1.0之间，设大这个参数可以带来结果的多样性
         bool output_logits = false; // 是否返回logits
-		bool enable_hash_id = false; // 给会话添加hash id
+        bool enable_hash_id = false; // 给会话添加hash id
         std::multiset <int> stop_token_ids;
 
         bool IsSimpleGreedy() const {
@@ -361,6 +361,9 @@ namespace fastllm {
 
         TokenizerType type = TokenizerType::BPE;
 
+        bool add_dummy_prefix = true;   // 是否在首位添加空格
+        bool remove_extra_whitespaces = true;   // 是否将多个空格合并为一个
+
         std::unordered_map <int, std::string> tokenToStringDict;
         std::unordered_map <int, float> tokenToScoreDict;
         std::unordered_map <std::string, int> stringToTokenDict;
@@ -379,6 +382,8 @@ namespace fastllm {
         int GetRank(std::vector<Symbol> &symbols,  std::vector<std::pair<int, int>> &partitions, int idx, int skip);
 
         void Insert(const std::string &s, int tokenId, float score = 1.0f); // 插入一个token
+
+        std::string Normalize(const std::string &ori); // 字符规范化
 
         Data Encode(const std::string &s); // 编码
 

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -17,6 +17,8 @@
 #include <iostream>
 #include <functional>
 #include <memory>
+#include <locale>
+#include <codecvt>
 #include "devices/cpu/cputhreadpool.h"
 
 #ifdef USE_SENTENCEPIECE
@@ -363,10 +365,15 @@ namespace fastllm {
 
         bool add_dummy_prefix = true;   // 是否在首位添加空格
         bool remove_extra_whitespaces = true;   // 是否将多个空格合并为一个
+        bool byte_as_char = false;  // 是否将byte变为展示字符
 
         std::unordered_map <int, std::string> tokenToStringDict;
         std::unordered_map <int, float> tokenToScoreDict;
         std::unordered_map <std::string, int> stringToTokenDict;
+
+        std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+        std::unordered_map <wchar_t, wchar_t> byteCharDict;
+        std::unordered_map <wchar_t, wchar_t> charByteDict;
 #ifdef USE_SENTENCEPIECE
         std::unique_ptr<sentencepiece::SentencePieceProcessor> spProcessor;
 #endif

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -372,6 +372,7 @@ namespace fastllm {
         std::unordered_map <int, std::string> tokenToStringDict;
         std::unordered_map <int, float> tokenToScoreDict;
         std::unordered_map <std::string, int> stringToTokenDict;
+        std::vector <std::string> specialTokens;
 
         std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
         std::unordered_map <wchar_t, wchar_t> byteCharDict;

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -898,11 +898,13 @@ namespace fastllm {
 
     std::string Tokenizer::Normalize(const std::string &ori) {
         if (this->byteAsChar) {
-            std::wstring ws = converter.from_bytes(ori);
-            for (int i=0; i < ws.length(); i++) {
-                if (charByteDict.find(ws[i]) != charByteDict.end()) {
-                    ws[i] = charByteDict[ws[i]];
+            std::wstring ws(ori.size(), L' ');
+            for (int i=0; i < ori.length(); i++) {
+                wchar_t wi = static_cast<wchar_t>(static_cast<unsigned char>(ori[i]));
+                if (charByteDict.find(wi) != charByteDict.end()) {
+                    wi = charByteDict[wi];
                 }
+                ws[i] = wi;
             }
             return converter.to_bytes(ws);
         }
@@ -1305,12 +1307,14 @@ namespace fastllm {
         }
         if (this->byteAsChar) {
             std::wstring wret = converter.from_bytes(ret);
+            std::string decoded(wret.size(), ' ');
             for (int i=0; i < wret.length(); i++) {
                 if (byteCharDict.find(wret[i]) != byteCharDict.end()) {
                     wret[i] = byteCharDict[wret[i]];
                 }
+                decoded[i] = static_cast<char>(wret[i]);
             }
-            ret = converter.to_bytes(wret);
+            ret = decoded;
         }
         int pos = ret.find("<|blank_");
         if (pos != -1) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -64,6 +64,12 @@ namespace fastllm {
             std::istringstream iss(value);
             iss >> std::boolalpha >> this->weight.tokenizer.remove_extra_whitespaces;
         }
+        if (this->weight.dicts.find("tokenizer_byte_as_char") != this->weight.dicts.end()) {
+            std::string value = this->weight.dicts["tokenizer_byte_as_char"];
+            transform(value.begin(), value.end(), value.begin(), ::tolower);
+            std::istringstream iss(value);
+            iss >> std::boolalpha >> this->weight.tokenizer.byte_as_char;
+        }
 
         this->deviceMap = GetDeviceMap();
     }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -56,19 +56,19 @@ namespace fastllm {
             std::string value = this->weight.dicts["tokenizer_add_dummy_prefix"];
             transform(value.begin(), value.end(), value.begin(), ::tolower);
             std::istringstream iss(value);
-            iss >> std::boolalpha >> this->weight.tokenizer.add_dummy_prefix;
+            iss >> std::boolalpha >> this->weight.tokenizer.addDummyPrefix;
         }
         if (this->weight.dicts.find("tokenizer_remove_extra_whitespaces") != this->weight.dicts.end()) {
             std::string value = this->weight.dicts["tokenizer_remove_extra_whitespaces"];
             transform(value.begin(), value.end(), value.begin(), ::tolower);
             std::istringstream iss(value);
-            iss >> std::boolalpha >> this->weight.tokenizer.remove_extra_whitespaces;
+            iss >> std::boolalpha >> this->weight.tokenizer.removeExtraWhitespaces;
         }
         if (this->weight.dicts.find("tokenizer_byte_as_char") != this->weight.dicts.end()) {
             std::string value = this->weight.dicts["tokenizer_byte_as_char"];
             transform(value.begin(), value.end(), value.begin(), ::tolower);
             std::istringstream iss(value);
-            iss >> std::boolalpha >> this->weight.tokenizer.byte_as_char;
+            iss >> std::boolalpha >> this->weight.tokenizer.byteAsChar;
         }
 
         this->deviceMap = GetDeviceMap();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -2,6 +2,7 @@
 
 #include "model.h"
 #include "fastllm.h"
+#include <sstream>
 
 #include "chatglm.h"
 #include "moss.h"
@@ -50,6 +51,18 @@ namespace fastllm {
         }
         if (this->weight.dicts.find("history_sep") != this->weight.dicts.end()) {
             history_sep = this->weight.dicts["history_sep"];
+        }
+        if (this->weight.dicts.find("tokenizer_add_dummy_prefix") != this->weight.dicts.end()) {
+            std::string value = this->weight.dicts["tokenizer_add_dummy_prefix"];
+            transform(value.begin(), value.end(), value.begin(), ::tolower);
+            std::istringstream iss(value);
+            iss >> std::boolalpha >> this->weight.tokenizer.add_dummy_prefix;
+        }
+        if (this->weight.dicts.find("tokenizer_remove_extra_whitespaces") != this->weight.dicts.end()) {
+            std::string value = this->weight.dicts["tokenizer_remove_extra_whitespaces"];
+            transform(value.begin(), value.end(), value.begin(), ::tolower);
+            std::istringstream iss(value);
+            iss >> std::boolalpha >> this->weight.tokenizer.remove_extra_whitespaces;
         }
 
         this->deviceMap = GetDeviceMap();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -88,7 +88,7 @@ namespace fastllm {
             model = (basellm*)(new ChatGLMModel());
         } else if (modelType == "moss") {
             model = (basellm*)(new MOSSModel());
-            model->weight.tokenizer.type = Tokenizer::TokenizerType::NORMAL;
+            model->weight.tokenizer.type = Tokenizer::TokenizerType::BPE;
             model->eos_token_id = 106068;
         } else if (modelType == "baichuan") {
             model = (basellm*)(new LlamaModel());

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -92,6 +92,9 @@ namespace fastllm {
             model->bot_role = "\n<bot>:";
             model->history_sep = "\n";
             model->weight.tokenizer.type = Tokenizer::TokenizerType::BPE;
+        } else if (modelType == "internlm") {
+            model = new LlamaModel();
+            model->model_type = "internlm";
         } else if (modelType == "llama") {
             model = (basellm*)(new LlamaModel());
         } else if (modelType == "qwen") {

--- a/src/pybinding.cpp
+++ b/src/pybinding.cpp
@@ -260,6 +260,9 @@ PYBIND11_MODULE(pyfastllm, m) {
 
 
   py::class_<fastllm::Tokenizer>(m, "Tokenizer")
+    .def_readonly("add_dummy_prefix", &fastllm::Tokenizer::addDummyPrefix)
+    .def_readonly("remove_extra_whitespaces", &fastllm::Tokenizer::removeExtraWhitespaces)
+    .def_readonly("byte_as_char", &fastllm::Tokenizer::byteAsChar)
     .def("encode", &fastllm::Tokenizer::Encode)
     // .def("decode", &fastllm::Tokenizer::Decode)
     .def("decode", &fastllm::Tokenizer::Decode, "Decode from Tensor")
@@ -273,7 +276,8 @@ PYBIND11_MODULE(pyfastllm, m) {
       return py::bytes(ret);
     })
     .def("clear", &fastllm::Tokenizer::Clear)
-    .def("insert", &fastllm::Tokenizer::Insert);
+    .def("insert", &fastllm::Tokenizer::Insert)
+    .def("set_special_tokens", &fastllm::Tokenizer::SetSpecialTokens);
   
   py::class_<fastllm::WeightMap>(m, "WeightMap")
     .def_readonly("tokenizer", &fastllm::WeightMap::tokenizer)

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -2,6 +2,8 @@ from fastllm_pytools import llm;
 import ctypes;
 import numpy as np
 import torch
+from transformers import PreTrainedTokenizerFast
+from tokenizers.decoders import ByteLevel
 
 fastllm_data_type_dict = {
     "int4": 8,
@@ -74,6 +76,10 @@ def create(model,
                     modelInfo["tokenizer_remove_extra_whitespaces"] = sp_model_proto.normalizer_spec.remove_extra_whitespaces
             except:
                 pass
+        elif isinstance(tokenizer, PreTrainedTokenizerFast):
+            if hasattr(tokenizer, "_tokenizer") and hasattr(tokenizer._tokenizer, "decoder") \
+                    and isinstance(tokenizer._tokenizer.decoder, ByteLevel):
+                modelInfo["tokenizer_byte_as_char"] = True
 
     peft_config = {}
     active_adapter = ""

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -67,6 +67,15 @@ def create(model,
 
     if tokenizer:
         modelInfo["tokenizer_use_score"] = "1" # 分词带分数
+        if len(tokenizer.all_special_tokens) > 0:
+            token_set = set()
+            for token in [tokenizer.bos_token, tokenizer.eos_token, tokenizer.unk_token, tokenizer.pad_token]:
+                for prompt in [pre_prompt, user_role, bot_role, history_sep]:
+                    if prompt and str(token) in prompt:
+                        modelInfo["tokenizer_has_special_tokens"] = "1"
+                token_set.add(str(token))
+            if len(tokenizer.all_special_tokens) > len(token_set):
+                modelInfo["tokenizer_has_special_tokens"] = "1"
         if hasattr(tokenizer, "sp_model") or (hasattr(tokenizer, "tokenizer") and hasattr(tokenizer.tokenizer, "sp_model")):
             try:
                 import sentencepiece.sentencepiece_model_pb2 as model_pb2
@@ -144,7 +153,7 @@ def create(model,
                     llm.fastllm_lib.add_tokenizer_word_llm_model(model_handle, v, vocab[v], ctypes.c_float(1.0));
                 else:
                     llm.fastllm_lib.add_tokenizer_word_llm_model(model_handle, v.encode(), vocab[v], ctypes.c_float(score));
-        if (len(tokenizer.all_special_tokens) > 0):
+        if ("tokenizer_has_special_tokens" in modelInfo):
             special_tokens_str = ''.join(tokenizer.all_special_tokens)
             special_tokens_len = [len(x) for x in tokenizer.all_special_tokens]
             special_tokens_ids = tokenizer.all_special_ids

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -144,6 +144,14 @@ def create(model,
                     llm.fastllm_lib.add_tokenizer_word_llm_model(model_handle, v, vocab[v], ctypes.c_float(1.0));
                 else:
                     llm.fastllm_lib.add_tokenizer_word_llm_model(model_handle, v.encode(), vocab[v], ctypes.c_float(score));
+        if (len(tokenizer.all_special_tokens) > 0):
+            special_tokens_str = ''.join(tokenizer.all_special_tokens)
+            special_tokens_len = [len(x) for x in tokenizer.all_special_tokens]
+            special_tokens_ids = tokenizer.all_special_ids
+            llm.fastllm_lib.set_special_tokens_llm_model(model_handle, len(special_tokens_len),
+                                                         (ctypes.c_int * len(special_tokens_len))(*special_tokens_len),
+                                                         special_tokens_str.encode(),
+                                                         (ctypes.c_int * len(special_tokens_ids))(*special_tokens_ids));
 
     weight_type_dict = {}
     module_dict = {}
@@ -195,6 +203,7 @@ def create(model,
                                              dict[key].numpy().astype(ori_np_data_type).ctypes.data_as(ctypes.c_void_p));
         tot += 1;
         print("convert (", tot, "/", len(dict), end = " )\r");
+        dict[key].to(torch.device("meta"))
 
     print("");
     llm.fastllm_lib.init_params_llm_model(model_handle);

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -145,7 +145,7 @@ class model:
         fastllm_lib.save_llm_model(self.model, path.encode());
 
     def eval(self):
-        pass;
+        return self;
 
     def build_tokenizer_decode_token_cache(self):
         if self.tokenizer_decode_token_cache is not None:

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -55,6 +55,8 @@ fastllm_lib.make_input_llm_model.restype = ctypes.c_char_p
 
 fastllm_lib.add_tokenizer_word_llm_model.argtype = [ctypes.c_int, ctypes.c_char_p, ctypes.c_float, ctypes.c_int]
 
+fastllm_lib.set_special_tokens_llm_model.argtype = [ctypes.c_int, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+
 fastllm_lib.set_device_map.argtype = [ctypes.c_int, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
 
 def set_cpu_threads(threads: int):

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -124,6 +124,15 @@ def tofile(exportPath,
 
     if tokenizer:
         modelInfo["tokenizer_use_score"] = "1" # 分词带分数
+        if len(tokenizer.all_special_tokens) > 0:
+            token_set = set()
+            for token in [tokenizer.bos_token, tokenizer.eos_token, tokenizer.unk_token, tokenizer.pad_token]:
+                for prompt in [pre_prompt, user_role, bot_role, history_sep]:
+                    if prompt and str(token) in prompt:
+                        modelInfo["tokenizer_has_special_tokens"] = "1"
+                token_set.add(str(token))
+            if len(tokenizer.all_special_tokens) > len(token_set):
+                modelInfo["tokenizer_has_special_tokens"] = "1"
         if hasattr(tokenizer, "sp_model") or (hasattr(tokenizer, "tokenizer") and hasattr(tokenizer.tokenizer, "sp_model")):
             try:
                 import sentencepiece.sentencepiece_model_pb2 as model_pb2
@@ -200,6 +209,11 @@ def tofile(exportPath,
                     fo.write(struct.pack('i', c))
                 fo.write(struct.pack('i', vocab[v]))
                 fo.write(struct.pack('f', score))
+        if ("tokenizer_has_special_tokens" in modelInfo):
+            fo.write(struct.pack('i', len(tokenizer.all_special_tokens)))
+            for special_token in tokenizer.all_special_tokens:
+                fo.write(struct.pack('i', len(special_token)))
+                fo.write(special_token.encode())
     else:
         fo.write(struct.pack('i', 0))
 

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -1,6 +1,8 @@
 import struct
 import numpy as np
 import torch
+from transformers import PreTrainedTokenizerFast
+from tokenizers.decoders import ByteLevel
 
 def writeString(fo, s):
     fo.write(struct.pack('i', len(s)))
@@ -131,6 +133,10 @@ def tofile(exportPath,
                     modelInfo["tokenizer_remove_extra_whitespaces"] = sp_model_proto.normalizer_spec.remove_extra_whitespaces
             except:
                 pass
+        elif isinstance(tokenizer, PreTrainedTokenizerFast):
+            if hasattr(tokenizer, "_tokenizer") and hasattr(tokenizer._tokenizer, "decoder") \
+                    and isinstance(tokenizer._tokenizer.decoder, ByteLevel):
+                modelInfo["tokenizer_byte_as_char"] = True
 
     if hasattr(model, "peft_config"):
         adapter_size = len(model.peft_config)

--- a/tools/scripts/alpaca2flm.py
+++ b/tools/scripts/alpaca2flm.py
@@ -1,11 +1,13 @@
 import sys
-from transformers import LlamaTokenizer, LlamaForCausalLM
+import torch
+from transformers import AutoTokenizer, LlamaForCausalLM
 from fastllm_pytools import torch2flm
 
 if __name__ == "__main__":
     model_name = sys.argv[3] if len(sys.argv) >= 4 else 'minlik/chinese-alpaca-33b-merged'
-    tokenizer = LlamaTokenizer.from_pretrained(model_name)
-    model = LlamaForCausalLM.from_pretrained(model_name).float()
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    # `torch_dtype=torch.float16` is set by default, if it will not cause an OOM Error, you can load model in float32.
+    model = LlamaForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)
     conf = model.config.__dict__
     conf["model_type"] = "llama"
     dtype = sys.argv[2] if len(sys.argv) >= 3 else "float16"

--- a/tools/scripts/internlm2flm.py
+++ b/tools/scripts/internlm2flm.py
@@ -1,0 +1,16 @@
+import sys
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from fastllm_pytools import torch2flm
+
+if __name__ == "__main__":
+    modelNameOrPath = sys.argv[3] if len(sys.argv) >= 4 else "internlm/internlm-chat-7b-v1_1"
+    tokenizer = AutoTokenizer.from_pretrained(modelNameOrPath, trust_remote_code=True);
+    # `torch_dtype=torch.float16` is set by default, if it will not cause an OOM Error, you can load model in float32.
+    model = AutoModelForCausalLM.from_pretrained(modelNameOrPath, trust_remote_code=True, torch_dtype=torch.float16)
+    model = model.eval()
+    dtype = sys.argv[2] if len(sys.argv) >= 3 else "float16"
+    exportPath = sys.argv[1] if len(sys.argv) >= 2 else "internlm-7b-' + dtype + '.flm"
+    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<s><s>", 
+                     user_role = "<|User|>:", bot_role = "<eoh>\n<|Bot|>:", 
+                     history_sep = "<eoa>\n<s>", dtype = dtype)

--- a/tools/src/pytools.cpp
+++ b/tools/src/pytools.cpp
@@ -117,6 +117,21 @@ extern "C" {
         return;
     }
 
+    DLL_EXPORT void set_special_tokens_llm_model(int modelId, int token_cnt, int *lens, char *tokens, int *ids) {
+        std::map <std::string, int> tokenMap;
+        int cur = 0;
+        for (int i = 0; i < token_cnt; i++) {
+            std::string key = "";
+            for (int j = 0; j < lens[i]; j++) {
+                key += tokens[cur++];
+            }
+            tokenMap[key] = ids[i];
+        }
+        auto model = models.GetModel(modelId);
+        model->weight.tokenizer.SetSpecialTokens(tokenMap);
+        return;
+    }
+
     DLL_EXPORT int token_decode(int modelId, int tokenId, int output_buffer_len, char *output_buffer) {
         // 正常时候返回0，输出buffer长度不足时返回输出的bytes数量，包含末尾的\0
         if(tokenId == -1) {


### PR DESCRIPTION
* SentencePiece 
  * 支持读取并对齐normalize的设置"add_dummy_prefix"和“remove_extra_whitespaces”，处理前面加一个空格和合并多个空格的情况；

* HuggingFace Tokenizers
  * 对齐toeknizer.json格式的BPE Tokenizer，不过由于`PretrainedTokenizerFast`没存储json路径，目前只支持从本地文件转换。
  * 支持ByteLevel处理器（将单字节编解码为特殊字符）

* HuggingFace Transformers
  * 支持设置特殊token，可在兼容之前flm文件的基础上序列化和反序列化，可使用`set_special_tokens_llm_model`方式在转换时配置，

* 支持 InternLM-7B 模型推理
  * 使用的时候最好配置一个`stop_token_id`。

* 测试过Tokenizer的模型：
  * XVERSE-7B-chat
  * deepseek_coder-1.3b-instruct
  * Yi-6B-Chat