### PR TITLE
C++支持Qwen3的模板

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,16 +50,32 @@ message(STATUS "MAKE_WHL_X86: ${MAKE_WHL_X86}")
 
 set(CMAKE_BUILD_TYPE "Release")
 
+string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]+$" "\\1" CXX_MAJOR_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread --std=c++17 -O2")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     string(REPLACE "/Ob2" "/Ob1 /Gy" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX /std:c++17 /arch:AVX2 /source-charset:utf-8")
+    if (CXX_MAJOR_VERSION GREATER_EQUAL 19)
+        set_source_files_properties(
+            "src/devices/cpu/avx512bf16.cpp"
+            PROPERTIES
+            COMPILE_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX10.1"
+        )
+    endif()
 else()
     if (MAKE_WHL_X86)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread --std=c++17 -O2 -mavx -mavx2 -mf16c -mfma -static-libstdc++ -static-libgcc")
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread --std=c++17 -O2 -march=native")
+    endif()
+    if (CXX_MAJOR_VERSION GREATER_EQUAL 10)
+        set_source_files_properties(
+            "src/devices/cpu/avx512bf16.cpp"
+            PROPERTIES
+            COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f -mavx512bf16"
+        )
     endif()
 endif()
 
@@ -75,12 +91,6 @@ set(FASTLLM_CXX_SOURCES src/fastllm.cpp src/device.cpp src/model.cpp src/executo
         third_party/json11/json11.cpp
         ${CPU_DEVICE_FILES}
         ${GRAPH_MODEL_FILES})
-
-set_source_files_properties(
-    "src/devices/cpu/avx512bf16.cpp"
-    PROPERTIES
-    COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f -mavx512bf16"
-)
 
 include_directories(include)
 include_directories(include/utils)
@@ -116,7 +126,6 @@ if (USE_CUDA)
 endif()
 
 if(USE_ROCM)
-    set(CMAKE_HIP_ARCHITECTURES ${ROCM_ARCH})
     list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/third_party/hipify_torch/cmake")
     include(Hipify)
     enable_language(HIP)
@@ -147,6 +156,7 @@ if(USE_ROCM)
     find_package(hipblas REQUIRED)
     find_package(rocprim REQUIRED)
     list(APPEND FASTLLM_LINKED_LIBS hip::device roc::hipblas roc::rocprim)
+    set(CMAKE_HIP_ARCHITECTURES ${ROCM_ARCH})
     add_compile_definitions(HIPBLAS_V2)
 
     # if gfx906(MI50) in ROCM_ARCH list, don't use Tensor Core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,13 @@ option(USE_IVCOREX "use iluvatar corex gpu" OFF)
 
 option(BUILD_CLI "build cli" OFF)
 
+option(UNIT_TEST "build unit tests" OFF)
+
 if(NOT DEFINED CUDA_ARCH)
     set(CUDA_ARCH "native")
 endif()
 
-if(NOT DEFINED ROCM_ARCH)
+if(USE_ROCM AND NOT DEFINED ROCM_ARCH)
     set(ROCM_ARCH "gfx908;gfx90a;gfx1100")
     message(STATUS "ROCM_ARCH not set, using default value: ${ROCM_ARCH}")
 endif()
@@ -236,8 +238,13 @@ target_link_libraries(main fastllm)
 add_executable(quant tools/src/quant.cpp)
 target_link_libraries(quant fastllm)
 
-add_executable(testOps test/ops/cppOps.cpp)
-target_link_libraries(testOps fastllm)
+if (UNIT_TEST)
+    add_executable(testOps test/ops/cppOps.cpp)
+    target_link_libraries(testOps fastllm)
+
+    add_executable(testTokenizer test/ops/tokenizerTest.cpp)
+    target_link_libraries(testTokenizer fastllm)
+endif()
 
 add_executable(webui example/webui/webui.cpp)
 target_link_libraries(webui fastllm)

--- a/example/Win32Demo/Win32Demo.cpp
+++ b/example/Win32Demo/Win32Demo.cpp
@@ -185,14 +185,15 @@ int chatllm(const char* prompt, int type) {
 	return ret.length();
 }
 
-void runConslusion() {
+void runConslusion(RunConfig &config) {
 	printf("欢迎使用 %s 模型. 输入内容对话，reset清空历史记录，stop退出程序.\n", modelType.c_str());
 	while (true) {
 		printf("用户: ");
 		std::string input;
 		std::getline(std::cin, input);
 		if (input == "reset" || input.empty()) {
-			messages->erase(std::next(messages->begin()), messages->end());
+			auto begin = config.systemPrompt.empty() ? messages->begin() : std::next(messages->begin());
+			messages->erase(begin, messages->end());
 			continue;
 		}
 		if (input == "stop") {
@@ -202,7 +203,7 @@ void runConslusion() {
 	}
 }
 
-void runWebUI()
+void runWebUI(RunConfig &config)
 {
 	system("chcp 65001");
 
@@ -253,9 +254,9 @@ int main(int argc, char **argv) {
 	initLLMConf(config);
 
 	if (!config.webuiType) {
-		runConslusion();
+		runConslusion(config);
 	} else {
-		runWebUI();
+		runWebUI(config);
 	}
 	delete generationConfig;
 	return 0;

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -484,7 +484,7 @@ namespace fastllm {
 
         void SetTokenizerConfig(const json11::Json &config);
 
-        std::string Normalize(const std::string &ori); // 字符规范化
+        std::string Normalize(const std::string &ori, const bool addDummyPrefix=true); // 字符规范化
 
         Data Encode(const std::string &s); // 编码
 

--- a/include/template.h
+++ b/include/template.h
@@ -54,7 +54,8 @@ namespace fastllm {
             JinjaTokenLMB, JinjaTokenRMB, JinjaTokenLSB, JinjaTokenRSB,
             JinjaTokenSet, JinjaTokenFor, JinjaTokenEndFor, JinjaTokenIf, JinjaTokenElse, JinjaTokenElseIf, JinjaTokenEndif,
             JinjaTokenIn,
-            JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv, JinjaTokenMod,
+            JinjaTokenAssign, JinjaTokenNotEqual, JinjaTokenEqual, JinjaTokenLess, JinjaTokenLessEqual, JinjaTokenMore, JinjaTokenMoreEqual,
+            JinjaTokenAdd, JinjaTokenSub, JinjaTokenMul, JinjaTokenDiv, JinjaTokenMod,
             JinjaTokenNot, JinjaTokenAnd, JinjaTokenOr,
             JinjaTokenFilter, JinjaTokenNamespace, JinjaTokenSlice
         };

--- a/include/template.h
+++ b/include/template.h
@@ -95,7 +95,7 @@ namespace fastllm {
             {"endif", JinjaToken::JinjaToKenType::JinjaTokenEndif},
             {"set", JinjaToken::JinjaToKenType::JinjaTokenSet},
             {"in", JinjaToken::JinjaToKenType::JinjaTokenIn},
-            {"is", JinjaToken::JinjaToKenType::JinjaTokenIn},
+            {"is", JinjaToken::JinjaToKenType::JinjaTokenEqual},
             {"true", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"false", JinjaToken::JinjaToKenType::JinjaTokenBOOL},
             {"and", JinjaToken::JinjaToKenType::JinjaTokenAnd},

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1671,7 +1671,7 @@ namespace fastllm {
             specialRoot = new TrieNode();
         for (auto &it : specialTokenMap) {
             TrieNode *now = this->specialRoot;
-            std::string normalized = Normalize(it.first);
+            std::string normalized = Normalize(it.first, false);
             for (int i = 0; i < normalized.size(); i++) {
                 if (now->next.find(normalized[i]) == now->next.end()) {
                     now->next[normalized[i]] = new TrieNode();
@@ -1738,7 +1738,7 @@ namespace fastllm {
         return std::numeric_limits<int>::max();
     }
 
-    std::string Tokenizer::Normalize(const std::string &ori) {
+    std::string Tokenizer::Normalize(const std::string &ori, const bool addDummyPrefix) {
         if (this->byteAsChar) {
             std::wstring ws(ori.size(), L' ');
             for (int i=0; i < ori.length(); i++) {
@@ -1752,7 +1752,7 @@ namespace fastllm {
         }
         std::string blank = "";
         blank += 226, blank += 150, blank += 129;
-        std::string s = this->addDummyPrefix ? blank : "";
+        std::string s = (addDummyPrefix && this->addDummyPrefix) ? blank : "";
         if (15 < ori.size() && ori.substr(0, 15) == "<FLM_FIX_TOKEN_") {
             s = "";
         }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -702,7 +702,7 @@ namespace fastllm {
             ((ChatGLMModel*)model)->tokenizerClass = tokenizerClass;
 
             // ChatGLM采用拼接token的方法，需要强行指定分割词的TokenID
-            model->pre_prompt = "";
+            model->pre_prompt = "[gMASK]<sop>";
             model->user_role = ("<FLM_FIX_TOKEN_" + std::to_string(model->weight.tokenizer.GetTokenId("<|user|>"))  + ">\n");
             model->bot_role = ("<FLM_FIX_TOKEN_" + std::to_string(model->weight.tokenizer.GetTokenId("<|assistant|>")) + ">\n");
             model->history_sep = "";

--- a/test/ops/tokenizerTest.cpp
+++ b/test/ops/tokenizerTest.cpp
@@ -1,0 +1,143 @@
+//
+// Created by TylunasLi on 9/9/24.
+//
+
+#include "fastllm.h"
+#include "model.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <codecvt>
+
+//GBK locale name in windows
+const char* GBK_LOCALE_NAME = ".936";
+
+std::string gbk_to_utf8(const std::string& str)
+{
+    std::wstring_convert<std::codecvt_byname<wchar_t, char, mbstate_t>> convert(new std::codecvt_byname<wchar_t, char, mbstate_t>(GBK_LOCALE_NAME));
+    std::wstring tmp_wstr;
+    tmp_wstr = convert.from_bytes(str);
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+    return conv.to_bytes(tmp_wstr);
+}
+
+std::string utf8_to_gbk(const std::string& str)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+    std::wstring tmp_wstr;
+    try {
+        tmp_wstr = conv.from_bytes(str);
+    } catch (const std::range_error& e) {
+        return str;
+    }
+    std::wstring_convert<std::codecvt_byname<wchar_t, char, mbstate_t>> convert(new std::codecvt_byname<wchar_t, char, mbstate_t>(GBK_LOCALE_NAME));
+    return convert.to_bytes(tmp_wstr);
+}
+#endif
+static std::string modelType;
+
+
+struct RunConfig {
+    std::string path = "chatglm-6b-int4.bin"; // 模型文件路径
+    std::string systemPrompt = "";
+    std::string defaultResponse = "";
+    std::set <std::string> eosToken;
+};
+
+void Usage() {
+    std::cout << "Usage:" << std::endl;
+    std::cout << "[-h|--help]:                  显示帮助" << std::endl;
+    std::cout << "<-p|--path> <args>:           模型文件的路径" << std::endl;
+    std::cout << "<--system> <args>:            设置系统提示词(system prompt)" << std::endl;
+    std::cout << "<--response> <args>:          设置默认回复" << std::endl;
+    std::cout << "<--eos_token> <args>:         设置额外的EOS Token" << std::endl;
+}
+
+void ParseArgs(int argc, char **argv, RunConfig &config) {
+    std::vector <std::string> sargv;
+    for (int i = 0; i < argc; i++) {
+        sargv.push_back(std::string(argv[i]));
+    }
+    for (int i = 1; i < argc; i++) {
+        if (sargv[i] == "-h" || sargv[i] == "--help") {
+            Usage();
+            exit(0);
+        } else if (sargv[i] == "-p" || sargv[i] == "--path") {
+            config.path = sargv[++i];
+        } else if (sargv[i] == "--system") {
+            config.systemPrompt = sargv[++i];
+        } else if (sargv[i] == "--response") {
+            config.defaultResponse = sargv[++i];
+        } else if (sargv[i] == "--eos_token") {
+            config.eosToken.insert(sargv[++i]);
+        } else {
+            Usage();
+            exit(-1);
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    RunConfig config;
+    fastllm::GenerationConfig generationConfig;
+    ParseArgs(argc, argv, config);
+
+    if (!fastllm::FileExists(config.path)) {
+        printf("模型文件 %s 不存在！\n", config.path.c_str());
+        exit(0);
+    }
+    bool isHFDir = fastllm::FileExists(config.path + "/config.json") || fastllm::FileExists(config.path + "config.json");
+    auto model = !isHFDir ? fastllm::CreateLLMModelFromFile(config.path) : fastllm::CreateLLMTokenizerFromHF(config.path);
+    for (auto &it : config.eosToken) {
+        generationConfig.stop_token_ids.insert(model->weight.tokenizer.GetTokenId(it));
+    }
+    std::string systemConfig = config.systemPrompt;
+    fastllm::ChatMessages *messages = systemConfig.empty() ? new fastllm::ChatMessages() : new fastllm::ChatMessages({{"system", systemConfig}});
+
+    modelType = model->model_type;
+    printf("欢迎使用 %s 模型. 输入内容对话，reset清空历史记录，stop退出程序.\n", modelType.c_str());
+
+    while (true) {
+        printf("用户: ");
+        std::string input;
+        std::getline(std::cin, input);
+        if (input == "reset" || input.empty()) {
+            if (systemConfig.empty())
+                messages->erase(messages->begin(), messages->end());
+            else
+                messages->erase(std::next(messages->begin()), messages->end());
+            continue;
+        }
+        if (input == "stop") {
+            break;
+        }
+#if defined(_WIN32) || defined(_WIN64)
+        input = gbk_to_utf8(input);
+#endif
+        messages->push_back(std::make_pair("user", input));
+        std::string prompt = model->ApplyChatTemplate(*messages);
+#if defined(_WIN32) || defined(_WIN64)
+        printf("%s\n", utf8_to_gbk(prompt).c_str());
+#else
+        printf("%s\n", prompt.c_str());
+#endif
+        fastllm::Data inputTokenData = model->weight.tokenizer.Encode(prompt);
+        std::vector<int> inputTokens;
+        inputTokens.resize(1);
+        for (int i = 0; i < inputTokenData.Count(0); i++) {
+            inputTokens.push_back((int)((float *) inputTokenData.cpuData)[i]);
+        }
+        for (auto const &i: inputTokens)
+            std::cout << i << " ";
+        std::cout << std::endl;
+        printf("tokens: %d\n", inputTokens.size());
+        std::string response = config.defaultResponse.empty() ? u8"<think>\n\n</think>Hello, how can I assist you today ?" : config.defaultResponse; 
+#if defined(_WIN32) || defined(_WIN64)
+        printf("%s: %s\n", modelType.c_str(), utf8_to_gbk(response).c_str());
+#else
+        printf("%s: %s\n", modelType.c_str(), response.c_str());
+#endif
+        messages->push_back(std::make_pair("assistant", response));
+    }
+    delete messages;
+    return 0;
+}


### PR DESCRIPTION
* 编译
  * 尝试将`avx512bf16`指令优化限制在`gcc >= 10.0` `Visual Studio >= 2022`上。
  * 增加Tokenizers的单元测试例子`testTokenizer`。使用 `-DUNIT_TEST=ON` 编译`testOps`和`testTokenizer`；

* C++ Tokenizer
  * 修复Jinja2模板的多个elseif逻辑；
  * Jinja2模板支持字符串`startswith()` `endswith()` `lstrip()` `rstrip()` `strip()`方法；
  * Jinja2模板支持切片的逆序操作（如`messages[::-1]`）；
  * Jinja2模板支持大于号`>`、小于号`<`；
  * 基于以上修改，支持Qwen3的Chat Template；
  * 修复#518 Normalize特殊token会加上空白，无法匹配特殊token的问题。

## 测试情况

以下模型测试通过
* qwen/Qwen3-1.7B
* microsoft/Phi-3-mini-4k-instruct
* codellama/CodeLlama-7b-Instruct-hf
* deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
* deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
* THUDM/glm-4-9b-chat