### PR TITLE
Fix numa mem bind 修复numa内存绑定

### DIFF
--- a/src/devices/numa/fastllm-numa.cpp
+++ b/src/devices/numa/fastllm-numa.cpp
@@ -110,7 +110,11 @@ namespace fastllm {
                 }
 
                 // 设置内存分配策略
-                numa_set_preferred(numaId);
+                struct bitmask *mask = numa_bitmask_alloc(numa_num_configured_nodes());
+                numa_bitmask_clearall(mask);
+                numa_bitmask_setbit(mask, numaId);
+                numa_set_membind(mask);
+                numa_bitmask_free(mask);
                 
                 printf("numa server running on node %d. (part %d / %d, %d threads)\n", numaId, partId, partCnt, numaThreads);
                 fastllm::ComputeServer *computeServer = new fastllm::ComputeServer(partId, partCnt, numaThreads);


### PR DESCRIPTION
MPOL_PREFERRED（这也是默认策略）并不能保证内存分配的本numa节点上，cached mem过多而系统内存余量没有过多时现象尤为明显。
对于TP实现Tensor总是平分的，一般而言我们也希望总是在本地numa上分配内存，在某个numa节点内存不够时，这将给出内存分配失败，而非在其他节点分配
https://docs.kernel.org/admin-guide/mm/numa_memory_policy.html