### PR TITLE
解决，arm64 windows下编译报错

### DIFF
--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include "utils.h"
+#define M_PI       3.14159265358979323846   // pi
 
 namespace fastllm {
     CpuDevice::CpuDevice() {


### PR DESCRIPTION
解决arm64 windows下编译报错：
![image](https://github.com/ztxz16/fastllm/assets/25482706/f0250f92-1c3d-45d1-a489-9a0dba5321d6)
