### PR TITLE
支持Hunyuan、ERNIE的稠密模型，修复chatglm系列

### DIFF
--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -84,7 +84,7 @@ bool FastllmCudaBatchMatMulTransB(const fastllm::Data &input0, const fastllm::Da
 bool FastllmCudaRotatePosition2D(fastllm::Data &data, const fastllm::Data &positionIds,
                                  const fastllm::Data &sinData, const fastllm::Data &cosData, int rotaryDim);
 bool FastllmCudaNearlyRotatePosition2D(fastllm::Data &data, const fastllm::Data &positionIds,
-                                 const fastllm::Data &sinData, const fastllm::Data &cosData, int rotaryDim);
+                                 const fastllm::Data &sinData, const fastllm::Data &cosData, int rotaryDim, int positionStride);
 bool FastllmCudaLlamaRotatePosition2D(fastllm::Data &data, const fastllm::Data &positionIds,
                                  const fastllm::Data &sinData, const fastllm::Data &cosData, int rotaryDim);
 bool FastllmCudaRepeatPenalty (fastllm::Data &input, fastllm::Data &penalty, fastllm::Data &penaltyScale);

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -693,9 +693,9 @@ namespace fastllm {
 
     void RotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim); // 2D position
 
-    void NearlyRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim); // 2D position, 相邻的元素旋转
+    void NearlyRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim, int positionStride = 1); // 2D position embedding, 相邻的维度旋转
 
