### PR TITLE
C++支持直接读取Qwen2.5系列HF模型

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -67,6 +67,13 @@
 | Qwen/Qwen2-1.5B-Instruct | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
 | Qwen/Qwen2-7B-Instruct   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
 | Qwen/Qwen2-72B-Instruct  |  | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-0.5B-Instruct | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-1.5B-Instruct | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-3B-Instruct   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-7B-Instruct   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-14B-Instruct  | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen2.5-32B-Instruct  | √ | √ | ✔ |
+| Qwen/Qwen2.5-72B-Instruct  |  | √ | ✔ |
 
 > 注3： 需要更新，检查 `tokenizer_config.json` 是否为最新版本
 
@@ -241,7 +248,7 @@ python3 tools/qwen2flm.py qwen-7b-int8.flm int8 #导出int8模型
 python3 tools/qwen2flm.py qwen-7b-int4.flm int4 #导出int4模型
 ```
 
-* **Qwen1.5**
+* **Qwen1.5 / Qwen2 / Qwen2.5**
 
 ```sh
 # 需要先安装QWen2环境（transformers >= 4.37.0）

--- a/example/Win32Demo/Win32Demo.cpp
+++ b/example/Win32Demo/Win32Demo.cpp
@@ -133,7 +133,7 @@ int initLLMConf(RunConfig config) {
 		generationConfig->stop_token_ids.insert(model->weight.tokenizer.GetTokenId(it));
 	}
 	std::string systemConfig = config.systemPrompt;
-	messages = new fastllm::ChatMessages({{"system", systemConfig}});
+	messages = systemConfig.empty() ? new fastllm::ChatMessages() : new fastllm::ChatMessages({{"system", systemConfig}});
 
 	modelType = model->model_type;
 	runType = config.webuiType ? RUN_TYPE_WEBUI : RUN_TYPE_CONSOLE;

--- a/example/webui/webui.cpp
+++ b/example/webui/webui.cpp
@@ -149,7 +149,8 @@ int main(int argc, char** argv) {
         locker.lock();
         if (sessions.find(uuid) == sessions.end()) {
             sessions[uuid] = new ChatSession();
-            sessions[uuid]->messages.push_back({"system", config.systemPrompt});
+            if (!config.systemPrompt.empty())
+                sessions[uuid]->messages.push_back({"system", config.systemPrompt});
         }
         auto *session = sessions[uuid];
         locker.unlock();

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -1143,6 +1143,7 @@ printf("len = %d, spend = %f s. tokens / s = %f\n", (int)total, spend, (float)to
             });
         }
         ret["add_generation_prompt"] = fastllm::JinjaVar{1};
+        ret["tools"] = fastllm::JinjaVar{std::vector <JinjaVar>()};
         return ret;
     }
 


### PR DESCRIPTION
* 修复Jinja模板引擎处理转义字符的错误，忽略模板中工具调用的部分
* Jinja模板引擎支持了not语义以及多个括号，因此可以支持Qwen2.5的chat_template

## 测试情况

在以下模型测试过
*  Qwen/Qwen2.5-1.5B-Instruct
*  Qwen/Qwen2.5-Coder-7B-Instruct