### PR TITLE
C++支持直接读取Qwen一代、codellama系列HF模型，支持转换MiniCPM3

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -99,8 +99,8 @@
 |-----------------: |------------|------------|------------|
 | meta-llama/Llama-2-7b-chat-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) |  |
 | meta-llama/Llama-2-13b-chat-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) |  |
-| codellama/CodeLlama-7b-Instruct-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) |  |
-| codellama/CodeLlama-13b-Instruct-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) |  |
+| codellama/CodeLlama-7b-Instruct-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) | ✔ |
+| codellama/CodeLlama-13b-Instruct-hf | [✔](llama_cookbook.md#llama2-chat) | [✔](llama_cookbook.md#llama2-chat) | ✔ |
 | xverse/XVERSE-13B-Chat | [✔](llama_cookbook.md#xverse) | [✔](llama_cookbook.md#xverse) |  |
 | xverse/XVERSE-7B-Chat | [✔](llama_cookbook.md#xverse) | [✔](llama_cookbook.md#xverse) |  |
 |  |  |  |  |

--- a/docs/models.md
+++ b/docs/models.md
@@ -130,6 +130,9 @@
 |  |  |  |  |
 | openbmb/MiniCPM-2B-sft-fp16 | [✔](#其它模型) | [✔](#minicpm模型导出) |  |
 | openbmb/MiniCPM-2B-dpo-fp16 | [✔](#其它模型) | [✔](#minicpm模型导出) |  |
+| openbmb/MiniCPM3-4B | [✔](#其它模型) | [✔](#minicpm模型导出) |  |
+|  |  |  |  |
+| microsoft/Phi-3-mini-4k-instruct |  |  | ✔ |
 
 
 ### 加载后转换（两行加速模式）(convert on-the-fly)
@@ -265,6 +268,7 @@ python3 tools/llamalike2flm.py qwen1.5-7b-int4.flm int4 "qwen/Qwen1.5-14B-Chat" 
 # 需要先安装MiniCPM环境（transformers >= 4.36.0） 
 # 默认脚本导出iniCPM-2B-dpo-fp16模型
 cd build 
-python tools/minicpm2flm.py minicpm-2b-float16.flm #导出dpo-float16模型
+python tools/minicpm2flm.py minicpm-2b-fp16.flm #导出dpo-float16模型
+python tools/minicpm2flm.py minicpm3-4b-fp16.flm openbmb/MiniCPM3-4B #导出minicpm3-float16模型
 ./main -p minicpm-2b-float16.flm # 执行模型
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -50,10 +50,10 @@
 
 |              模型  | 加载后转换 |  离线转换  |  直接读取  |
 |-------------------: |------------|------------|------------|
-| Qwen/Qwen-7B-Chat   | [✔](#其它模型) | [✔](#qwen模型导出) |  |
-| Qwen/Qwen-14B-Chat  | [✔](#其它模型) | [✔](#qwen模型导出) |  |
-| Qwen/Qwen-72B-Chat  | [✔](#其它模型) | [✔](#qwen模型导出) |  |
-| Qwen/Qwen-1_8B-Chat | [✔](#其它模型) | [✔](#qwen模型导出) |  |
+| Qwen/Qwen-7B-Chat   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen-14B-Chat  | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
+| Qwen/Qwen-72B-Chat  | [✔](#其它模型) | [✔](#qwen模型导出) | √ |
+| Qwen/Qwen-1_8B-Chat | [✔](#其它模型) | [✔](#qwen模型导出) | ✔ |
 | Qwen/Qwen1.5-0.5B-Chat | [✔](#其它模型) | [✔](#qwen模型导出) | ✔<sup>3</sup> |
 | Qwen/Qwen1.5-1.8B-Chat | [✔](#其它模型) | [✔](#qwen模型导出) | ✔<sup>3</sup> |
 | Qwen/Qwen1.5-4B-Chat   | [✔](#其它模型) | [✔](#qwen模型导出) | ✔<sup>3</sup> |

--- a/example/Android/LLMAssistant/app/src/main/cpp/CMakeLists.txt
+++ b/example/Android/LLMAssistant/app/src/main/cpp/CMakeLists.txt
@@ -33,17 +33,23 @@ set(PROJECT_SOURCE
         ../../../../../../../src/template.cpp
         ../../../../../../../src/devices/cpu/cpudevice.cpp
         ../../../../../../../src/devices/cpu/cpudevicebatch.cpp
+        ../../../../../../../src/devices/cpu/linear.cpp
         ../../../../../../../src/models/basellm.cpp
         ../../../../../../../src/models/bert.cpp
         ../../../../../../../src/models/chatglm.cpp
+        ../../../../../../../src/models/cogvlm.cpp
         ../../../../../../../src/models/deepseekv2.cpp
-        ../../../../../../../src/models/moss.cpp
-        ../../../../../../../src/models/llama.cpp
-        ../../../../../../../src/models/qwen.cpp
         ../../../../../../../src/models/glm.cpp
+        ../../../../../../../src/models/graphllm.cpp
+        ../../../../../../../src/models/llama.cpp
         ../../../../../../../src/models/internlm2.cpp
         ../../../../../../../src/models/minicpm.cpp
+        ../../../../../../../src/models/minicpm3.cpp
         ../../../../../../../src/models/moe.cpp
+        ../../../../../../../src/models/moss.cpp
+        ../../../../../../../src/models/phi3.cpp
+        ../../../../../../../src/models/qwen.cpp
+        ../../../../../../../src/models/xlmroberta.cpp
         )
 
 include_directories(

--- a/example/Win32Demo/fastllm-gpu.vcxproj
+++ b/example/Win32Demo/fastllm-gpu.vcxproj
@@ -196,9 +196,11 @@
   <ItemGroup>
     <ClInclude Include="..\..\include\device.h" />
     <ClInclude Include="..\..\include\devices\cpu\alivethreadpool.h" />
+    <ClInclude Include="..\..\include\devices\cpu\computeutils.h" />
     <ClInclude Include="..\..\include\devices\cpu\cpudevice.h" />
     <ClInclude Include="..\..\include\devices\cpu\cputhreadpool.h" />
     <ClInclude Include="..\..\include\devices\cuda\cudadevice.h" />
+    <ClInclude Include="..\..\include\devices\multicuda\multicudadevice.h" />
     <ClInclude Include="..\..\include\executor.h" />
     <ClInclude Include="..\..\include\fastllm.h" />
     <ClInclude Include="..\..\include\graph.h" />
@@ -206,6 +208,7 @@
     <ClInclude Include="..\..\include\models\basellm.h" />
     <ClInclude Include="..\..\include\models\bert.h" />
     <ClInclude Include="..\..\include\models\chatglm.h" />
+    <ClInclude Include="..\..\include\models\cogvlm.h" />
     <ClInclude Include="..\..\include\models\deepseekv2.h" />
     <ClInclude Include="..\..\include\models\factoryllm.h" />
     <ClInclude Include="..\..\include\models\glm.h" />
@@ -213,9 +216,12 @@
     <ClInclude Include="..\..\include\models\internlm2.h" />
     <ClInclude Include="..\..\include\models\llama.h" />
     <ClInclude Include="..\..\include\models\minicpm.h" />
+    <ClInclude Include="..\..\include\models\minicpm3.h" />
     <ClInclude Include="..\..\include\models\moe.h" />
     <ClInclude Include="..\..\include\models\moss.h" />
+    <ClInclude Include="..\..\include\models\phi3.h" />
     <ClInclude Include="..\..\include\models\qwen.h" />
+    <ClInclude Include="..\..\include\models\xlmroberta.h" />
     <ClInclude Include="..\..\include\template.h" />
     <ClInclude Include="..\..\include\utils\armMath.h" />
     <ClInclude Include="..\..\include\utils\utils.h" />
@@ -225,8 +231,10 @@
     <ClCompile Include="..\..\src\device.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\linear.cpp" />
     <ClCompile Include="..\..\src\devices\cuda\cudadevice.cpp" />
     <ClCompile Include="..\..\src\devices\cuda\cudadevicebatch.cpp" />
+    <ClCompile Include="..\..\src\devices\multicuda\multicudadevice.cpp" />
     <ClCompile Include="..\..\src\executor.cpp" />
     <ClCompile Include="..\..\src\fastllm.cpp" />
     <ClCompile Include="..\..\src\graph.cpp" />
@@ -234,18 +242,23 @@
     <ClCompile Include="..\..\src\models\basellm.cpp" />
     <ClCompile Include="..\..\src\models\bert.cpp" />
     <ClCompile Include="..\..\src\models\chatglm.cpp" />
+    <ClCompile Include="..\..\src\models\cogvlm.cpp" />
     <ClCompile Include="..\..\src\models\deepseekv2.cpp" />
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
+    <ClCompile Include="..\..\src\models\graph\phi3.cpp" />
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
     <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
     <ClCompile Include="..\..\src\models\llama.cpp" />
     <ClCompile Include="..\..\src\models\minicpm.cpp" />
+    <ClCompile Include="..\..\src\models\minicpm3.cpp" />
     <ClCompile Include="..\..\src\models\moe.cpp" />
     <ClCompile Include="..\..\src\models\moss.cpp" />
+    <ClCompile Include="..\..\src\models\phi3.cpp" />
     <ClCompile Include="..\..\src\models\qwen.cpp" />
+    <ClCompile Include="..\..\src\models\xlmroberta.cpp" />
     <ClCompile Include="..\..\src\template.cpp" />
     <ClCompile Include="..\..\third_party\json11\json11.cpp" />
   </ItemGroup>
@@ -253,7 +266,13 @@
     <ClInclude Include="..\..\include\devices\cuda\fastllm-cuda.cuh">
       <FileType>Document</FileType>
     </ClInclude>
+    <ClInclude Include="..\..\include\devices\multicuda\fastllm-multicuda.cuh">
+      <FileType>Document</FileType>
+    </ClInclude>
     <CudaCompile Include="..\..\src\devices\cuda\fastllm-cuda.cu">
+      <FileType>Document</FileType>
+    </CudaCompile>
+    <CudaCompile Include="..\..\src\devices\multicuda\fastllm-multicuda.cu">
       <FileType>Document</FileType>
     </CudaCompile>
   </ItemGroup>

--- a/example/Win32Demo/fastllm-gpu.vcxproj.filters
+++ b/example/Win32Demo/fastllm-gpu.vcxproj.filters
@@ -49,6 +49,12 @@
     <Filter Include="源文件\third_party">
       <UniqueIdentifier>{385ba64f-d978-469c-af0c-498ec33a1bb7}</UniqueIdentifier>
     </Filter>
+    <Filter Include="头文件\devices\multicuda">
+      <UniqueIdentifier>{917a368b-3a0e-476b-9f35-6af4433aca16}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="源文件\devices\multicuda">
+      <UniqueIdentifier>{9fbf8989-df11-4dc7-9697-d69d10b7f0bf}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\device.h">
@@ -78,6 +84,9 @@
     <ClInclude Include="..\..\include\models\chatglm.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\cogvlm.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\deepseekv2.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
@@ -99,19 +108,31 @@
     <ClInclude Include="..\..\include\models\minicpm.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\minicpm3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\moe.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\models\moss.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\phi3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\qwen.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\devices\cpu\cpudevice.h">
-      <Filter>头文件\devices\cpu</Filter>
+    <ClInclude Include="..\..\include\models\xlmroberta.h">
+      <Filter>头文件\models</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\devices\cpu\alivethreadpool.h">
+      <Filter>头文件\devices\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\devices\cpu\computeutils.h">
+      <Filter>头文件\devices\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\devices\cpu\cpudevice.h">
       <Filter>头文件\devices\cpu</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\devices\cpu\cputhreadpool.h">
@@ -128,6 +149,12 @@
     </ClInclude>
     <ClInclude Include="..\..\include\devices\cuda\fastllm-cuda.cuh">
       <Filter>头文件\devices\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\devices\multicuda\multicudadevice.h">
+      <Filter>头文件\devices\multicuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\devices\multicuda\fastllm-multicuda.cuh">
+      <Filter>头文件\devices\multicuda</Filter>
     </ClInclude>
     <ClInclude Include="..\..\third_party\json11\json11.hpp">
       <Filter>头文件\third_party</Filter>
@@ -161,6 +188,9 @@
     <ClCompile Include="..\..\src\models\chatglm.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\cogvlm.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\deepseekv2.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
@@ -179,16 +209,28 @@
     <ClCompile Include="..\..\src\models\minicpm.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\minicpm3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\moe.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\moss.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\phi3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\xlmroberta.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\phi3.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp">
@@ -203,11 +245,17 @@
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp">
       <Filter>源文件\devices\cpu</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\linear.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\devices\cuda\cudadevice.cpp">
       <Filter>源文件\devices\cuda</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\devices\cuda\cudadevicebatch.cpp">
       <Filter>源文件\devices\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\devices\multicuda\multicudadevice.cpp">
+      <Filter>源文件\devices\multicuda</Filter>
     </ClCompile>
     <ClCompile Include="..\..\third_party\json11\json11.cpp">
       <Filter>源文件\third_party</Filter>
@@ -216,6 +264,9 @@
   <ItemGroup>
     <CudaCompile Include="..\..\src\devices\cuda\fastllm-cuda.cu">
       <Filter>源文件\devices\cuda</Filter>
+    </CudaCompile>
+    <CudaCompile Include="..\..\src\devices\multicuda\fastllm-multicuda.cu">
+      <Filter>源文件\devices\multicuda</Filter>
     </CudaCompile>
   </ItemGroup>
 </Project>

--- a/example/Win32Demo/fastllm.vcxproj
+++ b/example/Win32Demo/fastllm.vcxproj
@@ -173,6 +173,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\include\device.h" />
     <ClInclude Include="..\..\include\devices\cpu\alivethreadpool.h" />
+    <ClInclude Include="..\..\include\devices\cpu\computeutils.h" />
     <ClInclude Include="..\..\include\devices\cpu\cpudevice.h" />
     <ClInclude Include="..\..\include\devices\cpu\cputhreadpool.h" />
     <ClInclude Include="..\..\include\executor.h" />
@@ -182,6 +183,7 @@
     <ClInclude Include="..\..\include\models\basellm.h" />
     <ClInclude Include="..\..\include\models\bert.h" />
     <ClInclude Include="..\..\include\models\chatglm.h" />
+    <ClInclude Include="..\..\include\models\cogvlm.h" />
     <ClInclude Include="..\..\include\models\deepseekv2.h" />
     <ClInclude Include="..\..\include\models\factoryllm.h" />
     <ClInclude Include="..\..\include\models\glm.h" />
@@ -189,9 +191,12 @@
     <ClInclude Include="..\..\include\models\internlm2.h" />
     <ClInclude Include="..\..\include\models\llama.h" />
     <ClInclude Include="..\..\include\models\minicpm.h" />
+    <ClInclude Include="..\..\include\models\minicpm3.h" />
     <ClInclude Include="..\..\include\models\moe.h" />
     <ClInclude Include="..\..\include\models\moss.h" />
+    <ClInclude Include="..\..\include\models\phi3.h" />
     <ClInclude Include="..\..\include\models\qwen.h" />
+    <ClInclude Include="..\..\include\models\xlmroberta.h" />
     <ClInclude Include="..\..\include\template.h" />
     <ClInclude Include="..\..\include\utils\armMath.h" />
     <ClInclude Include="..\..\include\utils\utils.h" />
@@ -201,6 +206,7 @@
     <ClCompile Include="..\..\src\device.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\linear.cpp" />
     <ClCompile Include="..\..\src\executor.cpp" />
     <ClCompile Include="..\..\src\fastllm.cpp" />
     <ClCompile Include="..\..\src\graph.cpp" />
@@ -208,18 +214,23 @@
     <ClCompile Include="..\..\src\models\basellm.cpp" />
     <ClCompile Include="..\..\src\models\bert.cpp" />
     <ClCompile Include="..\..\src\models\chatglm.cpp" />
+    <ClCompile Include="..\..\src\models\cogvlm.cpp" />
     <ClCompile Include="..\..\src\models\deepseekv2.cpp" />
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
+    <ClCompile Include="..\..\src\models\graph\phi3.cpp" />
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
     <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
     <ClCompile Include="..\..\src\models\llama.cpp" />
     <ClCompile Include="..\..\src\models\minicpm.cpp" />
+    <ClCompile Include="..\..\src\models\minicpm3.cpp" />
     <ClCompile Include="..\..\src\models\moe.cpp" />
     <ClCompile Include="..\..\src\models\moss.cpp" />
+    <ClCompile Include="..\..\src\models\phi3.cpp" />
     <ClCompile Include="..\..\src\models\qwen.cpp" />
+    <ClCompile Include="..\..\src\models\xlmroberta.cpp" />
     <ClCompile Include="..\..\src\template.cpp" />
     <ClCompile Include="..\..\third_party\json11\json11.cpp" />
   </ItemGroup>

--- a/example/Win32Demo/fastllm.vcxproj.filters
+++ b/example/Win32Demo/fastllm.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="..\..\include\models\chatglm.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\cogvlm.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\deepseekv2.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
@@ -99,13 +102,22 @@
     <ClInclude Include="..\..\include\models\minicpm.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\minicpm3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\moe.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\models\moss.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\phi3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\qwen.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\models\xlmroberta.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\devices\cpu\cpudevice.h">
@@ -155,6 +167,9 @@
     <ClCompile Include="..\..\src\models\chatglm.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\cogvlm.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\deepseekv2.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
@@ -173,16 +188,28 @@
     <ClCompile Include="..\..\src\models\minicpm.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\minicpm3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\moe.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\moss.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\phi3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\xlmroberta.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
+      <Filter>源文件\models\graph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\graph\phi3.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp">

--- a/include/template.h
+++ b/include/template.h
@@ -53,9 +53,9 @@ namespace fastllm {
             JinjaTokenLMB, JinjaTokenRMB, JinjaTokenLSB, JinjaTokenRSB,
             JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenElseIf, JinjaTokenEndif,
             JinjaTokenIn,
-            JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv,
+            JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv, JinjaTokenMod,
             JinjaTokenNot, JinjaTokenAnd, JinjaTokenOr,
-            JinjaTokenFliter, JinjaTokenNamespace
+            JinjaTokenFilter, JinjaTokenNamespace, JinjaTokenSlice
         };
 
         JinjaToKenType type;
@@ -74,7 +74,9 @@ namespace fastllm {
             {'-', JinjaToken::JinjaToKenType::JinjaTokenSub},
             {'*', JinjaToken::JinjaToKenType::JinjaTokenMul},
             {'/', JinjaToken::JinjaToKenType::JinjaTokenDiv},
-            {'|', JinjaToken::JinjaToKenType::JinjaTokenFliter}
+            {'%', JinjaToken::JinjaToKenType::JinjaTokenMod},
+            {'|', JinjaToken::JinjaToKenType::JinjaTokenFilter},
+            {':', JinjaToken::JinjaToKenType::JinjaTokenSlice}
     };
 
     static std::map <char, char> escapeChars = {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -479,10 +479,13 @@ namespace fastllm {
         if (tokenizerClass == "PreTrainedTokenizerFast" || tokenizerClass == "LlamaTokenizerFast"
             || tokenizerClass == "Qwen2Tokenizer"
             || tokenizerClass == "BloomTokenizer"
-            || tokenizerClass == "LlamaTokenizer"
+            || tokenizerClass == "LlamaTokenizer" || tokenizerClass == "CodeLlamaTokenizer"
             || tokenizerClass == "MiniCPMTokenizer") {
             // PreTrainedTokenizerFast
             std::string tokenizerFile = path + "tokenizer.json";
+            if (!fastllm::FileExists(tokenizerFile)) {
+                ErrorInFastLLM("Model with a supported tokenizer_class: " + tokenizerClass + "，but has no \"tokenizer.json\"!");
+            }
             auto tokenizer = json11::Json::parse(ReadAllFile(tokenizerFile), error);
             for (auto &it : tokenizer["model"]["vocab"].object_items()) {
                 model->weight.AddTokenizerWord(it.first, it.second.int_value(), 1.0f);

--- a/src/models/minicpm3.cpp
+++ b/src/models/minicpm3.cpp
@@ -80,6 +80,8 @@ namespace fastllm {
         if (this->weight.dicts.find("kv_lora_rank") != this->weight.dicts.end()) {
             this->kv_lora_rank = std::stoi(this->weight.dicts["kv_lora_rank"]);
         }
+        weight.tokenizer.SetSpecialTokens({{"<s>", 2}, {"<s>", 1}, {"<unk>", 0}, {"<|im_start|>", 73441}, {"<|im_end|>", 73440}, {"<|tool_call|>", 73442}, 
+                                          {"<|execute_start|>", 73443}, {"<|execute_end|>", 73444}, {"<|fim_prefix|>", 73445}, {"<|fim_middle|>", 73446}, {"<|fim_suffix|>", 73447}});
     }
 
     int MiniCpm3Model::Forward(const fastllm::Data &inputIds, const fastllm::Data &attentionMask,

--- a/src/models/qwen.cpp
+++ b/src/models/qwen.cpp
@@ -56,6 +56,11 @@ namespace fastllm {
         }
 
         weight.embeddingNames.insert("transformer.wte.weight");
+        weight.linearNames = {
+            "lm_head.weight", "transformer.h.*.ln_1.weight", "transformer.h.*.attn.c_attn.weight",
+            "transformer.h.*.attn.c_proj.weight", "transformer.h.*.ln_2.weight",
+            "transformer.h.*.mlp.w1.weight", "transformer.h.*.mlp.w2.weight", "transformer.h.*.mlp.c_proj.weight"
+        };
     }
 
     int QWenModel::Forward(const Data &inputIds,

--- a/src/models/qwen.cpp
+++ b/src/models/qwen.cpp
@@ -171,12 +171,13 @@ namespace fastllm {
 
             // Attention
             MatMulTransB(query, pastKey, attnWeights, 1.0 / sqrt(head_dim));
-            attnWeights.Reshape({1, attnWeights.dims[0], attnWeights.dims[1], attnWeights.dims[2]});
+            attnWeights.Reshape({batch, -1, attnWeights.dims[1], attnWeights.dims[2]});
             if (!attentionMask.dims.empty()) {
                 AttentionMask(attnWeights, attentionMask, -10000);
             }
 
             Softmax(attnWeights, attnWeights, -1);
+            attnWeights.Reshape({1, -1, attnWeights.dims[2], attnWeights.dims[3]});
             MatMul(attnWeights, pastValue, attnOutput);
 
             attnOutput.Reshape({attnOutput.dims[1], attnOutput.dims[2], attnOutput.dims[3]});
@@ -465,45 +466,68 @@ namespace fastllm {
                                        Data &inputIds, Data &attentionMask, Data &positionIds) {
         int batch = inputTokens.size();
         int index = params[0].find("index")->second;
-        int promptLen = params[0].find("promptLen")->second;
 
         inputIds.ToDevice(DataDevice::CPU);
         attentionMask.ToDevice(DataDevice::CPU);
         positionIds.ToDevice(DataDevice::CPU);
         
+        std::vector<int> seqLens;
+        seqLens.resize(batch);
+        int maxLen = 0;
+        for (int i = 0; i < batch; i++) {
+            int promptLen = params[i].find("promptLen")->second + index;
+            maxLen = std::max(promptLen, maxLen);
+            seqLens[i] = promptLen;
+        }
+
         if (index == 0) {
             int seqLen = inputTokens[0].size();
-            std::vector<float> ids = std::vector<float>(batch * seqLen, 0);
-            std::vector <float> vmask = std::vector <float> (batch * seqLen * seqLen, 0);
-            std::vector<float> vpids = std::vector<float>(batch * seqLen, 0);
-            for (int b = 0; b < batch; b++) {
-                for (int i = 0; i < seqLen; i++) {
-                    ids[b * seqLen + i] = inputTokens[b][i];
+            std::vector<float> ids = std::vector <float> (batch * maxLen, 0);
+            std::vector<float> vpids = std::vector <float> (batch * maxLen, 0);
+            std::vector<float> vmask = std::vector <float> (batch * maxLen * maxLen, 0);
+            for (int i = 0; i < batch; i++) {
+                auto &tokens = inputTokens[i];
+                int len = tokens.size(), base = maxLen - len;
+                for (int j = 0; j < len; j++) {
+                    ids[i * maxLen + base + j] = tokens[j];
+                }
+                for (int j = 0; j < len; j++) {
+                    vpids[i * maxLen + base + j] = j;
+                }
+
+                std::fill(vmask.data() + i * maxLen * maxLen,
+                          vmask.data() + i * maxLen * maxLen + (maxLen - len) * maxLen, 1.0);
+                for (int j = maxLen - len; j < maxLen; j++) {
+                    std::fill(vmask.data() + i * maxLen * maxLen + j * maxLen,
+                              vmask.data() + i * maxLen * maxLen + j * maxLen + maxLen - len, 1.0);
+                }
+                for (int j = 0; j < len; j++) {
+                    for (int k = j + 1; k < len; k++) {
+                        vmask[i * maxLen * maxLen + (base + j) * maxLen + base + k] = 1;
+                    }
                 }
             }
-            for (int i = 0; i < seqLen; i++) {
-                vpids[i] = i;
-                for (int j = i + 1; j < seqLen; j++) {
-                    vmask[i * seqLen + j] = 1;
-                }
-            }
-            for (int b = 1; b < batch; b++) {
-                memcpy(vmask.data() + b * seqLen * seqLen, vmask.data(), seqLen * seqLen * sizeof(float));
-                memcpy(vpids.data() + b * seqLen, vpids.data(), seqLen * sizeof(float));
-            }
-            inputIds.CopyFrom(Data(DataType::FLOAT32, {batch, seqLen}, ids));
-            attentionMask.CopyFrom(Data(DataType::FLOAT32, {batch, seqLen, seqLen}, vmask));
-            positionIds.CopyFrom(Data(DataType::FLOAT32, {batch, seqLen}, vpids));
+
+            inputIds.CopyFrom(Data(DataType::FLOAT32, {batch, maxLen}, ids));
+            attentionMask.CopyFrom(Data(DataType::FLOAT32, {batch, maxLen, maxLen}, vmask));
+            positionIds.CopyFrom(Data(DataType::FLOAT32, {batch, maxLen}, vpids));
         } else {
-            std::vector<float> ids = std::vector<float>(batch * 1, 0);
-            std::vector<float> vpids = std::vector<float>(batch * 1, 0);
-            for (int b = 0; b < batch; b++) {
-                ids[b] = inputTokens[b][0];
-                vpids[b] = (float) (promptLen + index - 1);
+            maxLen++;
+            std::vector<float> fret;
+            for (int i = 0; i < batch; i++) {
+                fret.push_back(inputTokens[i][0]);
             }
-            inputIds.CopyFrom(Data(DataType::FLOAT32, {batch, 1}, ids));
-            attentionMask.CopyFrom(Data());
-            positionIds.CopyFrom(Data(DataType::FLOAT32, {batch, 1}, vpids));
+            std::vector<float> pids = std::vector<float>(batch);
+            std::vector<float> vmasks = std::vector<float>(batch * maxLen, 0.0f);
+            for (int i = 0; i < batch; i++) {
+                pids[i] = seqLens[i] - 1;
+                for (int j = 0; j < maxLen - seqLens[i] - 1; j++) {
+                    vmasks[i * maxLen + j] = 1.0f;
+                }
+            }
+            inputIds.CopyFrom(Data(DataType::FLOAT32, {batch, 1}, fret));
+            attentionMask.CopyFrom(Data(DataType::FLOAT32, {batch, 1, maxLen}, vmasks));
+            positionIds.CopyFrom(Data(DataType::FLOAT32, {batch, 1}, pids));
         }
     }
 

--- a/tools/fastllm_pytools/hf_model.py
+++ b/tools/fastllm_pytools/hf_model.py
@@ -101,8 +101,8 @@ def create(model,
         modelInfo["tokenizer_class"] = tokenizer.name;
     if "rope_scaling" in modelInfo and isinstance(modelInfo["rope_scaling"], builtins.dict):
         rope_scaling = modelInfo.pop("rope_scaling")
-        modelInfo["rope_scaling.type"] = rope_scaling["type"]
-        modelInfo["rope_scaling.factor"] = rope_scaling["factor"]
+        for key, value in rope_scaling.items():
+            modelInfo["rope_scaling." + key] = value
     if eos_id:
         modelInfo["eos_token_id"] = str(eos_id)
 

--- a/tools/fastllm_pytools/torch2flm.py
+++ b/tools/fastllm_pytools/torch2flm.py
@@ -186,8 +186,8 @@ def tofile(exportPath,
         modelInfo["tokenizer_class"] = tokenizer.name;
     if "rope_scaling" in modelInfo and isinstance(modelInfo["rope_scaling"], builtins.dict):
         rope_scaling = modelInfo.pop("rope_scaling")
-        modelInfo["rope_scaling.type"] = rope_scaling["type"]
-        modelInfo["rope_scaling.factor"] = rope_scaling["factor"]
+        for key, value in rope_scaling.items():
+            modelInfo["rope_scaling." + key] = value
     if eos_id:
         modelInfo["eos_token_id"] = str(eos_id)
 

--- a/tools/scripts/chatglm_export.py
+++ b/tools/scripts/chatglm_export.py
@@ -3,8 +3,9 @@ from transformers import AutoTokenizer, AutoModel
 from ftllm import torch2flm
 
 if __name__ == "__main__":
-    tokenizer = AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True)
-    model = AutoModel.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True)
+    modelNameOrPath = sys.argv[3] if len(sys.argv) >= 4 else 'THUDM/chatglm2-6b'
+    tokenizer = AutoTokenizer.from_pretrained(modelNameOrPath, trust_remote_code=True)
+    model = AutoModel.from_pretrained(modelNameOrPath, trust_remote_code=True)
     model = model.eval()
 
     dtype = sys.argv[2] if len(sys.argv) >= 3 else "float16"

--- a/tools/scripts/minicpm2flm.py
+++ b/tools/scripts/minicpm2flm.py
@@ -10,10 +10,13 @@ if __name__ == "__main__":
     model = AutoModelForCausalLM.from_pretrained(modelNameOrPath, trust_remote_code=True, torch_dtype=torch.float16)
     model = model.eval()
 
-    model.config.__dict__['model_type'] = 'minicpm'
-
     dtype = sys.argv[2] if len(sys.argv) >= 3 else "float16"
     exportPath = sys.argv[1] if len(sys.argv) >= 2 else "minicpm-2b-" + dtype + ".flm"
-    torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<s>", 
-                     user_role = "<用户>", bot_role = "<AI>", 
-                     history_sep = "", dtype = dtype)
+
+    if model.config.architectures == ["MiniCPMForCausalLM"]:
+        model.config.model_type = "minicpm"
+        torch2flm.tofile(exportPath, model, tokenizer, pre_prompt = "<s>", user_role = "<用户>",
+                         bot_role = "<AI>", history_sep = "", dtype = dtype)
+    else:
+        torch2flm.tofile(exportPath, model, tokenizer, pre_prompt="", user_role="<|im_start|>user\n",
+                         bot_role="<|im_end|>\n<|im_start|>assistant\n", history_sep="<|im_end|>\n", eos_id = tokenizer.eos_token_id, dtype = dtype)


### PR DESCRIPTION
* 修复 #496 增加Jinja2 `not`运算符之后，导致 Deepseek Coder V1 模板解析异常的问题；
* 支持直接读取Qwen一代模型 `.safetensors` 版本；
* 改进Qwen一代批量推理，改为前向padding，目前batch内部顺序变换输出不一致的问题（#429）显著减少；
* Jinja2模板支持取模运算`%`和数组切片运算符`[:]`，因此支持了 codellama-7b-instruct的HF模型；
* 修改脚本，支持 MiniCPM3-4B 的转换（该模型未提供`.safetensors` 版本）；
* 更新Win32Demo工程以反映项目最新变化；
* 更新文档

## 测试情况

在以下模型测试过
* deepseek-ai/Deepseek-Coder-1.3B-Instruct
* openbmb/MiniCPM3-4B
* Qwen/Qwen-1.8b-Chat
* codellama/codellama-7b-instruct
* Qwen/Qwen2.5-Coder-7B-Instruct
* microsoft/Phi-3-mini-4k-instruct

## TODO
支持 MiniCPM3-4B 和 phi-3.5 的 longRoPE 外推，Qwen2的yarn外推