### PR TITLE
C++支持Deepseek R1蒸馏模型的模板解析和Tokenize

### DIFF
--- a/include/template.h
+++ b/include/template.h
@@ -76,6 +76,7 @@ namespace fastllm {
             {'/', JinjaToken::JinjaToKenType::JinjaTokenDiv},
             {'%', JinjaToken::JinjaToKenType::JinjaTokenMod},
             {'|', JinjaToken::JinjaToKenType::JinjaTokenFilter},
+            {',', JinjaToken::JinjaToKenType::JinjaTokenNamespace},
             {':', JinjaToken::JinjaToKenType::JinjaTokenSlice}
     };
 

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -477,8 +477,13 @@ __global__ void FastllmSiluKernel(float* a, float *b, int len) {
 __global__ void FastllmSiluKernel(half* a, half *b, int len) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     if (idx < len) {
+#ifdef CUDA_NO_TENSOR_CORE
+        float x = __half2float(a[idx]);
+        b[idx] = __float2half(x / (1.0 + expf(-x)));
+#else
         half x = a[idx];
         b[idx] = __hdiv(x, __hadd(__float2half(1.0), hexp(-x)));
+#endif
     }
 }
 

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1319,11 +1319,12 @@ namespace fastllm {
             specialRoot = new TrieNode();
         for (auto &it : specialTokenMap) {
             TrieNode *now = this->specialRoot;
-            for (int i = 0; i < it.first.size(); i++) {
-                if (now->next.find(it.first[i]) == now->next.end()) {
-                    now->next[it.first[i]] = new TrieNode();
+            std::string normalized = Normalize(it.first);
+            for (int i = 0; i < normalized.size(); i++) {
+                if (now->next.find(normalized[i]) == now->next.end()) {
+                    now->next[normalized[i]] = new TrieNode();
                 }
-                now = now->next[it.first[i]];
+                now = now->next[normalized[i]];
             }
             now->tokenId = it.second;
             now->score = 0.0f;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -554,7 +554,6 @@ namespace fastllm {
             for (auto &it : tokenizer["added_tokens"].array_items()) {
                 spTokens[it["content"].string_value()] = it["id"].int_value();
             }
-            model->weight.tokenizer.SetSpecialTokens(spTokens);
             if (!spTokens.empty())
                 model->weight.AddDict("tokenizer_has_special_tokens", "1");
 
@@ -563,6 +562,7 @@ namespace fastllm {
                 model->weight.tokenizer.byteAsChar = true;
                 model->weight.AddDict("tokenizer_byte_as_char", "True");
             }
+            model->weight.tokenizer.SetSpecialTokens(spTokens);
         } else if (tokenizerClass == "ChatGLM4Tokenizer") {
             // GLM4御用的分词
             std::vector <std::string> lines, line;


### PR DESCRIPTION
* 修复NVIDIA旧架构GPU编译报错
* Jinja2模板支持多个值的namespace，因此支持Deepseek R1 Distrill的模板；
* 修复C++ Tokenzier在ByteLevel模式下，special token没有转换的问题。

## 测试情况
在以下模型测试过
* deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B