### PR TITLE
修复Qwen各代存在的C++对话Bug

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -10,7 +10,7 @@
 * **离线转换** (convert offline)  
     将原始模型转换为.flm格式的模型，一些[模型](#flm模型库)已经转换好。
 
-* **加载后转换（不推荐）**
+* **加载后转换（不推荐）**  (convert on-the-fly (NOT RECOMMENDED)) 
     将原始模型加载为HuggingFace模型，再通过`from_hf()`方法，转换并加速，这种方法内存占用大且速度慢，目前不再推荐。
 
 ## 支持模型一览 Model List
@@ -74,7 +74,7 @@
 | Qwen/Qwen2.5-32B-Instruct  | √ | √ | ✔ |
 | Qwen/Qwen2.5-72B-Instruct  |  | √ | ✔ |
 
-> 注3： 需要更新，检查 `tokenizer_config.json` 是否为最新版本
+> 注3： ~~需要更新，检查 `tokenizer_config.json` 是否为最新版本~~
 
 ### DeepSeek系列
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -539,8 +539,8 @@ namespace fastllm {
             }
             model->weight.tokenizer.type = Tokenizer::TokenizerType::QWEN;
             model->weight.tokenizer.chatTemplate = "";
-            model->weight.dicts["im_end_id"] = std::to_string(lines.size() + 1);
-            model->weight.dicts["im_start_id"] = std::to_string(lines.size() + 2);
+            model->weight.dicts["im_start_id"] = std::to_string(lines.size() + 1);
+            model->weight.dicts["im_end_id"] = std::to_string(lines.size() + 2);
         } else {
             ErrorInFastLLM("Unsupport tokenizer_class: " + tokenizerClass);
         }

--- a/src/models/qwen.cpp
+++ b/src/models/qwen.cpp
@@ -57,8 +57,7 @@ namespace fastllm {
 
         weight.embeddingNames.insert("transformer.wte.weight");
         weight.linearNames = {
-            "lm_head.weight", "transformer.h.*.ln_1.weight", "transformer.h.*.attn.c_attn.weight",
-            "transformer.h.*.attn.c_proj.weight", "transformer.h.*.ln_2.weight",
+            "lm_head.weight", "transformer.h.*.attn.c_attn.weight", "transformer.h.*.attn.c_proj.weight", 
             "transformer.h.*.mlp.w1.weight", "transformer.h.*.mlp.w2.weight", "transformer.h.*.mlp.c_proj.weight"
         };
     }


### PR DESCRIPTION
* 修复 #497 中Qwen一代加载safetensors德推理错误
* 修复Jinja elif的解析，解决 #496 中Qwen2.5 C++下多轮对话时模板报错
* 支持Jinja 模板中的负数下标，支持Qwen1.5最初版本的模板

## 测试情况

在以下模型测试过
* Qwen/Qwen-1.8b-Chat
* Qwen/Qwen1.5-0.5B-Chat
* Qwen/Qwen2-7B-Instruct
* Qwen/Qwen2.5-1.5B-Instruct