### PR TITLE
修复webui/apiserver的Windows编译，并支持直接读取HF模型

### DIFF
--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -1,7 +1,6 @@
 // Provide by Jacques CHEN (http://whchen.net/index.php/About.html)
 // HTML file reference from ChatGLM-MNN （https://github.com/wangzhaode/ChatGLM-MNN)
 
-#include "model.h"
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -120,6 +119,7 @@ using socket_t = int;
 #include <string>
 #include <sys/stat.h>
 #include <thread>
+#include "model.h"
 
 struct APIConfig {
     std::string path = "chatglm-6b-int4.bin"; // 模型文件路径

--- a/example/webui/webui.cpp
+++ b/example/webui/webui.cpp
@@ -1,8 +1,8 @@
 // Provide by Jacques CHEN (http://whchen.net/index.php/About.html)
 // HTML file reference from ChatGLM-MNN （https://github.com/wangzhaode/ChatGLM-MNN)
 
-#include "model.h"
 #include "httplib.h"
+#include "model.h"
 
 #include <cstdio>
 #include <cstring>

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <thread>
 #include <vector>
+#include <filesystem>
 
 #if defined(_WIN32) or defined(_WIN64)
 #include <Windows.h>
@@ -31,9 +32,15 @@
 #endif
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER <= 1900 // VS 2015
+    namespace fs = std::experimental::filesystem;
+#else
+    namespace fs = std::filesystem;
+#endif
+
 namespace fastllm {
     static void MySleep(int t) {
-        std::this_thread::sleep_for(std::chrono::seconds(0));
+        std::this_thread::sleep_for(std::chrono::seconds(t));
     }
 
     static void ErrorInFastLLM(const std::string &error) {
@@ -112,6 +119,15 @@ namespace fastllm {
             ret.push_back(atoi(cur.c_str()));
         }
         return ret;
+    }
+
+    static bool FileExists(std::string filePath) {
+#if defined(__GNUC__) && __GNUC__ < 9
+        return access(filePath.c_str(), R_OK) == 0;
+#else
+        fs::path path(filePath);
+        return fs::exists(path);
+#endif
     }
 
     struct TimeRecord {

--- a/main.cpp
+++ b/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     fastllm::PrintInstructionInfo();
     fastllm::SetThreads(config.threads);
     fastllm::SetLowMemMode(config.lowMemMode);
-    bool isHFDir = access((config.path + "/config.json").c_str(), R_OK) == 0 || access((config.path + "config.json").c_str(), R_OK) == 0;
+    bool isHFDir = fastllm::FileExists(config.path + "/config.json") || fastllm::FileExists(config.path + "config.json");
     auto model = !isHFDir ? fastllm::CreateLLMModelFromFile(config.path) : fastllm::CreateLLMModelFromHF(config.path, config.dtype, config.groupCnt);
     if (config.atype != fastllm::DataType::FLOAT32) {
         model->SetDataType(config.atype);

--- a/main.cpp
+++ b/main.cpp
@@ -11,11 +11,11 @@ std::map <std::string, fastllm::DataType> dataTypeDict = {
 };
 
 struct RunConfig {
-	std::string path = "chatglm-6b-int4.bin"; // 模型文件路径
+    std::string path = "chatglm-6b-int4.bin"; // 模型文件路径
     std::string systemPrompt = "";
     std::set <std::string> eosToken;
-	int threads = 4; // 使用的线程数
-	bool lowMemMode = false; // 是否使用低内存模式
+    int threads = 4; // 使用的线程数
+    bool lowMemMode = false; // 是否使用低内存模式
 
     fastllm::DataType dtype = fastllm::DataType::FLOAT16;
     fastllm::DataType atype = fastllm::DataType::FLOAT32;
@@ -23,11 +23,11 @@ struct RunConfig {
 };
 
 void Usage() {
-	std::cout << "Usage:" << std::endl;
-	std::cout << "[-h|--help]:                  显示帮助" << std::endl;
-	std::cout << "<-p|--path> <args>:           模型文件的路径" << std::endl;
-	std::cout << "<-t|--threads> <args>:        使用的线程数量" << std::endl;
-	std::cout << "<-l|--low>:                   使用低内存模式" << std::endl;
+    std::cout << "Usage:" << std::endl;
+    std::cout << "[-h|--help]:                  显示帮助" << std::endl;
+    std::cout << "<-p|--path> <args>:           模型文件的路径" << std::endl;
+    std::cout << "<-t|--threads> <args>:        使用的线程数量" << std::endl;
+    std::cout << "<-l|--low>:                   使用低内存模式" << std::endl;
     std::cout << "<--system> <args>:            设置系统提示词(system prompt)" << std::endl;
     std::cout << "<--eos_token> <args>:         设置eos token" << std::endl;
     std::cout << "<--dtype> <args>:             设置权重类型(读取hf文件时生效)" << std::endl;
@@ -38,21 +38,21 @@ void Usage() {
 }
 
 void ParseArgs(int argc, char **argv, RunConfig &config, fastllm::GenerationConfig &generationConfig) {
-	std::vector <std::string> sargv;
-	for (int i = 0; i < argc; i++) {
-		sargv.push_back(std::string(argv[i]));
-	}
-	for (int i = 1; i < argc; i++) {
-		if (sargv[i] == "-h" || sargv[i] == "--help") {
-			Usage();
-			exit(0);
-		} else if (sargv[i] == "-p" || sargv[i] == "--path") {
-			config.path = sargv[++i];
-		} else if (sargv[i] == "-t" || sargv[i] == "--threads") {
-			config.threads = atoi(sargv[++i].c_str());
-		} else if (sargv[i] == "-l" || sargv[i] == "--low") {
-			config.lowMemMode = true;
-		} else if (sargv[i] == "-m" || sargv[i] == "--model") {
+    std::vector <std::string> sargv;
+    for (int i = 0; i < argc; i++) {
+        sargv.push_back(std::string(argv[i]));
+    }
+    for (int i = 1; i < argc; i++) {
+        if (sargv[i] == "-h" || sargv[i] == "--help") {
+            Usage();
+            exit(0);
+        } else if (sargv[i] == "-p" || sargv[i] == "--path") {
+            config.path = sargv[++i];
+        } else if (sargv[i] == "-t" || sargv[i] == "--threads") {
+            config.threads = atoi(sargv[++i].c_str());
+        } else if (sargv[i] == "-l" || sargv[i] == "--low") {
+            config.lowMemMode = true;
+        } else if (sargv[i] == "-m" || sargv[i] == "--model") {
             i++;
         } else if (sargv[i] == "--top_p") {
             generationConfig.top_p = atof(sargv[++i].c_str());
@@ -81,20 +81,24 @@ void ParseArgs(int argc, char **argv, RunConfig &config, fastllm::GenerationConf
                                     "Unsupport act type: " + atypeStr);
             config.atype = dataTypeDict[atypeStr];
         } else {
-			Usage();
-			exit(-1);
-		}
-	}
+            Usage();
+            exit(-1);
+        }
+    }
 }
 
 int main(int argc, char **argv) {
     RunConfig config;
     fastllm::GenerationConfig generationConfig;
-	ParseArgs(argc, argv, config, generationConfig);
+    ParseArgs(argc, argv, config, generationConfig);
 
     fastllm::PrintInstructionInfo();
     fastllm::SetThreads(config.threads);
     fastllm::SetLowMemMode(config.lowMemMode);
+    if (!fastllm::FileExists(config.path)) {
+        printf("模型文件 %s 不存在！\n", config.path.c_str());
+        exit(0);
+    }
     bool isHFDir = fastllm::FileExists(config.path + "/config.json") || fastllm::FileExists(config.path + "config.json");
     auto model = !isHFDir ? fastllm::CreateLLMModelFromFile(config.path) : fastllm::CreateLLMModelFromHF(config.path, config.dtype, config.groupCnt);
     if (config.atype != fastllm::DataType::FLOAT32) {
@@ -139,5 +143,5 @@ int main(int argc, char **argv) {
         messages.push_back(std::make_pair("assistant", ret));
     }
 
-	return 0;
+    return 0;
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -5,7 +5,7 @@
 #include "fastllm.h"
 #include <sstream>
 #include <fstream>
-#include <filesystem>
+
 #include "chatglm.h"
 #include "moss.h"
 #include "llama.h"
@@ -16,12 +16,6 @@
 #include "minicpm.h"
 #include "internlm2.h"
 #include "bert.h"
-
-#if defined(_MSC_VER) && _MSC_VER <= 1900 // VS 2015
-    namespace fs = std::experimental::filesystem;
-#else
-    namespace fs = std::filesystem;
-#endif
 
 namespace fastllm {
     std::string ReadAllFile(const std::string &fileName) {
@@ -382,8 +376,7 @@ namespace fastllm {
         std::set <std::string> stFiles;
         std::string stIndexFile = path + "model.safetensors.index.json";
         std::string error;
-        fs::path stIndex(stIndexFile);
-        if (!fs::exists(stIndex)) {
+        if (!FileExists(stIndexFile)) {
             stFiles.insert(path + "model.safetensors");
         } else {
             auto stIndex = json11::Json::parse(ReadAllFile(stIndexFile), error)["weight_map"];


### PR DESCRIPTION
1. 修复 #464 中引入的 webui / apiserver 的windows编译问题，修复 main 的 windows编译（只是编译通过）；
2. main / webui / apiserver 找不到文件则退出；
3. webui / apiserver 支持直接读取HF .safetensers 模型；

## 测试情况
在以下环境测试过编译：
* Windows 10 + VIsual Studio 2015R3
* CentOS7 + GCC 8.3
在以下环境运行通过：
* CentOS7 + GCC 8.3