### PR TITLE
修复DeepSeek-V2-Lite；C++支持Deepseek R1蒸馏模型的模板

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -31,7 +31,7 @@ jobs:
         mkdir build-x86
         cd build-x86
         cmake .. -DUSE_CUDA=OFF
-        make -j
+        make -j $(nproc)
         cp main fastllm-main-x86_64
         
     - name: Export and Upload Artifact

--- a/docs/models.md
+++ b/docs/models.md
@@ -209,7 +209,7 @@ new_model = llm.model("model.flm"); # 导入flm模型
 
 可以在以下链接中找到一部分已经转换好的模型
 
-[huggingface](https://huggingface.co/huangyuyang) [modelscope](https://modelscope.cn/profile/huangyuyang)
+[huggingface](https://huggingface.co/fastllm) [modelscope](https://modelscope.cn/profile/huangyuyang)
 
 ### 模型导出(convert offline)
 

--- a/example/Android/LLMAssistant/app/src/main/cpp/CMakeLists.txt
+++ b/example/Android/LLMAssistant/app/src/main/cpp/CMakeLists.txt
@@ -49,6 +49,8 @@ set(PROJECT_SOURCE
         ../../../../../../../src/models/moss.cpp
         ../../../../../../../src/models/phi3.cpp
         ../../../../../../../src/models/qwen.cpp
+        ../../../../../../../src/models/qwen3.cpp
+        ../../../../../../../src/models/qwen3_moe.cpp
         ../../../../../../../src/models/xlmroberta.cpp
         )
 

--- a/example/Win32Demo/fastllm-gpu.vcxproj
+++ b/example/Win32Demo/fastllm-gpu.vcxproj
@@ -221,6 +221,8 @@
     <ClInclude Include="..\..\include\models\moss.h" />
     <ClInclude Include="..\..\include\models\phi3.h" />
     <ClInclude Include="..\..\include\models\qwen.h" />
+    <ClInclude Include="..\..\include\models\qwen3.h" />
+    <ClInclude Include="..\..\include\models\qwen3_moe.h" />
     <ClInclude Include="..\..\include\models\xlmroberta.h" />
     <ClInclude Include="..\..\include\template.h" />
     <ClInclude Include="..\..\include\utils\armMath.h" />
@@ -247,7 +249,7 @@
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
-    <ClCompile Include="..\..\src\models\graph\phi3.cpp" />
+    <ClCompile Include="..\..\src\models\graph\gemma2.cpp" />
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
     <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
@@ -258,6 +260,8 @@
     <ClCompile Include="..\..\src\models\moss.cpp" />
     <ClCompile Include="..\..\src\models\phi3.cpp" />
     <ClCompile Include="..\..\src\models\qwen.cpp" />
+    <ClCompile Include="..\..\src\models\qwen3.cpp" />
+    <ClCompile Include="..\..\src\models\qwen3_moe.cpp" />
     <ClCompile Include="..\..\src\models\xlmroberta.cpp" />
     <ClCompile Include="..\..\src\template.cpp" />
     <ClCompile Include="..\..\third_party\json11\json11.cpp" />

--- a/example/Win32Demo/fastllm-gpu.vcxproj.filters
+++ b/example/Win32Demo/fastllm-gpu.vcxproj.filters
@@ -123,6 +123,12 @@
     <ClInclude Include="..\..\include\models\qwen.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\qwen3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\models\qwen3_moe.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\xlmroberta.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
@@ -224,13 +230,19 @@
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\qwen3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\qwen3_moe.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\xlmroberta.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\models\graph\phi3.cpp">
+    <ClCompile Include="..\..\src\models\graph\gemma2.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp">

--- a/example/Win32Demo/fastllm.vcxproj
+++ b/example/Win32Demo/fastllm.vcxproj
@@ -196,6 +196,8 @@
     <ClInclude Include="..\..\include\models\moss.h" />
     <ClInclude Include="..\..\include\models\phi3.h" />
     <ClInclude Include="..\..\include\models\qwen.h" />
+    <ClInclude Include="..\..\include\models\qwen3.h" />
+    <ClInclude Include="..\..\include\models\qwen3_moe.h" />
     <ClInclude Include="..\..\include\models\xlmroberta.h" />
     <ClInclude Include="..\..\include\template.h" />
     <ClInclude Include="..\..\include\utils\armMath.h" />
@@ -219,7 +221,7 @@
     <ClCompile Include="..\..\src\models\glm.cpp" />
     <ClCompile Include="..\..\src\models\graphllm.cpp" />
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp" />
-    <ClCompile Include="..\..\src\models\graph\phi3.cpp" />
+    <ClCompile Include="..\..\src\models\graph\gemma2.cpp" />
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp" />
     <ClCompile Include="..\..\src\models\graph\telechat.cpp" />
     <ClCompile Include="..\..\src\models\internlm2.cpp" />
@@ -230,6 +232,8 @@
     <ClCompile Include="..\..\src\models\moss.cpp" />
     <ClCompile Include="..\..\src\models\phi3.cpp" />
     <ClCompile Include="..\..\src\models\qwen.cpp" />
+    <ClCompile Include="..\..\src\models\qwen3.cpp" />
+    <ClCompile Include="..\..\src\models\qwen3_moe.cpp" />
     <ClCompile Include="..\..\src\models\xlmroberta.cpp" />
     <ClCompile Include="..\..\src\template.cpp" />
     <ClCompile Include="..\..\third_party\json11\json11.cpp" />

--- a/example/Win32Demo/fastllm.vcxproj.filters
+++ b/example/Win32Demo/fastllm.vcxproj.filters
@@ -117,6 +117,12 @@
     <ClInclude Include="..\..\include\models\qwen.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\models\qwen3.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\models\qwen3_moe.h">
+      <Filter>头文件\models</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\models\xlmroberta.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
@@ -203,13 +209,19 @@
     <ClCompile Include="..\..\src\models\qwen.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\qwen3.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\models\qwen3_moe.cpp">
+      <Filter>源文件\models</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\models\xlmroberta.cpp">
       <Filter>源文件\models</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\fastllmjson.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\models\graph\phi3.cpp">
+    <ClCompile Include="..\..\src\models\graph\gemma2.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\models\graph\qwen2.cpp">

--- a/include/device.h
+++ b/include/device.h
@@ -14,13 +14,13 @@ namespace fastllm {
 
     class BaseOperator {
     public:
-        // 是否可以运行某一个算子
+        // 是否可以运行某一个算子  
         virtual bool CanRun(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams);
 
         // 对某一个算子进行形状推理
         virtual void Reshape(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams);
 
-        // 对某一个算子进行推理
+        // 对某一个算子进行推理  
         virtual void Run(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams) = 0;
     };
 
@@ -33,8 +33,8 @@ namespace fastllm {
 
     class BaseDevice {
     public:
-        virtual bool Malloc (void **ret, size_t size) = 0; // 分配尺寸为size的空间
-        virtual bool Malloc (void **ret, Data &data); // 分配形状为dims的空间
+        virtual bool Malloc (void **ret, size_t size) = 0; // 分配尺寸为size的空间  
+        virtual bool Malloc (void **ret, Data &data); // 分配形状为dims的空间  
         virtual bool Free(void *ret) = 0; // 释放ret
 
         virtual bool CopyDataToCPU(void *dst, void *src, size_t size) = 0; // device上的src拷贝到cpu上的dst
@@ -43,13 +43,13 @@ namespace fastllm {
         virtual bool CopyDataFromCPU(void *dst, void *src, size_t size) = 0; // cpu上的src拷贝到device上的dst
         virtual bool CopyDataFromCPU(Data &data); // data数据从CPU移动到该device
 
-        // 是否可以运行某一个算子
+        // 是否可以运行某一个算子  
         virtual bool CanRun(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams);
 
         // 对某一个算子进行形状推理
         virtual void Reshape(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams);
 
-        // 对某一个算子进行推理
+        // 对某一个算子进行推理  
         virtual void Run(const std::string &opType, const DataDict &datas, const FloatDict &floatParams, const IntDict &intParams);
 
         std::string deviceType;

--- a/include/template.h
+++ b/include/template.h
@@ -6,6 +6,7 @@
 #define FASTLLM_TEMPLATE_H
 
 #include "utils/utils.h"
+#include <functional>
 
 namespace fastllm {
     struct JinjaVar {
@@ -49,7 +50,7 @@ namespace fastllm {
     // 词法分析后的Token
     struct JinjaToken {
         enum JinjaToKenType {
-            JinjaTokenID = 0, JinjaTokenBOOL, JinjaTokenNUM, JinjaTokenSTRING, JinjaTokenDOT,
+            JinjaTokenID = 0, JinjaTokenBOOL, JinjaTokenNUM, JinjaTokenSTRING, JinjaTokenFUNC, JinjaTokenDOT,
             JinjaTokenLMB, JinjaTokenRMB, JinjaTokenLSB, JinjaTokenRSB,
             JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenElseIf, JinjaTokenEndif,
             JinjaTokenIn,
@@ -133,6 +134,8 @@ namespace fastllm {
     JinjaVar JinjaTrim(const JinjaVar &a);
 
     int GetOpLevel(JinjaToken::JinjaToKenType type);
+
+    using JinjaFunction = std::function<JinjaVar(const JinjaVar &)>;
 
     // Jinja模板
     struct JinjaTemplate {

--- a/include/template.h
+++ b/include/template.h
@@ -76,6 +76,7 @@ namespace fastllm {
             {'/', JinjaToken::JinjaToKenType::JinjaTokenDiv},
             {'%', JinjaToken::JinjaToKenType::JinjaTokenMod},
             {'|', JinjaToken::JinjaToKenType::JinjaTokenFilter},
+            {',', JinjaToken::JinjaToKenType::JinjaTokenNamespace},
             {':', JinjaToken::JinjaToKenType::JinjaTokenSlice}
     };
 

--- a/include/template.h
+++ b/include/template.h
@@ -146,7 +146,7 @@ namespace fastllm {
 
         JinjaTemplate (const std::string &temp);
 
-        JinjaVar ComputeExpression(JinjaVar &local, std::vector <JinjaToken> tokens, int st, int end);
+        JinjaVar ComputeExpression(JinjaVar &local, std::vector <JinjaToken> tokens, int st, int end, JinjaVar *setValue = nullptr);
 
         void Parse(int st, int end, JinjaVar &var, std::string &ret);
 

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -3317,7 +3317,7 @@ void * FastllmCudaMalloc(size_t size) {
         if (cudaBuffers[i].size >= size && !cudaBuffers[i].busy) {
             cudaBuffers[i].busy = true;
             noBusyCnt[id] -= cudaBuffers[i].size;
-            while (cudaBuffers[cudaBuffersMinId[id]].busy) {
+            while (cudaBuffersMinId[id] < cudaBuffers.size() && cudaBuffers[cudaBuffersMinId[id]].busy) {
                 cudaBuffersMinId[id]++;
             }
             return cudaBuffers[i].data;

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1291,7 +1291,7 @@ namespace fastllm {
                     }
                     weightSum[gid] += sum0[0] + sum0[1] + sum0[2] + sum0[3];
 #endif
-#ifdef __AVX2__X
+#ifdef __AVX2__
                     __m256i acc = _mm256_setzero_si256();
                     const __m256i lowMask = _mm256_set1_epi8(0xf);
                     const __m256i ones = _mm256_set1_epi16(1);

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1647,11 +1647,12 @@ namespace fastllm {
             specialRoot = new TrieNode();
         for (auto &it : specialTokenMap) {
             TrieNode *now = this->specialRoot;
-            for (int i = 0; i < it.first.size(); i++) {
-                if (now->next.find(it.first[i]) == now->next.end()) {
-                    now->next[it.first[i]] = new TrieNode();
+            std::string normalized = Normalize(it.first);
+            for (int i = 0; i < normalized.size(); i++) {
+                if (now->next.find(normalized[i]) == now->next.end()) {
+                    now->next[normalized[i]] = new TrieNode();
                 }
-                now = now->next[it.first[i]];
+                now = now->next[normalized[i]];
             }
             now->tokenId = it.second;
             now->score = 0.0f;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1068,7 +1068,8 @@ namespace fastllm {
                                         tensor.buffer, tensor.minsBuffer, tensor.scalesBuffer,
                                         model->moeLinears.find(weightName) != model->moeLinears.end() ? moeGroupCnt : groupCnt);
                             }
-                            model->weight[weightName].CalcWeightSum();
+                            if (it.second == DATA_AUTO_LINEAR || it.second == DATA_AUTO_CONV)
+                                model->weight[weightName].CalcWeightSum();
                             tensor.ClearBuffer();
 
                             locker.lock();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -657,7 +657,6 @@ namespace fastllm {
             for (auto &it : tokenizer["added_tokens"].array_items()) {
                 spTokens[it["content"].string_value()] = it["id"].int_value();
             }
-            model->weight.tokenizer.SetSpecialTokens(spTokens);
             if (!spTokens.empty())
                 model->weight.AddDict("tokenizer_has_special_tokens", "1");
 
@@ -666,6 +665,7 @@ namespace fastllm {
                 model->weight.tokenizer.byteAsChar = true;
                 model->weight.AddDict("tokenizer_byte_as_char", "True");
             }
+            model->weight.tokenizer.SetSpecialTokens(spTokens);
         } else if (tokenizerClass == "ChatGLM4Tokenizer") {
             // GLM4御用的分词
             std::vector <std::string> lines, line;

--- a/src/models/graphllm.cpp
+++ b/src/models/graphllm.cpp
@@ -425,15 +425,19 @@ namespace fastllm {
     void GraphLLMModelConfig::InitParams(GraphLLMModel *model) {
     }
 
-    static std::map<std::string, GraphLLMModelConfigCreator> graphLLMModelConfigFactoryCreator;
+    static std::map<std::string, GraphLLMModelConfigCreator> *graphLLMModelConfigFactoryCreator = nullptr;
 
     void GraphLLMModelConfigFactory::RegisterGraphLLMModelConfig(const std::string& type, GraphLLMModelConfigCreator creator) {
-        graphLLMModelConfigFactoryCreator[type] = creator;
+        if (graphLLMModelConfigFactoryCreator == nullptr)
+            graphLLMModelConfigFactoryCreator = new std::map<std::string, GraphLLMModelConfigCreator>();
+        (*graphLLMModelConfigFactoryCreator)[type] = creator;
     }
 
     GraphLLMModelConfig* GraphLLMModelConfigFactory::CreateGraphLLMModelConfig(const std::string& type) {
-        auto it = graphLLMModelConfigFactoryCreator.find(type);
-        if (it != graphLLMModelConfigFactoryCreator.end()) {
+        if (graphLLMModelConfigFactoryCreator == nullptr)
+            return nullptr;
+        auto it = graphLLMModelConfigFactoryCreator->find(type);
+        if (it != graphLLMModelConfigFactoryCreator->end()) {
             return it->second();
         } else {
             return nullptr;

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -393,7 +393,7 @@ namespace fastllm {
                 }
                 AssertInFastLLM(ops.size() > 0 && ops.back().type == JinjaToken::JinjaTokenLSB, "Error: barckets doesn't match.");
                 ops.pop_back();
-                if (ops.back().type == JinjaToken::JinjaTokenFUNC) {
+                if (ops.size() > 0 && ops.back().type == JinjaToken::JinjaTokenFUNC) {
                     suffixExp.push_back(ops.back());
                     ops.pop_back();
                 }

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -157,6 +157,10 @@ namespace fastllm {
                         }
                         AssertInFastLLM(ok, "Jinja error: parse string failed: " + value.substr(st, std::min(10, (int)value.size() - st)));
                     } else if (singleCharTokens.find(now) != singleCharTokens.end()) {
+                        if (singleCharTokens[now] == JinjaToken::JinjaTokenLSB && !tokens.empty()) {
+                            if (tokens.back().type == JinjaToken::JinjaTokenID)
+                                tokens.back().type = JinjaToken::JinjaTokenFUNC;
+                        }
                         tokens.push_back(JinjaToken(singleCharTokens[now]));
                         st++;
                         continue;
@@ -232,10 +236,22 @@ namespace fastllm {
                 return a.intValue % b.intValue;
             }
         } else if (op == JinjaToken::JinjaTokenIn) {
-            return b.dictValue.find(a.stringValue) != b.dictValue.end();
+            if (b.type == JinjaVar::JinjaDict) {
+                return b.dictValue.find(a.stringValue) != b.dictValue.end();
+            } else if (a.type == JinjaVar::JinjaString && b.type == JinjaVar::JinjaString) {
+                return b.stringValue.find(a.stringValue) != std::string::npos;
+            } else if (b.type == JinjaVar::JinjaNone) {
+                return a.type == JinjaVar::JinjaNone;
+            }
         } else if (op == JinjaToken::JinjaTokenEqual) {
+            if (a.type != JinjaVar::JinjaNone && b.type == JinjaVar::JinjaNone && b.stringValue == "defined") {
+                return true;
+            }
             if (a.type != b.type) {
                 return false;
+            }
+            if (a.type == JinjaVar::JinjaNone && b.stringValue == "none") {
+                return true;
             }
             if (a.type == JinjaVar::JinjaString) {
                 return a.stringValue == b.stringValue;
@@ -293,6 +309,32 @@ namespace fastllm {
         }
     }
 
+    static std::map<std::string, JinjaFunction> functionMap;
+
+    static std::map<std::string, int> functionArgCount;
+
+    static void initFunctionMap() {
+        functionMap["trim"] = JinjaTrim;
+        functionMap["split"] = [](const JinjaVar &a) {
+            JinjaVar string = a.arrayValue[1];
+            JinjaVar delimiter = a.arrayValue[0];
+            std::vector<JinjaVar> tokens;
+            size_t start = 0;
+            size_t end = string.stringValue.find(delimiter.stringValue);
+            size_t delimiter_length = delimiter.stringValue.size();
+        
+            while (end != std::string::npos) {
+                tokens.push_back(JinjaVar(string.stringValue.substr(start, end - start)));
+                start = end + delimiter_length;
+                end = string.stringValue.find(delimiter.stringValue, start);
+            }
+            tokens.push_back(JinjaVar(string.stringValue.substr(start)));
+            return JinjaVar(tokens);
+        };
+        functionArgCount["trim"] = 1;
+        functionArgCount["split"] = 2;
+    }
+
     JinjaTemplate::JinjaTemplate (const std::string &temp) {
         this->temp = temp;
         // 词法解析
@@ -311,12 +353,15 @@ namespace fastllm {
                 blocks.push_back(JinjaBlock(part));
                 // 处理切片语法糖
                 part = temp.substr(i, curEnd + 2 - i);
-                size_t slicepos = part.find("[:");
+                std::string::size_type slicepos = part.find("[:");
                 if (slicepos != std::string::npos)
                     part.replace(slicepos, 2, "[0:");
                 slicepos = part.find(":]");
                 if (slicepos != std::string::npos)
                     part.replace(slicepos, 2, ":0]");
+                slicepos = part.find("is not");
+                if (slicepos != std::string::npos)
+                    part.replace(slicepos, 6, "!=");
                 blocks.push_back(JinjaBlock(part));
                 trimNext = (temp[curEnd - 1] == '-');
                 pos = curEnd + 2;
@@ -324,6 +369,8 @@ namespace fastllm {
             }
         }
         blocks.push_back(temp.substr(pos));
+        if (functionMap.empty())
+            initFunctionMap();
     }
 
     JinjaVar JinjaTemplate::ComputeExpression(JinjaVar &local, std::vector <JinjaToken> tokens, int st, int end) {
@@ -346,6 +393,10 @@ namespace fastllm {
                 }
                 AssertInFastLLM(ops.size() > 0 && ops.back().type == JinjaToken::JinjaTokenLSB, "Error: barckets doesn't match.");
                 ops.pop_back();
+                if (ops.back().type == JinjaToken::JinjaTokenFUNC) {
+                    suffixExp.push_back(ops.back());
+                    ops.pop_back();
+                }
             } else if (tokens[i].type == JinjaToken::JinjaTokenNamespace) {
                 // 目前仅支持 "变量 = 表达式" 格式
                 int index = tokens[i + 1].type == JinjaToken::JinjaTokenLSB ? 1 : 0;
@@ -365,6 +416,10 @@ namespace fastllm {
                 if (suffixExp.back().type != JinjaToken::JinjaTokenSlice)
                     suffixExp.push_back(tokens[i]);
                 ops.pop_back();
+            } else if (tokens[i].type == JinjaToken::JinjaTokenFUNC) {
+                if (ops.back().type == JinjaToken::JinjaTokenDOT)
+                    ops.pop_back();
+                ops.push_back(tokens[i]);
             } else if (tokens[i].type == JinjaToken::JinjaTokenDOT ||
                         tokens[i].type == JinjaToken::JinjaTokenAdd ||
                         tokens[i].type == JinjaToken::JinjaTokenSub ||
@@ -395,10 +450,7 @@ namespace fastllm {
         std::vector <JinjaVar> vars;
         for (auto &it : suffixExp) {
             if (it.type == JinjaToken::JinjaTokenID) {
-                if (it.value == "defined")
-                    vars.push_back(local);
-                else
-                    vars.push_back(JinjaVar(JinjaVar::JinjaNone, it.value));
+                vars.push_back(JinjaVar(JinjaVar::JinjaNone, it.value));
             } else if (it.type == JinjaToken::JinjaTokenBOOL) {
                 vars.push_back(JinjaVar(it.value));
             } else if (it.type == JinjaToken::JinjaTokenSTRING) {
@@ -443,6 +495,23 @@ namespace fastllm {
                 } else {
                     vars.push_back(JinjaVar({{a.stringValue, b}}));
                 }
+            } else if (it.type == JinjaToken::JinjaTokenFUNC) {
+                if (functionMap.find(it.value) != functionMap.end()) {
+                    int argCount = functionArgCount[it.value];
+                    AssertInFastLLM(vars.size() >= argCount, "Jinja Error: function expression error.");
+                    JinjaVar args;
+                    for (int k=0; k<argCount; k++) {
+                        JinjaVar a = vars.back();
+                        if (a.type == JinjaVar::JinjaNone) {
+                            a = local[a];
+                        }
+                        args.arrayValue.push_back(a);
+                        vars.pop_back();
+                    }
+                    vars.push_back(functionMap[it.value](args));
+                } else {
+                    ErrorInFastLLM("Jinja Error: unsupport function " + it.value);
+                }
             } else if (it.type == JinjaToken::JinjaTokenFilter) {
                 AssertInFastLLM(vars.size() > 1, "Jinja Error: expression error.");
                 JinjaVar a = vars[vars.size() - 2], b = vars.back();
@@ -451,19 +520,25 @@ namespace fastllm {
                 }
                 vars.pop_back();
                 vars.pop_back();
-                if (b.stringValue == "trim") {
-                    vars.push_back(JinjaTrim(a));
+                if (functionMap.find(b.stringValue) != functionMap.end()) {
+                    vars.push_back(functionMap[b.stringValue](a));
                 } else {
                     ErrorInFastLLM("Jinja Error: unsupport filter " + b.stringValue);
                 }
             } else if (it.type == JinjaToken::JinjaTokenNot) {
                 AssertInFastLLM(vars.size() >= 1, "Jinja Error: expression error.");
                 JinjaVar a = vars.back();
-                if (a.type == JinjaVar::JinjaNone) {
-                    a = local[a];
-                }
                 vars.pop_back();
-                vars.push_back(a.type == JinjaVar::JinjaNone ? JinjaVar(1) : JinjaVar(!a.BoolValue()));
+                if (a.type == JinjaVar::JinjaNone && a.stringValue == "defined") {
+                    vars.push_back(JinjaVar(JinjaVar::JinjaNone, "none"));
+                } else if (a.type == JinjaVar::JinjaNone && a.stringValue == "none") {
+                    vars.push_back(JinjaVar(JinjaVar::JinjaNone, "defined"));
+                } else {
+                    if (a.type == JinjaVar::JinjaNone) {
+                        a = local[a];
+                    }
+                    vars.push_back(a.type == JinjaVar::JinjaNone ? JinjaVar(1) : JinjaVar(!a.BoolValue()));
+                }
             } else if (it.type == JinjaToken::JinjaTokenSub) {
                 AssertInFastLLM(vars.size() > 0, "Jinja Error: expression '-' error.");
                 JinjaVar a = vars.back();


### PR DESCRIPTION
* 修复github CI Build；
* 一维layernorm类权重无需量化，不执行calcWeightSum，解决报错；
* GraphLLM工厂改为懒加载，修复Win32Demo启动异常；
* 修复C++ Tokenzier在ByteLevel模式下，special token没有转换的问题；
* Jinja2模板支持多个值的namespace，因此支持Deepseek R1 Distrill的模板；
* Jinja2模板支持字符串`split()`函数，支持Deepseek R1 Distrill多轮；
* 修改Jinja2模板set逻辑，可以修改全局变量的值，支持支持Deepseek R1 Distrill的system prompt；

## 测试情况
在以下环境运行测试通过：
* Windows 10 + VIsual Studio 2015R3 + CUDA 9.2
在以下模型测试过
* deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
* deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
* Qwen/Qwen-1.8b-Chat
* Qwen/Qwen1.5-0.5B-Chat
* Qwen/Qwen2-1.5B-Instruct
* Qwen/Qwen2.5-0.5B-Instruct

以下模型prompt似乎有问题：
* microsoft/Phi-3-mini-4k-instruct