### PR TITLE
修复 OpenAI 兼容接口在缺少 hf_tokenizer 时的 tool call 崩溃

### DIFF
--- a/tools/fastllm_pytools/openai_server/fastllm_completion.py
+++ b/tools/fastllm_pytools/openai_server/fastllm_completion.py
@@ -204,11 +204,18 @@ class FastLLmCompletion:
 
   def _ensure_tool_parser(self):
       if self.tool_parser is None:
+          tokenizer = self.model.hf_tokenizer
+          chat_template = getattr(tokenizer, "chat_template", None)
+          if tokenizer is None or chat_template is None:
+              raise ValueError(
+                  "Tool calling requires a Hugging Face tokenizer with chat_template. "
+                  "Please use an HF model directory or provide the original tokenizer files."
+              )
           from .tool_parsers import ToolParserManager
           self.tool_parser = ToolParserManager.get_tool_parser_auto(
-              self.model.get_type(), self.model.hf_tokenizer.chat_template,
+              self.model.get_type(), chat_template,
               force_chat_template = self.model.force_chat_template,
-              force_type = self.model.tool_call_parser)(self.model.hf_tokenizer)
+              force_type = self.model.tool_call_parser)(tokenizer)
 
   def _parse_anthropic_message_content(
       self,
@@ -552,12 +559,8 @@ class FastLLmCompletion:
            logging.info(f"Abort request: {request_id}")
            return self.create_error_response("Client disconnected")
 
-      if (request.tools and self.tool_parser is None):
-          from .tool_parsers import ToolParser, ToolParserManager
-          self.tool_parser = ToolParserManager.get_tool_parser_auto(
-              self.model.get_type(), self.model.hf_tokenizer.chat_template,
-              force_chat_template=self.model.force_chat_template,
-              force_type=self.model.tool_call_parser)(self.model.hf_tokenizer)
+      if request.tools:
+          self._ensure_tool_parser()
 
       if request.tools:
           tool_call_info = self.tool_parser.extract_tool_calls(result, request)
@@ -653,13 +656,8 @@ class FastLLmCompletion:
 
         # 2. content部分
 
-        if (request.tools and self.tool_parser is None):
-            # tools不为空
-            from .tool_parsers import ToolParser, ToolParserManager            
-            self.tool_parser = ToolParserManager.get_tool_parser_auto (
-                self.model.get_type(), self.model.hf_tokenizer.chat_template, 
-                force_chat_template = self.model.force_chat_template, 
-                force_type = self.model.tool_call_parser) (self.model.hf_tokenizer)
+        if request.tools:
+            self._ensure_tool_parser()
         
         completion_tokens = 0
 


### PR DESCRIPTION
## 问题

OpenAI 兼容接口的 tool call 路径在 `hf_tokenizer` 为空时，会直接访问 `hf_tokenizer.chat_template`，导致空指针崩溃。

## 修复

- 统一通过 `_ensure_tool_parser()` 初始化 tool parser
- 对缺少 `hf_tokenizer` / `chat_template` 的情况增加显式校验
- 返回明确错误，避免直接崩溃

## 验证

本地复验后，当前行为已从 `AttributeError` 变为明确错误返回。

## 关联

- Related: #648
