### PR TITLE
直接读取Llama3，Qwen2的HF模型，apiserver webui benchmark使用ChatTemplate

### DIFF
--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -310,7 +310,7 @@ struct WorkQueue {
             }
         }
         if (node->error != "") {
-printf("error body = %s, prompt = %s, error = %s\n", node->request.body.c_str(), node->config["prompt"].string_value().c_str(), node->error.c_str());
+            printf("error body = %s, prompt = %s, error = %s\n", node->request.body.c_str(), node->config["prompt"].string_value().c_str(), node->error.c_str());
             message += node->error;
             int ret = write(node->client, message.c_str(), message.length()); //返回error
             close(node->client);
@@ -318,7 +318,9 @@ printf("error body = %s, prompt = %s, error = %s\n", node->request.body.c_str(),
         }
 
         std::string output = "";
-        auto prompt = model->MakeInput("", 0, node->config["prompt"].string_value());
+        fastllm::ChatMessages messages;
+        messages.push_back({"user", node->config["prompt"].string_value()});
+        auto prompt = model->ApplyChatTemplate(messages);
         auto inputs = model->weight.tokenizer.Encode(prompt);
         std::vector<int> tokens;
         for (int i = 0; i < inputs.Count(0); i++) {

--- a/include/template.h
+++ b/include/template.h
@@ -94,7 +94,7 @@ namespace fastllm {
             {"or", JinjaToken::JinjaToKenType::JinjaTokenOr},
     };
 
-    // 一个Jinja块
+    // 一个Jinja块 
     struct JinjaBlock {
         enum JinjaBlockType {
             JinjaBlockOriginal = 0, JinjaBlockEmpty, JinjaBlockVar, JinjaBlockFor, 

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,7 @@ void Usage() {
     std::cout << "<--system> <args>:            设置系统提示词(system prompt)" << std::endl;
     std::cout << "<--eos_token> <args>:         设置eos token" << std::endl;
     std::cout << "<--dtype> <args>:             设置权重类型(读取hf文件时生效)" << std::endl;
+    std::cout << "<--atype> <args>:             设置推理使用的数据类型(float32/float16)" << std::endl;
     std::cout << "<--top_p> <args>:             采样参数top_p" << std::endl;
     std::cout << "<--top_k> <args>:             采样参数top_k" << std::endl;
     std::cout << "<--temperature> <args>:       采样参数温度，越高结果越不固定" << std::endl;
@@ -104,7 +105,7 @@ int main(int argc, char **argv) {
     if (config.atype != fastllm::DataType::FLOAT32) {
         model->SetDataType(config.atype);
     }
-    model->SetSaveHistoryChat(true);    
+    model->SetSaveHistoryChat(true);
     
     for (auto &it : config.eosToken) {
         generationConfig.stop_token_ids.insert(model->weight.tokenizer.GetTokenId(it));

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -984,6 +984,7 @@ printf("len = %d, spend = %f s. tokens / s = %f\n", (int)total, spend, (float)to
                 {"content", message.second}
             });
         }
+        ret["add_generation_prompt"] = fastllm::JinjaVar{1};
         return ret;
     }
 

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -926,6 +926,10 @@ namespace fastllm {
             pastKeyValues.push_back(std::make_pair(Data(DataType::FLOAT32),
                                                    Data(DataType::FLOAT32)));
         }
+        if (this->weight.weight.find("lm_head.weight") == this->weight.weight.end()) {
+            this->weight["lm_head.weight"] = Data();
+            this->weight["lm_head.weight"].CopyFrom(this->weight["model.embed_tokens.weight"]);
+        }
         Forward(inputIds, attentionMask, positionIds, pastKeyValues);
         printf("finish.\n");
     }


### PR DESCRIPTION
1. 修复直接读取Llama3 HF模型的能力，支持直接读取Qwen2、Qwen1.5的HF模型
2. 配合修改，apiserver webui benchmark使用ChatTemplate

## 测试情况

在以下模型上测试通过
- Windows
  - Meta-Llama-3-8B-Instruct
- Centos7 
  - Meta-Llama-3-8B-Instruct
  - Qwen2-1.5B-Instruct（embedding和lm_head权重共享）
  - Qwen2-7B-Instruct
  - Qwen1.5-1.8B-Chat （需要更新最新的tokenizer_config.json）
  - Qwen1.5-7B-Chat （需要更新最新的tokenizer_config.json）