### PR TITLE
修复NVIDIA旧架构GPU编译问题，初步优化旧架构GPU性能

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(fastllm LANGUAGES CXX)
 
-option(USE_CUDA "use cuda" OFF)
+option(USE_CUDA "use CUDA" OFF)
+option(CUDA_NO_TENSOR_CORE "Optimize for legacy CUDA GPUs which has Tensor Core." OFF)
 
 option(PY_API "python api" OFF)
 
@@ -13,6 +14,8 @@ option(USE_SENTENCEPIECE "use sentencepiece" OFF)
 option(USE_IVCOREX "use iluvatar corex gpu" OFF)
 
 message(STATUS "USE_CUDA: ${USE_CUDA}")
+
+message(STATUS "For legacy CUDA GPUs: ${CUDA_NO_TENSOR_CORE}")
 
 message(STATUS "PYTHON_API: ${PY_API}")
 
@@ -56,6 +59,9 @@ endif()
 if (USE_CUDA)
     enable_language(CUDA)
     add_compile_definitions(USE_CUDA)
+    if (CUDA_NO_TENSOR_CORE)
+        add_compile_definitions(CUDA_NO_TENSOR_CORE)
+    endif()
     include_directories(include/devices/cuda)
     #message(${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
     set(FASTLLM_CUDA_SOURCES src/devices/cuda/cudadevice.cpp src/devices/cuda/cudadevicebatch.cpp src/devices/cuda/fastllm-cuda.cu)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,6 +43,21 @@ cmake .. -DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=native
  if (PY_API)
 ```
 
+### identifier "__hdiv" is undefined
+
+**现象：**
+
+> src/devices/cuda/fastllm-cuda.cu(247): error: identifier "hexp" is undefined  
+> src/devices/cuda/fastllm-cuda.cu(247): error: identifier "__hdiv" is undefined  
+> ...
+
+**原因：** [计算能力（Compute Capability）](https://developer.nvidia.com/cuda-gpus) <= 5.3 的GPU不支持半精度计算。
+
+**解决办法：** 如需要支持这些GPU，执行cmake时使用编译选项`CUDA_NO_TENSOR_CORE`：
+
+```shell
+cmake .. -DUSE_CUDA=ON -DCUDA_NO_TENSOR_CORE=ON
+```
 
 ## Windows
 


### PR DESCRIPTION
## 说明

fastllm在主分支中增加了fp16算子后，引发了一些编译问题。

1. 在 CUDA < 11.0 以及 CUDA < 11.6 且 Compute Capability < 8.0 时，CUDA 没有定义`__hmax`函数，
3. 老设备（如Tesla M40 / Tesla K40等）不支持fp16计算，因此会编译失败。

本次做了如下的修改：

1. 修复了问题1；
2. 本次更新增加了编译选项`CUDA_NO_TENSOR_CORE`；  
   1.  修改了fp16算子部分，开启编译宏后，这部分使用fp32计算；
   2.  修改了矩阵乘法的计算方式，优化了 Maxwell、Pascal架构(不包括Tesla P100)，16系列（1660s CMP-40HX ）上的推理速度。

## 测试

用以下方式测试过：

- cmake 配置`CMAKE_CUDA_ARCHITECTURES`选项，验证编译。
  - CentOS 7 CUDA 10.0 CUDA 11.8
  - Ubuntu20.04 CUDA 11.0 CUDA 11.3
- Tesla P40 / RTX 1070 测试chatglm/qwen/llama系列。
