### PR TITLE
C++支持直接读取Deepseek Coder V1系列HF模型

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -74,17 +74,16 @@
 
 |                                       模型  | 加载后转换 |  离线转换  |  直接读取  |
 |-------------------------------------------: |------------|------------|------------|
-| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup><sup>5</sup> |
-| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup><sup>5</sup> |
-| deepseek-ai/Deepseek-Coder-7B-Instruct v1.5 | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup> |
-| deepseek-ai/deepseek-coder-33b-instruct     | [√](llama_cookbook.md#deepseek-coder) | [√](llama_cookbook.md#deepseek-coder) | ✔<sup>4</sup> |
+| deepseek-ai/Deepseek-Coder-1.3B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
+| deepseek-ai/Deepseek-Coder-6.7B-Instruct    | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
+| deepseek-ai/Deepseek-Coder-7B-Instruct v1.5 | [✔](llama_cookbook.md#deepseek-coder) | [✔](llama_cookbook.md#deepseek-coder) | ✔ |
+| deepseek-ai/deepseek-coder-33b-instruct     | [√](llama_cookbook.md#deepseek-coder) | [√](llama_cookbook.md#deepseek-coder) | ✔ |
 | deepseek-ai/DeepSeek-V2-Chat                | √ | ✔ | √ |
 | deepseek-ai/DeepSeek-V2-Lite-Chat           | √ | ✔ | ✔ |
 | deepseek-ai/DeepSeek-Coder-V2-Instruct      | √ | ✔ | √ |
 | deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct | √ | ✔ | ✔ |
 
 > 注4： Python ftllm用AutoTokenizer而不使用Fastllm Tokenizer可以实现加载，但是C++程序尚不支持加载该模型的Tokenizer。
-> 注5： C++端仅支持最早的几个 `tokenizer_config.json` 版本
 
 
 ### LLaMA类模型

--- a/include/template.h
+++ b/include/template.h
@@ -15,8 +15,8 @@ namespace fastllm {
         };
 
         JinjaVarType type = JinjaNone;
-        long long intValue;
-        float floatValue;
+        long long intValue = 0LL;
+        float floatValue = 0.0f;
         std::string stringValue;
         std::vector <JinjaVar> arrayValue;
         std::map <std::string, JinjaVar> dictValue;
@@ -55,7 +55,7 @@ namespace fastllm {
             JinjaTokenIn,
             JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv,
             JinjaTokenNot, JinjaTokenAnd, JinjaTokenOr,
-            JinjaTokenFliter
+            JinjaTokenFliter, JinjaTokenNamespace
         };
 
         JinjaToKenType type;
@@ -96,7 +96,8 @@ namespace fastllm {
             {"false", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"and", JinjaToken::JinjaToKenType::JinjaTokenAnd},
             {"or", JinjaToken::JinjaToKenType::JinjaTokenOr},
-            {"not", JinjaToken::JinjaToKenType::JinjaTokenNot}
+            {"not", JinjaToken::JinjaToKenType::JinjaTokenNot},
+            {"namespace", JinjaToken::JinjaToKenType::JinjaTokenNamespace}
     };
 
     // 一个Jinja块 


### PR DESCRIPTION
* 根据Jinja模板引擎的文档，支持了“{%-”和“-%}”的去空白语义。
* Jinja模板引擎支持了namespace的创建和参数读取，因此可以支持Deepseek Coder V1的chat_template

## 测试情况

在以下模型测试过
* deepseek-ai/Deepseek-Coder-1.3B-Instruct
* deepseek-ai/Deepseek-Coder-6.7B-Instruct