### PR TITLE
增加主动退出指定对话的方法

### DIFF
--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -35,6 +35,7 @@ def add_server_args(parser):
     parser.add_argument("--api_key", type = str, default = "", help = "API Key")
     parser.add_argument("--think", type = str, default = "false", help="if <think> lost")
     parser.add_argument("--hide_input", action = 'store_true', help = "不显示请求信息")
+    parser.add_argument("--dev_mode", action = 'store_true', help = "开发模式, 启用后能够获取对话列表并主动停止")
 
 def make_normal_llm_model(args):
     if (args.model and args.model != ''):


### PR DESCRIPTION
增加了一个dev_mode模式（默认关闭），启用后才可以查看所有对话的ID，并通过API停止对应的对话，有效解决某些第三方平台无法停止对话的情况。（当然只适用于开发环境）
<img width="745" alt="DevMode" src="https://github.com/user-attachments/assets/691b94ac-6bcd-4fc0-8ff6-65e1d2dc7482" />
* 获取所有运行的对话
<img width="752" alt="All in running" src="https://github.com/user-attachments/assets/522a04ab-fab0-43fd-9178-11c36d28da3b" />

* 停止某一个对话
<img width="737" alt="Cancle" src="https://github.com/user-attachments/assets/f1c45457-3738-4194-b2ed-6460438eaf5e" />
