### PR TITLE
采用向量化访存优化旧架构GPU性能

### DIFF
--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -1126,6 +1126,47 @@ __global__ void FastllmGemvInt4NoZeroKernel2(float *A, uint8_t *B, float *C,
     }
 }
 
+template <int THREAD_PER_BLOCK, int PART>
+__global__ void FastllmGemvInt4NoZeroKernel1(float *A, uint8_t *B, float *C,
+                                             float *bias, float *scales, float *mins,
+                                             int m, int k) {
+    __shared__ float sdata[THREAD_PER_BLOCK];
+    unsigned int tid = threadIdx.x;
+
+    // 1. 计算
+    int st = blockIdx.x * PART;
+    int end = st + PART;
+    for (int p = st; p < end; p++) {
+        sdata[tid] = 0;
+        const uint8_t *baseB = B + p * m / 2;
+        float minv = __ldg(mins + p) / __ldg(scales + p);
+        for (int i = tid * 2; i < m / 2; i += THREAD_PER_BLOCK * 2) {
+            float4 aBuffer = FETCH_FLOAT4(A[i * 2]);
+            uint16_t bBuffer = *reinterpret_cast<const uint16_t *>(baseB + i);
+            sdata[tid] += aBuffer.x * (minv + ((bBuffer >> 4) & 15)) + aBuffer.y * (minv + (bBuffer & 15));
+            sdata[tid] += aBuffer.z * (minv + (bBuffer >> 12)) + aBuffer.w * (minv + ((bBuffer >> 8) & 15));
+        }
+        __syncthreads();
+
+        float diff = 0.0f;
+        for (unsigned int s = THREAD_PER_BLOCK/2; s > 0; s >>= 1) {
+            if (tid < s) {
+                float other = sdata[tid + s] - diff;
+                float sumTmp = sdata[tid] + other;
+                diff = (sumTmp - sdata[tid]) - other;
+                sdata[tid] = sumTmp;
+            }
+            __syncthreads();
+        }
+        //if (tid <= 32)
+            //warpReduce(sdata, tid);
+        if (tid == 0) {
+            C[p] = sdata[0] * scales[p] + bias[p];
+        }
+        __syncthreads();
+    }
+}
+
 template <int THREAD_PER_BLOCK>
 __global__ void FastllmSplitBatchKernel(uint8_t *input, uint8_t **outputs, int outer, int channels, int inner) {
     int bid = blockIdx.x / outer, oid = blockIdx.x % outer;
@@ -1842,7 +1883,7 @@ bool FastllmCudaMatMulFloatInt4NoZero(const fastllm::Data &input, fastllm::Data 
 #endif
     } else {
         for (int i = 0; i < n; i++) {
-            FastllmGemvInt4NoZeroKernel2<256, 1> <<< k, 256 >>>(cudaInput + i * m,
+            FastllmGemvInt4NoZeroKernel1<256, 1> <<< k, 256 >>>(cudaInput + i * m,
                                                                 (uint8_t *) weight.cudaData,
                                                                 cudaOutput + i * k,
                                                                 cudaBiasData,


### PR DESCRIPTION
## 修改内容

1. 针对单条推理decode阶段的GPU GEMV算子优化
    a. 在`CUDA_NO_TENSOR_CORE`编译选项下，fp16/int8 修改为向量化访存，获得一定速度提升；
    b. 对全部架构int4的GEMV开启向量化访存。

2. 针对int8/int4批量推理的反量化操作
   a. 在`CUDA_NO_TENSOR_CORE`编译选项下，修改为向量化访存。

## 测试情况

单条推理优化后结果，采用benchmark测试：

|    GPU    | 编译器 | CUDA      |   模型-精度   |  优化前 |  优化后  |
| --------- | ------ | --------- | ------------- | ------- | -------- |
| Tesla P40 | VS2015 | CUDA  9.2 | ChatGLM  fp16 | 20.7tps |  21.4tps |
| Tesla P40 | GCC9.4 | CUDA 10.0 | ChatGLM  fp16 | 20.8tps |  21.5tps |
| Tesla P40 | VS2015 | CUDA  9.2 | ChatGLM2 int8 | 23.6tps |  24.9tps |
| Tesla P40 | GCC9.4 | CUDA 10.0 | ChatGLM2 int8 | 23.6tps |  24.5tps |
| Tesla P40 | VS2015 | CUDA  9.2 | ChatGLM2 int4 | 15.0tps |  **27.6tps** |
| Tesla P40 | GCC9.4 | CUDA 10.0 | ChatGLM2 int4 | 14.8tps |  **27.2tps** |
| GTX1080Ti | GCC8.3 | CUDA 11.6 | ChatGLM2 int4 | 17.9tps |  **32.9tps** |
| RTX 3090  | GCC7.5 | CUDA 11.0 | ChatGLM2 int4 | 99.8tps | 117.7tps |
| RTX 3090  | GCC8.3 | CUDA 11.6 | ChatGLM2 int4 | 95.4tps | 101.3tps |
