### PR TITLE
修复Windows上MSVC无法成功编译的Bug。

### DIFF
--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -121,7 +121,7 @@ using socket_t = int;
 #include <thread>
 #include "model.h"
 
-long long GetCurrentTime() {
+long long _GetCurrentTime() {
     auto now = std::chrono::high_resolution_clock::now();
     auto duration = now.time_since_epoch();
     return std::chrono::duration_cast<std::chrono::seconds>(duration).count();
@@ -430,7 +430,7 @@ struct WorkQueue {
             }
 
             std::string curId = "fastllm-" + GenerateRandomID();
-            auto createTime = GetCurrentTime();
+            auto createTime = _GetCurrentTime();
 
             if (isStream) {
                 message = "";

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,7 @@
-#include "model.h"
+﻿#include "model.h"
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
 
 std::map <std::string, fastllm::DataType> dataTypeDict = {
     {"float32", fastllm::DataType::FLOAT32},
@@ -89,6 +92,9 @@ void ParseArgs(int argc, char **argv, RunConfig &config, fastllm::GenerationConf
 }
 
 int main(int argc, char **argv) {
+#ifdef _WIN32
+    system("chcp 65001");
+#endif
     RunConfig config;
     fastllm::GenerationConfig generationConfig;
     ParseArgs(argc, argv, config, generationConfig);
@@ -97,7 +103,7 @@ int main(int argc, char **argv) {
     fastllm::SetThreads(config.threads);
     fastllm::SetLowMemMode(config.lowMemMode);
     if (!fastllm::FileExists(config.path)) {
-        printf("模型文件 %s 不存在！\n", config.path.c_str());
+        printf(u8"模型文件 %s 不存在！\n", config.path.c_str());
         exit(0);
     }
     bool isHFDir = fastllm::FileExists(config.path + "/config.json") || fastllm::FileExists(config.path + "config.json");
@@ -114,10 +120,10 @@ int main(int argc, char **argv) {
     fastllm::ChatMessages messages = {{"system", systemConfig}};
 
     static std::string modelType = model->model_type;
-    printf("欢迎使用 %s 模型. 输入内容对话，reset清空历史记录，stop退出程序.\n", model->model_type.c_str());
+    printf(u8"欢迎使用 %s 模型. 输入内容对话，reset清空历史记录，stop退出程序.\n", model->model_type.c_str());
 
     while (true) {
-        printf("用户: ");
+        printf(u8"用户: ");
         std::string input;
         std::getline(std::cin, input);
         if (input == "reset") {


### PR DESCRIPTION
原因是example/apiserver/apiserver.cpp中自定义的GetCurrentTime函数与VC内置函数重名。