-    void LlamaRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim); // 2D position for llama
+    void LlamaRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim); // 2D position embedding for llama，前后各一半的维度旋转
 
     void RepeatPenalty(Data &input, const Data &penalty, const Data &penaltyScale); // 重复惩罚
 

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -95,7 +95,7 @@ namespace fastllm {
         }
 
         void Push(int id) {
-            if (tokenQueue.size() == tot) {
+            if (tokenQueue.size() == tot && tot > 0) {
                 tokenSet.erase(tokenSet.find(tokenQueue.front()));
                 tokenQueue.pop();
             }

--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -5063,15 +5063,17 @@ namespace fastllm {
         Data &sinData = *(datas.find("sin")->second);
         Data &cosData = *(datas.find("cos")->second);
         int rotaryDim = intParams.find("rotaryDim") != intParams.end() ? intParams.find("rotaryDim")->second : 64;
+        int positionStride = intParams.find("positionStride") != intParams.end() ? intParams.find("positionStride")->second : 1;
 
         int len = data.dims[0], bs = data.dims[1];
         int spatial = data.Count(2);
         int n = data.dims[2], m = data.dims[3];
         int stride = (int)sinData.dims[1];
+        positionStride *= positionIds.dims.back();
         for (int l = 0; l < len; l++) {
             for (int b = 0; b < bs; b++) {
                 if (data.dataType == DataType::FLOAT32) {
-                    int index = (int) ((float *) positionIds.cpuData)[(b * 2) * positionIds.dims.back() + l];
+                    int index = (int) ((float *) positionIds.cpuData)[b * positionStride + l];
                     float *sin = ((float*)sinData.cpuData) + stride * index;
                     float *cos = ((float*)cosData.cpuData) + stride * index;
 
@@ -5086,7 +5088,7 @@ namespace fastllm {
                         d += m;
                     }
                 } else if (data.dataType == DataType::FLOAT16) {
-                    int index = (int) ((float *) positionIds.cpuData)[(b * 2) * positionIds.dims.back() + l];
+                    int index = (int) ((float *) positionIds.cpuData)[b * positionStride + l];
                     float *sin = ((float*)sinData.cpuData) + stride * index;
                     float *cos = ((float*)cosData.cpuData) + stride * index;
 

--- a/src/devices/cuda/cudadevice.cpp
+++ b/src/devices/cuda/cudadevice.cpp
@@ -983,8 +983,9 @@ namespace fastllm {
         Data &sinData = *(datas.find("sin")->second);
         Data &cosData = *(datas.find("cos")->second);
         int rotaryDim = intParams.find("rotaryDim") != intParams.end() ? intParams.find("rotaryDim")->second : 64;
+        int positionStride = intParams.find("positionStride") != intParams.end() ? intParams.find("positionStride")->second : 1;
 
-        FastllmCudaNearlyRotatePosition2D(data, positionIds, sinData, cosData, rotaryDim);
+        FastllmCudaNearlyRotatePosition2D(data, positionIds, sinData, cosData, rotaryDim, positionStride);
     }
 
     void CudaLlamaRotatePosition2DOp::Run(const std::string &opType, const fastllm::DataDict &datas,

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1756,7 +1756,15 @@ namespace fastllm {
         float *base = ((float*)logits.cpuData) + outerOffset * vocabSize;
 
         if (fabs(config.repeat_penalty - 1.0) > 1e-6) {
-            for (int id : tokens.tokenSet) {
+            std::multiset<int>::iterator begin = tokens.tokenSet.begin();
+            std::multiset<int>::iterator end = tokens.tokenSet.end();
+            std::set<int> unique(tokens.tokenSet.begin(), tokens.tokenSet.end());
+            if (config.last_n <= 0) {
+                begin = unique.begin();
+                end = unique.end();
+            }
+            for (std::multiset<int>::iterator iter = begin; iter != end; ++iter) {
+                int id = *iter;
                 base[id] = (base[id] < 0 ? base[id] * config.repeat_penalty : base[id] / config.repeat_penalty);
             }
         }

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1077,10 +1077,18 @@ namespace fastllm {
     }
 
     void Data::FreeSpace() {
+        if (isFake)
+            return;
         this->expansionSize = 0;
         this->expansionBytes = 0;
         if (this->dataDevice == DataDevice::CPU) {
+#ifdef USE_MMAP
+            if (this->name.empty())
+                delete[] this->cpuData;
+#else
             delete[] this->cpuData;
+#endif
+            this->cpuData = nullptr;
         } else if (this->dataDevice == DataDevice::CUDA) {
 #ifdef USE_CUDA
             if (this->directMemory) {
@@ -1088,6 +1096,7 @@ namespace fastllm {
             } else {
                 FastllmCudaFree(this->cudaData);
             }
+            this->cudaData = nullptr;
 #else
             ErrorInFastLLM("Error: cuda is not supported.\n");
 #endif
@@ -1207,8 +1216,12 @@ namespace fastllm {
         if (isFake) {
             return;
         }
-#ifndef USE_MMAP
-        delete[] this->cpuData;
+        if (this->cpuData != nullptr)
+#ifdef USE_MMAP
+            if (this->name.empty())
+                delete[] this->cpuData;
+#else
+           delete[] this->cpuData;
 #endif
 #ifdef USE_CUDA
         if (this->cudaData != nullptr) {
@@ -2402,17 +2415,11 @@ namespace fastllm {
 
     void WeightMap::ReleaseWeight() {
         for (auto &w : this->weight) {
-#ifndef USE_MMAP
-            delete[] w.second.cpuData;
-            w.second.cpuData = nullptr;
-#endif
-#ifdef USE_CUDA
-            if (w.second.cudaData != nullptr) {
-                FastllmCudaDirectFree(w.second.cudaData);
-                w.second.cudaData = nullptr;
-            }
-#endif
+            w.second.FreeSpace();
         }
+#ifdef USE_CUDA
+        FastllmCudaClearBigBuffer();
+#endif
     }
 
     Data &WeightMap::operator[](const std::string &key) {

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -2740,10 +2740,10 @@ namespace fastllm {
         }, {}, {{"rotaryDim", rotaryDim}});
     }
 
-    void NearlyRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim) {
+    void NearlyRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim, int positionStride) {
         curExecutor->Run("NearlyRotatePosition2D", {
                 {"input", &input}, {"positionIds", (Data*)&positionIds}, {"sin", &sinData}, {"cos", &cosData}
-        }, {}, {{"rotaryDim", rotaryDim}});
+        }, {}, {{"rotaryDim", rotaryDim}, {"positionStride", positionStride}});
     }
 
     void LlamaRotatePosition2D(Data &input, const Data &positionIds, Data &sinData, Data &cosData, int rotaryDim) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -247,9 +247,9 @@ namespace fastllm {
             model = (basellm*)(new CogvlmModel());
         } else if (modelType == "minimax_m1" || modelType == "minimax_text_01") {
             model = (basellm*)(new MinimaxModel());
-        } else if (modelType == "hunyuan" || modelType == "hunyuan_v1_moe") {
+        } else if (modelType == "hunyuan" || modelType == "hunyuan_v1_dense" || modelType == "hunyuan_v1_moe") {
             model = (basellm*)(new HunyuanModel());
-        } else if (modelType == "ernie4_5_moe") {
+        } else if (modelType == "ernie4_5_moe" || modelType == "ernie4_5") {
             model = (basellm*)(new Ernie4_5Model());
         } else if (modelType == "PanguProMoE") {
             model = (basellm*)(new PanguMOEModel());
@@ -720,7 +720,8 @@ namespace fastllm {
             model->weight.tokenizer.SetSpecialTokens(spTokens);
 #ifdef USE_SENTENCEPIECE
         } else if (tokenizerClass == "PreTrainedTokenizer"
-            || tokenizerClass == "InternLM2Tokenizer" || tokenizerClass == "InternLM3Tokenizer") {
+            || tokenizerClass == "InternLM2Tokenizer" || tokenizerClass == "InternLM3Tokenizer"
+            || tokenizerClass == "Ernie4_5_Tokenizer") {
             std::string tokenizerFile = path + "tokenizer.model";
             std::string&& tokenizerProto = ReadAllFile(tokenizerFile);
             model->weight.tokenizer.spProcessor = std::make_unique<sentencepiece::SentencePieceProcessor>();

--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -202,8 +202,8 @@ namespace fastllm {
                 q.Reshape({q.dims[0], q.dims[1], -1, embed_dim / num_attention_heads});
                 k.Reshape({k.dims[0], k.dims[1], -1, embed_dim / num_attention_heads});
                 v.Reshape({v.dims[0], v.dims[1], -1, embed_dim / num_attention_heads});
-                fastllm::NearlyRotatePosition2D(q, positionIds, sinData, cosData, rotary_dim);
-                fastllm::NearlyRotatePosition2D(k, positionIds, sinData, cosData, rotary_dim);
+                fastllm::NearlyRotatePosition2D(q, positionIds, sinData, cosData, rotary_dim / 2, 2);
+                fastllm::NearlyRotatePosition2D(k, positionIds, sinData, cosData, rotary_dim / 2, 2);
             }
 
             Data &pastKey = pastKeyValues[i].first, &pastValue = pastKeyValues[i].second;
@@ -498,8 +498,8 @@ namespace fastllm {
                 fastllm::RotatePosition2D(q, *positionIds[0], sinData, cosData, rotary_dim);
                 fastllm::RotatePosition2D(k, *positionIds[0], sinData, cosData, rotary_dim);
             } else if (version == 2) {
-                fastllm::NearlyRotatePosition2D(q, *positionIds[0], sinData, cosData, rotary_dim);
-                fastllm::NearlyRotatePosition2D(k, *positionIds[0], sinData, cosData, rotary_dim);
+                fastllm::NearlyRotatePosition2D(q, *positionIds[0], sinData, cosData, rotary_dim / 2, 2);
+                fastllm::NearlyRotatePosition2D(k, *positionIds[0], sinData, cosData, rotary_dim / 2, 2);
             }
 
             k.Resize({k.dims[0], k.dims[1] * k.dims[2], k.dims[3]});

--- a/src/models/ernie4_5.cpp
+++ b/src/models/ernie4_5.cpp
@@ -43,10 +43,12 @@ namespace fastllm {
     void Ernie4_5Model::InitParams() {
         basellm::InitParams();
 
-        n_shared_experts = atoi(this->weight.dicts["moe_num_shared_experts"].c_str());
-        num_experts = atoi(this->weight.dicts["moe_num_experts"].c_str());
-        num_experts_per_tok = atoi(this->weight.dicts["moe_k"].c_str());
-        norm_topk_prob = (this->weight.dicts["norm_topk_prob"] == "true");
+        if (this->weight.dicts.find("") != this->weight.dicts.end()) {
+            n_shared_experts = atoi(this->weight.dicts["moe_num_shared_experts"].c_str());
+            num_experts = atoi(this->weight.dicts["moe_num_experts"].c_str());
+            num_experts_per_tok = atoi(this->weight.dicts["moe_k"].c_str());
+            norm_topk_prob = (this->weight.dicts["norm_topk_prob"] == "true");
+        }
 
         num_key_value_heads = num_attention_heads;
         if (this->weight.dicts.find("num_key_value_heads") != this->weight.dicts.end()) {

--- a/src/models/hunyuan.cpp
+++ b/src/models/hunyuan.cpp
@@ -45,11 +45,12 @@ namespace fastllm {
 
     void HunyuanModel::InitParams() {
         basellm::InitParams();
-        num_experts = atoi(this->weight.dicts["num_experts"].c_str());
-        // num_experts_per_tok = atoi(this->weight.dicts["num_experts_per_tok"].c_str());
-        num_experts_per_tok = 8; // atoi(this->weight.dicts["num_experts_per_tok"].c_str());
+        if (this->weight.dicts.find("num_experts") != this->weight.dicts.end()) {
+            num_experts = atoi(this->weight.dicts["num_experts"].c_str());
+            num_experts_per_tok = 8; // atoi(this->weight.dicts["moe_topk"].c_str());
 
-        norm_topk_prob = (this->weight.dicts["norm_topk_prob"] == "true");
+            norm_topk_prob = (this->weight.dicts["norm_topk_prob"] == "true");
+        }
 
         num_key_value_heads = num_attention_heads;
         if (this->weight.dicts.find("num_key_value_heads") != this->weight.dicts.end()) {


### PR DESCRIPTION
## 修改点
* 修改了`NearlyRotatePosition2D`算子的逻辑；
    原本该算子是为ChatGLM2系列服务的，`position_id`兼容ChatGLM-6B的特殊格式，同时只处理一半`q`和`k`，提交 d0c22b6 中修改了算子的逻辑，应用在全部`q`和`k`上，适配deepseek_v2，但是chatglm模型没有做对应修改，导致回答混乱；同时deepseek_v2的`position_id`取值位置不准确；本次做了修复。
* 支持Hunyuan的稠密模型系列（Hunyuan-7B-Instruct）；
* 支持ERNIE-4.5-0.3B-PT；
* 修改`Data`释放内存的逻辑；
    - `·DUSE_MMAP`选项开启时，无名字的张量需要释放内存
    - Fake张量无需释放
* 修改重复惩罚因子（repeat_penalty），当last_n为0时，重复惩罚计算方式与Transfromers一致，但默认不开启。

## 测试情况
在以下模型测试过：
* deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
* paddlepaddle/ERNIE-4.5-0.3B-PT
* tencent/Hunyuan-1.8B-Instruct
* zai-org/chatglm2-6b