### PR TITLE
C++支持直接加载DeepSeek V2 Lite系列的HF模型

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -68,20 +68,24 @@
 | Qwen/Qwen2-7B-Instruct   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
 | Qwen/Qwen2-72B-Instruct  |  | [✔](#qwen模型导出) | ✔ |
 
-> 注3： 需要更新，检查 tokenizer_config.json 是否为最新版本
+> 注3： 需要更新，检查 `tokenizer_config.json` 是否为最新版本
 
 ### DeepSeek系列
 
 |                                       模型  | 加载后转换 |  离线转换  |  直接读取  |
 |-------------------------------------------: |------------|------------|------------|
-| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
-| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
-| deepseek-ai/Deepseek-Coder-7B-Instruct v1.5 | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
-| deepseek-ai/deepseek-coder-33b-instruct     | [√](llama_cookbook.md#deepseek-coder) | [√](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
-| deepseek-ai/DeepSeek-V2-Chat                | √ | ✔ | √<sup>4</sup> |
-| deepseek-ai/DeepSeek-V2-Lite-Chat           | √ | ✔ | √<sup>4</sup> |
-| deepseek-ai/DeepSeek-Coder-V2-Instruct      | √ | √ | √<sup>4</sup> |
-| deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct | √ | √ | √<sup>4</sup> |
+| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup><sup>5</sup> |
+| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup><sup>5</sup> |
+| deepseek-ai/Deepseek-Coder-7B-Instruct v1.5 | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup> |
+| deepseek-ai/deepseek-coder-33b-instruct     | [√](llama_cookbook.md#deepseek-coder) | [√](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup> |
+| deepseek-ai/DeepSeek-V2-Chat                | √ | ✔ | √ |
+| deepseek-ai/DeepSeek-V2-Lite-Chat           | √ | ✔ | ✔ |
+| deepseek-ai/DeepSeek-Coder-V2-Instruct      | √ | ✔ | √ |
+| deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct | √ | ✔ | ✔ |
+
+> 注4： Python ftllm用AutoTokenizer而不使用Fastllm Tokenizer可以实现加载，但是C++程序尚不支持加载该模型的Tokenizer。
+> 注5： C++端仅支持最早的几个 `tokenizer_config.json` 版本
+
 
 ### LLaMA类模型
 
@@ -106,8 +110,6 @@
 |  |  |  |  |
 | meta-llama/Meta-Llama-3-8B-Instruct |  | [✔](tools/scripts/llama3_to_flm.py) | ✔ |
 | meta-llama/Meta-Llama-3-70B-Instruct |  | [✔](tools/scripts/llama3_to_flm.py) | ✔ |
-
-> 注4： Python ftllm用AutoTokenizer而不使用Fastllm Tokenizer可以实现加载，但是C++程序尚不支持加载该模型的Tokenizer。
 
 ### 其它模型
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -74,8 +74,8 @@
 
 |                                       模型  | 加载后转换 |  离线转换  |  直接读取  |
 |-------------------------------------------: |------------|------------|------------|
-| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
-| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
+| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
+| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
 | deepseek-ai/Deepseek-Coder-7B-Instruct v1.5 | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
 | deepseek-ai/deepseek-coder-33b-instruct     | [√](llama_cookbook.md#deepseek-coder) | [√](llama_cookbook.md#deepseek-coder) | ❌<sup>4</sup> |
 | deepseek-ai/DeepSeek-V2-Chat                | √ | ✔ | √<sup>4</sup> |

--- a/example/Win32Demo/Win32Demo.vcxproj
+++ b/example/Win32Demo/Win32Demo.vcxproj
@@ -104,6 +104,7 @@
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/arch:AVX /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\third_party\json11;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -122,6 +123,7 @@
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/arch:AVX /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\third_party\json11;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,6 +143,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\third_party\json11;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -162,6 +165,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;__AVX__;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\third_party\json11;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/example/Win32Demo/fastllm-gpu.vcxproj
+++ b/example/Win32Demo/fastllm-gpu.vcxproj
@@ -237,6 +237,9 @@
     <ClCompile Include="..\..\src\models\deepseekv2.cpp" />
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
+    <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
+    <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
+    <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
     <ClCompile Include="..\..\src\models\llama.cpp" />
     <ClCompile Include="..\..\src\models\minicpm.cpp" />

--- a/example/Win32Demo/fastllm-gpu.vcxproj.filters
+++ b/example/Win32Demo/fastllm-gpu.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="源文件\models">
       <UniqueIdentifier>{ad23d9cc-65a3-4c41-b87f-5826ce7a6dca}</UniqueIdentifier>
     </Filter>
+    <Filter Include="源文件\models\graph">
+      <UniqueIdentifier>{8ea8c4cc-b75e-4c3a-a4e9-1e4900de6380}</UniqueIdentifier>
+    </Filter>
     <Filter Include="头文件\utils">
       <UniqueIdentifier>{1da1956b-b0ea-4a15-9b4a-11a431319b7d}</UniqueIdentifier>
     </Filter>
@@ -184,6 +187,15 @@
     </ClCompile>
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\qwen2.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\telechat.cpp">
+      <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp">
       <Filter>源文件\devices\cpu</Filter>

--- a/example/Win32Demo/fastllm.vcxproj
+++ b/example/Win32Demo/fastllm.vcxproj
@@ -211,6 +211,9 @@
     <ClCompile Include="..\..\src\models\deepseekv2.cpp" />
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
+    <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
+    <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
+    <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
     <ClCompile Include="..\..\src\models\llama.cpp" />
     <ClCompile Include="..\..\src\models\minicpm.cpp" />

--- a/example/Win32Demo/fastllm.vcxproj.filters
+++ b/example/Win32Demo/fastllm.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="源文件\models">
       <UniqueIdentifier>{ad23d9cc-65a3-4c41-b87f-5826ce7a6dca}</UniqueIdentifier>
     </Filter>
+    <Filter Include="源文件\models\graph">
+      <UniqueIdentifier>{8ea8c4cc-b75e-4c3a-a4e9-1e4900de6380}</UniqueIdentifier>
+    </Filter>
     <Filter Include="头文件\utils">
       <UniqueIdentifier>{1da1956b-b0ea-4a15-9b4a-11a431319b7d}</UniqueIdentifier>
     </Filter>
@@ -178,6 +181,15 @@
     </ClCompile>
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\qwen2.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\telechat.cpp">
+      <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp">
       <Filter>源文件\devices\cpu</Filter>

--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -1,11 +1,11 @@
 #include "fastllm.h"
 
+std::vector <long long> FastllmCudaGetFreeSizes();
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
 void FastllmInitCublas(void);
-
-std::vector <long long> FastllmCudaGetFreeSizes();
 
 void FastllmCudaMallocBigBuffer(size_t size);
 void FastllmCudaClearBigBuffer();

--- a/include/template.h
+++ b/include/template.h
@@ -51,7 +51,7 @@ namespace fastllm {
         enum JinjaToKenType {
             JinjaTokenID = 0, JinjaTokenBOOL, JinjaTokenNUM, JinjaTokenSTRING, JinjaTokenDOT,
             JinjaTokenLMB, JinjaTokenRMB, JinjaTokenLSB, JinjaTokenRSB,
-            JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenEndif,
+            JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenElseIf, JinjaTokenEndif,
             JinjaTokenIn,
             JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv,
             JinjaTokenNot, JinjaTokenAnd, JinjaTokenOr,
@@ -86,10 +86,12 @@ namespace fastllm {
             {"for", JinjaToken::JinjaToKenType::JinjaTokenFor},
             {"endfor", JinjaToken::JinjaToKenType::JinjaTokenEndFor},
             {"if", JinjaToken::JinjaToKenType::JinjaTokenIf},
+            {"elif", JinjaToken::JinjaToKenType::JinjaTokenElseIf},
             {"else", JinjaToken::JinjaToKenType::JinjaTokenElse},
             {"endif", JinjaToken::JinjaToKenType::JinjaTokenEndif},
             {"set", JinjaToken::JinjaToKenType::JinjaTokenSet},
             {"in", JinjaToken::JinjaToKenType::JinjaTokenIn},
+            {"is", JinjaToken::JinjaToKenType::JinjaTokenIn},
             {"true", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"false", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"and", JinjaToken::JinjaToKenType::JinjaTokenAnd},
@@ -101,7 +103,7 @@ namespace fastllm {
     struct JinjaBlock {
         enum JinjaBlockType {
             JinjaBlockOriginal = 0, JinjaBlockEmpty, JinjaBlockVar, JinjaBlockFor, 
-            JinjaBlockEndFor, JinjaBlockIf, JinjaBlockElse, JinjaBlockEndIf,
+            JinjaBlockEndFor, JinjaBlockIf, JinjaBlockElseIf, JinjaBlockElse, JinjaBlockEndIf,
             JinjaBlockSet
         };
 

--- a/include/template.h
+++ b/include/template.h
@@ -49,7 +49,7 @@ namespace fastllm {
     // 词法分析后的Token
     struct JinjaToken {
         enum JinjaToKenType {
-            JinjaTokenID = 0, JinjaTokenNUM, JinjaTokenSTRING, JinjaTokenDOT, 
+            JinjaTokenID = 0, JinjaTokenBOOL, JinjaTokenNUM, JinjaTokenSTRING, JinjaTokenDOT,
             JinjaTokenLMB, JinjaTokenRMB, JinjaTokenLSB, JinjaTokenRSB,
             JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenEndif,
             JinjaTokenIn,
@@ -90,8 +90,11 @@ namespace fastllm {
             {"endif", JinjaToken::JinjaToKenType::JinjaTokenEndif},
             {"set", JinjaToken::JinjaToKenType::JinjaTokenSet},
             {"in", JinjaToken::JinjaToKenType::JinjaTokenIn},
+            {"true", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
+            {"false", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"and", JinjaToken::JinjaToKenType::JinjaTokenAnd},
             {"or", JinjaToken::JinjaToKenType::JinjaTokenOr},
+            {"not", JinjaToken::JinjaToKenType::JinjaTokenNot}
     };
 
     // 一个Jinja块 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -449,7 +449,7 @@ namespace fastllm {
         if (!model->weight.tokenizer.chatTemplate.empty() && model->weight.dicts.find("chat_template") == model->weight.dicts.end())
             model->weight.AddDict("chat_template", model->weight.tokenizer.chatTemplate);
         std::string tokenizerClass = tokenizerConfig["tokenizer_class"].string_value();
-        if (tokenizerClass == "PreTrainedTokenizerFast" 
+        if (tokenizerClass == "PreTrainedTokenizerFast" || tokenizerClass == "LlamaTokenizerFast"
             || tokenizerClass == "Qwen2Tokenizer"
             || tokenizerClass == "BloomTokenizer") {
             // PreTrainedTokenizerFast

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -1064,6 +1064,8 @@ printf("len = %d, spend = %f s. tokens / s = %f\n", (int)total, spend, (float)to
         for (auto &it : this->weight.tokenizer.tokenizerConfig.object_items()) {
             if (it.first != "messages" && it.second.is_string()) {
                 local[it.first] = it.second.string_value();
+            } else if (it.first.find_last_of("_token") != std::string::npos && it.second.is_object()) {
+                local[it.first] = it.second["content"].string_value();
             }
         }
         JinjaTemplate temp = JinjaTemplate(this->weight.tokenizer.chatTemplate);


### PR DESCRIPTION
修改了Jinja模板的解析，支持布尔变量“true”和“false”，支持[Jinja模板支持"is defined"和“elif”，
现在支持了DeepSeek V2系列模板，因此可以直接读取DeepSeek V2 Lite系列模型。（V2 236B 太大了，没法测试）

## 测试情况

* 在以下模型上测试过
deepseek-ai/DeepSeek-V2-Lite-Chat
deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct