### PR TITLE
优化GPU在int4g精度下的性能，优化旧GPU在float16计算模式下的性能

### DIFF
--- a/example/Win32Demo/fastllm-gpu.vcxproj
+++ b/example/Win32Demo/fastllm-gpu.vcxproj
@@ -231,6 +231,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\device.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\avx512bf16.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\avx512vnni.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\linear.cpp" />

--- a/example/Win32Demo/fastllm-gpu.vcxproj.filters
+++ b/example/Win32Demo/fastllm-gpu.vcxproj.filters
@@ -251,6 +251,12 @@
     <ClCompile Include="..\..\src\models\graph\telechat.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\avx512bf16.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\avx512vnni.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp">
       <Filter>源文件\devices\cpu</Filter>
     </ClCompile>

--- a/example/Win32Demo/fastllm.vcxproj
+++ b/example/Win32Demo/fastllm.vcxproj
@@ -206,6 +206,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\device.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\avx512bf16.cpp" />
+    <ClCompile Include="..\..\src\devices\cpu\avx512vnni.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp" />
     <ClCompile Include="..\..\src\devices\cpu\linear.cpp" />

--- a/example/Win32Demo/fastllm.vcxproj.filters
+++ b/example/Win32Demo/fastllm.vcxproj.filters
@@ -37,12 +37,6 @@
     <Filter Include="头文件\devices\cpu">
       <UniqueIdentifier>{c17acf48-126f-4578-aaf9-aef7cfcb9fd9}</UniqueIdentifier>
     </Filter>
-    <Filter Include="头文件\devices\cuda">
-      <UniqueIdentifier>{d7bfe0ea-81a6-4dc4-b526-a5a4eb114296}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="源文件\devices\cuda">
-      <UniqueIdentifier>{fa0efa1b-9d09-40d3-811d-5a2cfb37d536}</UniqueIdentifier>
-    </Filter>
     <Filter Include="头文件\third_party">
       <UniqueIdentifier>{1aa28959-8e28-496c-9bb2-e81e86c2b998}</UniqueIdentifier>
     </Filter>
@@ -126,10 +120,13 @@
     <ClInclude Include="..\..\include\models\xlmroberta.h">
       <Filter>头文件\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\devices\cpu\cpudevice.h">
+    <ClInclude Include="..\..\include\devices\cpu\alivethreadpool.h">
       <Filter>头文件\devices\cpu</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\devices\cpu\alivethreadpool.h">
+    <ClInclude Include="..\..\include\devices\cpu\computeutils.h">
+      <Filter>头文件\devices\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\devices\cpu\cpudevice.h">
       <Filter>头文件\devices\cpu</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\devices\cpu\cputhreadpool.h">
@@ -230,10 +227,19 @@
     <ClCompile Include="..\..\src\models\graph\telechat.cpp">
       <Filter>源文件\models\graph</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\avx512bf16.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\avx512vnni.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\devices\cpu\cpudevice.cpp">
       <Filter>源文件\devices\cpu</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\devices\cpu\cpudevicebatch.cpp">
+      <Filter>源文件\devices\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\devices\cpu\linear.cpp">
       <Filter>源文件\devices\cpu</Filter>
     </ClCompile>
     <ClCompile Include="..\..\third_party\json11\json11.cpp">

--- a/include/device.h
+++ b/include/device.h
@@ -26,7 +26,7 @@ namespace fastllm {
 
     class BaseBatchOperator : BaseOperator {
     public:
-        // 对某一个算子进行形状推理
+        // 对某一个算子进行形状推理  
         virtual void Reshape(const std::string &opType, const DataDict &datas, const FloatDict &floatParams,
                              const IntDict &intParams);
     };

--- a/include/devices/cpu/alivethreadpool.h
+++ b/include/devices/cpu/alivethreadpool.h
@@ -89,7 +89,7 @@ namespace fastllm {
     };
 
     struct AliveThreadPool {
-        std::pair <int, int> curActivateThreadInterval; // 设定当前激活 [curActivateThreadInterval.first, curActivateThreadInterval.second) 的线程
+        std::pair <int, int> curActivateThreadInterval; // 设定当前激活 [curActivateThreadInterval.first, curActivateThreadInterval.second) 的线程  
 
         std::vector <AliveThreadLoop*> loops;
         std::vector <std::thread*> threads;
@@ -302,7 +302,7 @@ namespace fastllm {
         }
     }
 
-    // [n, m, k] -> [m, n, k], 以k个元素为单位做转置 
+    // [n, m, k] -> [m, n, k], 以k个元素为单位做转置   
     struct MultiThreadTransposeByLineOp : MultiThreadBaseOp {
         uint8_t *input, *output;
         int n, m, k, st, end;
@@ -318,7 +318,7 @@ namespace fastllm {
         }
     };
 
-    // [n, m, k] -> [m, n, k], 以k个元素为单位做转置 
+    // [n, m, k] -> [m, n, k], 以k个元素为单位做转置   
     static void RunMultiThreadTransposeByLine(uint8_t *output, uint8_t *input, int n, int m, int k, AliveThreadPool *pool) {
         /*if (len < 256 * 1024) {
             memcpy(output, input, len);

--- a/include/devices/cpu/cpudevice.h
+++ b/include/devices/cpu/cpudevice.h
@@ -162,10 +162,13 @@ namespace fastllm {
         CpuDevice ();
 
         bool Malloc (void **ret, size_t size); // 分配尺寸为size的空间
+        using BaseDevice::Malloc;
         bool Free(void *ret); // 释放ret
 
         bool CopyDataToCPU(void *dst, void *src, size_t size); // 不重要, cpu device不会进行这个操作
+        using BaseDevice::CopyDataToCPU;
         bool CopyDataFromCPU(void *dst, void *src, size_t size); // 不重要, cpu device不会进行这个操作
+        using BaseDevice::CopyDataFromCPU;
 
         int threads = 4;
     };

--- a/src/devices/cpu/avx512vnni.cpp
+++ b/src/devices/cpu/avx512vnni.cpp
@@ -27,12 +27,13 @@ namespace fastllm {
         }
         return ans + _mm512_reduce_add_epi32(acc);
 #endif
+        return 0;
     };
 
-    // int8和int4的矩阵乘法
+    // int8和int4的矩阵乘法  
     // a: [n * m]的int8矩阵
     // b: [k * m]的int4矩阵
-    // c: [n * k]的float32的结果矩阵
+    // c: [n * k]的float32的结果矩阵  
     bool MatMulInt8Int4_AVX512VNNI(uint8_t *a, uint8_t *b, float *c, int n, int m, int k) {
 #ifdef __AVX512VNNI__
         float *values = c;

--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -212,7 +212,8 @@ namespace fastllm {
         int i = 0;
 #ifdef __AVX__
         for (; i + 7 < len; i += 8) {
-            __m256i float_vec = (__m256i)_mm256_cvtph_ps(_mm_loadu_si128((__m128i *) (float16 + i)));
+            __m256 _float_vec = _mm256_cvtph_ps(_mm_loadu_si128((__m128i *) (float16 + i)));
+            __m256i float_vec = *((__m256i *)&_float_vec);
             __m256i shifted = _mm256_srli_epi32(float_vec, 16);
             __m128i lo = _mm256_castsi256_si128(shifted);
             __m128i hi = _mm256_extracti128_si256(shifted, 1);

--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -288,6 +288,8 @@ namespace fastllm {
         Data *output = (datas.find("output")->second);
         output->dataType = DataType::FLOAT16;
         output->Resize(input->dims);
+        if (input->expansionDims.size() != 0)
+            output->Expansion(input->expansionDims);
     }
 
     void CpuConvertToFloat16::Run(const std::string &opType, const fastllm::DataDict &datas,
@@ -312,6 +314,8 @@ namespace fastllm {
         Data *output = (datas.find("output")->second);
         output->dataType = DataType::FLOAT32;
         output->Resize(input->dims);
+        if (input->expansionDims.size() != 0)
+            output->Expansion(input->expansionDims);
     }
 
     void CpuConvertToFloat32::Run(const std::string &opType, const fastllm::DataDict &datas,

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -404,7 +404,6 @@ __global__ void FastllmCudaInt4Group2HalfKernel(uint8_t* a, float *scales, float
 __global__ void FastllmCudaInt4Group2HalfKernel(uint8_t* a, half *scales, half *mins, half *b, int k, int m, int group, int groupCnt) {
     unsigned int tid = threadIdx.x;
     unsigned int st = blockIdx.x;
-#ifdef CUDA_NO_TENSOR_CORE
     half2 scalesBuffer;
     half2 minBuffer;
     int threshold = ST128_FP16_COUNT;
@@ -434,13 +433,6 @@ __global__ void FastllmCudaInt4Group2HalfKernel(uint8_t* a, half *scales, half *
         }
         reinterpret_cast<uint4 *>(b)[index / ST128_FP16_COUNT] = bBuffer.in;
     }
-#else
-    for (int i = tid * 2; i < m; i += blockDim.x * 2) {
-        int gid = st * group + (i / groupCnt);
-        b[st * m + i] = __float2half((float)scales[gid] * (a[(st * m + i) / 2] >> 4) + (float)mins[gid]);
-        b[st * m + i + 1] = __float2half((float)scales[gid] * (a[(st * m + i) / 2] & 0xF) + (float)mins[gid]);
-    }
-#endif
 }
 
 __global__ void FastllmCudaInt42HalfKernel(uint8_t* a, float *scales, float *mins, half *b, int len, int per) {
@@ -1856,7 +1848,7 @@ __global__ void FastllmGemvInt4Kernel2(float *A, uint8_t *B, float *C,
 }
 
 template <int THREAD_PER_BLOCK, int PART>
-__global__ void FastllmGemvInt4GroupKernel2(float *A, uint8_t *B, float *C,
+__global__ void FastllmGemvInt4GroupKernel3(float *A, uint8_t *B, float *C,
                                              float *bias, half *scales, half *mins,
                                              int m, int k, int group, int groupCnt) {
     __shared__ float sdata[PART][THREAD_PER_BLOCK];
@@ -1880,6 +1872,57 @@ __global__ void FastllmGemvInt4GroupKernel2(float *A, uint8_t *B, float *C,
                          + aBuffer.y * (curmin + curscale * (float)(bBuffer & 15));
             sdata[p - st][tid] += aBuffer.z * (curmin + curscale * (float)(bBuffer >> 12)) 
                          + aBuffer.w * (curmin + curscale * (float)((bBuffer >> 8) & 15));
+        }
+    }
+    __syncthreads();
+    for (int p = 0; p < PART; p++) {
+        for (unsigned int s = 1; s < THREAD_PER_BLOCK; s *= 2) {
+            if ((tid & (2 * s - 1)) == 0) {
+                sdata[p][tid] += sdata[p][tid + s];
+            }
+            __syncthreads();
+        }
+
+        if (tid == 0) {
+            C[st + p] = sdata[p][0] + bias[st + p];
+        }
+        __syncthreads();
+    }
+}
+
+template <int THREAD_PER_BLOCK, int PART>
+__global__ void FastllmGemvInt4GroupKernel2(float *A, uint8_t *B, float *C,
+                                             float *bias, half *scales, half *mins,
+                                             int m, int k, int group, int groupCnt) {
+    __shared__ float sdata[PART][THREAD_PER_BLOCK];
+    unsigned int tid = threadIdx.x;
+    // 1. 计算
+    int st = blockIdx.x * PART;
+    int end = st + PART;
+    #pragma unroll
+    for (int p = 0; p < PART; p++) {
+        sdata[p][tid] = 0;
+    }
+
+    for (int i = tid; i < m / 8; i += THREAD_PER_BLOCK) {
+        float4 aBuffer = FETCH_FLOAT4(A[i * 8]);
+        float4 bBuffer = FETCH_FLOAT4(A[i * 8 + 4]);
+
+        for (int p = st; p < end; p++) {
+            uint8_t now0 = B[p * m / 2 + i * 4];
+            uint8_t now1 = B[p * m / 2 + i * 4 + 1];
+            uint8_t now2 = B[p * m / 2 + i * 4 + 2];
+            uint8_t now3 = B[p * m / 2 + i * 4 + 3];
+            int g = p * group + (i * 8 / groupCnt);
+            float curmin = (float)mins[g], curscale = (float)scales[g];
+            sdata[p - st][tid] += (aBuffer.x * (curmin + (float)curscale * (now0 >> 4)) 
+                         + aBuffer.y * (curmin + (float)curscale * (now0 & 15)));
+            sdata[p - st][tid] += (aBuffer.z * (curmin + (float)curscale * (now1 >> 4)) 
+                         + aBuffer.w * (curmin + (float)curscale * (now1 & 15)));
+            sdata[p - st][tid] += (bBuffer.x * (curmin + (float)curscale * (now2 >> 4)) 
+                         + bBuffer.y * (curmin + (float)curscale * (now2 & 15)));
+            sdata[p - st][tid] += (bBuffer.z * (curmin + (float)curscale * (now3 >> 4)) 
+                         + bBuffer.w * (curmin + (float)curscale * (now3 & 15)));
         }
     }
     __syncthreads();
@@ -2994,7 +3037,11 @@ bool FastllmCudaMatMulFloatInt4(const fastllm::Data &input, fastllm::Data &weigh
 
 void LaunchFastllmGemmFp32Int4Group(float *input, uint8_t *weight, float *output, float *bias, half *scales, half *mins, int n, int m, int k, int group, int groupCnt) {
     for (int i = 0; i < n; i++) {
+#ifdef CUDA_NO_TENSOR_CORE
+        FastllmGemvInt4GroupKernel3<64, 4> <<< k / 4, 64 >>>(input + i * m, weight, output + i * k, bias, scales, mins, m, k, group, groupCnt);
+#else
         FastllmGemvInt4GroupKernel2<64, 4> <<< k / 4, 64 >>>(input + i * m, weight, output + i * k, bias, scales, mins, m, k, group, groupCnt);
+#endif
     }
 }
 

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -427,7 +427,8 @@ namespace fastllm {
             } else {
                 this->expansionDims.clear();
                 this->Resize(ori.dims);
-                this->Allocate();
+                this->FreeSpace();
+                this->MallocSpace(Count(0));
             }
         }
 


### PR DESCRIPTION
## 修改点

* 修复MSVC编译器报错

* int4g(AWQ)模式下，开启`CUDA_NO_TENSOR_CORE`编译选项，计算能力5.x和6.1的GPU恢复正常prefill速度，

* `--atype float16`模式下，开启`CUDA_NO_TENSOR_CORE`编译选项，计算能力5.x和6.1的GPU恢复正常prefill速度，

* 优化int4g(AWQ)模式下小并发推理的GEMV算子访存连续性，int4g批量推理的反量化操作也修改为向量化访存。

* `--atype float16`模式下，开启`CUDA_NO_TENSOR_CORE`编译选项，Attention计算改为float32模式，对计算能力5.x和6.1的GPU，decode速度有较多提升。<sup>1</sup>

* 修复CopyFrom从大Data到小Data分配失败的问题，解决benchmark报错

* 修复直接内存分配导致float16下int4 prefill速度慢的问题

## 影响

1. 以前开启`CUDA_NO_TENSOR_CORE`编译选项，新GPU基本也不减速，但是为了加快Attention部分的速度，现在`CUDA_NO_TENSOR_CORE`编译选项下，Attention计算改为float32模式。有较好fp16计算能力的卡（P100，带Tensor Core的GPU）在float16下会减速。
    经过测试，新GPU开启`CUDA_NO_TENSOR_CORE`选项后，decode速度下降5%左右，prefill速度下降12%左右。

## 测试情况

| GPU       | 编译器 | CUDA      | 模型--精度       | 计算精度 | 场景    | 优化前  | 优化之后    |
| --------- | ------ | --------- | ---------------- | -------- | ------- | ------- | ----------- |
| Tesla P40 | VS2015 | CUDA  9.2 | Qwen2.5-7B   AWQ | float32  | prefill | 10.5tps | *257.26tps* |
| Tesla P40 | VS2015 | CUDA  9.2 | Qwen2.5-7B   AWQ | float32  | decode  | 19.9tps | **27.2tps** |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B   AWQ | float32  | decode  | 20.29tps  | **35.3tps** |
| Tesla P40 | VS2015 | CUDA  9.2 | Qwen2.5-7B   AWQ | float16  | prefill | 10.5tps | *247.36tps* |
| Tesla P40 | VS2015 | CUDA  9.2 | Qwen2.5-7B   AWQ | float16  | decode  | 8.26tps |   8.92tps   |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B   AWQ | float16  | decode  | 20.00tps  | **29.4tps** |
| Tesla P40 | VS2015 | CUDA  9.2 | ChatGLM3-6B int4 | float16  | prefill | 145.3tps  | **250.9tps** |
| Tesla P40 | VS2015 | CUDA  9.2 | ChatGLM3-6B int4 | float16  | decode  | 25.4tps | **32.7tps** |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B  fp16 | float16  | prefill | 10.59tps  | *315.14tps* |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B  fp16 | float16  | decode  |  16.5tps  |   19.9tps   |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B  int8 | float16  | prefill | 10.30tps  | *229.39tps* |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B  int8 | float16  | decode  |  21.6tps  |   27.0tps   |
| Tesla P40 | GCC9.4 | CUDA 11.8 | Qwen2.5-7B  int4 | float16  | prefill | 10.64tps  | *273.36tps* |
| Tesla P40 | VS2015 | CUDA  9.2 | Qwen2.5-7B  int4 | float16  | decode  |  19.2tps  | **30.8tps** |
| GTX1080Ti | GCC8.3 | CUDA 11.6 | Qwen2.5-7B   AWQ | float32  | prefill |  12.5tps  | *353.72tps* |
| GTX1080Ti | GCC8.3 | CUDA 11.6 | Qwen2.5-7B   AWQ | float32  | decode  |  22.7tps  | **34.8tps** |
| GTX1080Ti | GCC8.3 | CUDA 11.6 | Qwen2.5-7B   AWQ | float16  | prefill |  12.5tps  | *351.53tps* |
| GTX1080Ti | GCC8.3 | CUDA 11.6 | Qwen2.5-7B   AWQ | float16  | decode  |  22.1tps  | **34.9tps** |
| RTX 3090  | GCC7.5 | CUDA 11.6 | QwQ-32B      AWQ | float32  | prefill |  374.8tps |  *424.6tps* |
| RTX 3090  | GCC8.3 | CUDA 11.6 | QwQ-32B      AWQ | float16  | prefill |  426.2tps |  *446.4tps* |
| RTX 3090  | GCC7.5 | CUDA 11.6 | Qwen2.5-7B  int4 | float16  | prefill | 1569.7tps | **2103.8tps** |
| RTX 3090  | GCC8.3 | CUDA 11.6 | Qwen2.5-7B  int4 | float16  | prefill |  416.2tps | **1750.3tps** |
