### PR TITLE
修复 nightly sdist 安装时 metadata 包名错误的问题

### DIFF
--- a/tools/scripts/setup.py
+++ b/tools/scripts/setup.py
@@ -1,3 +1,4 @@
+import email
 import os
 from setuptools import setup, find_packages
 
@@ -11,9 +12,41 @@ PACKAGE_INFO = {
     "release": {"name": "ftllm", "version": "0.1.5.1"},
     "nightly": {"name": "ftllm-nightly", "version": "0.0.0.3"},
 }
-variant = "nightly" if os.environ.get("FASTLLM_NIGHTLY", "0") == "1" else "release"
-package_name = PACKAGE_INFO[variant]["name"]
-package_version = PACKAGE_INFO[variant]["version"]
+
+
+def load_package_info_from_metadata():
+    metadata_paths = [
+        "PKG-INFO",
+        "ftllm.egg-info/PKG-INFO",
+        "ftllm_nightly.egg-info/PKG-INFO",
+    ]
+    for metadata_path in metadata_paths:
+        if not os.path.exists(metadata_path):
+            continue
+        with open(metadata_path, "r", encoding = "utf-8") as metadata_file:
+            metadata = email.message_from_file(metadata_file)
+        name = metadata.get("Name")
+        version = metadata.get("Version")
+        if name and version:
+            return {
+                "name": name,
+                "version": version,
+            }
+    return None
+
+
+def resolve_package_info():
+    if os.environ.get("FASTLLM_NIGHTLY", "0") == "1":
+        return PACKAGE_INFO["nightly"]
+    metadata_package_info = load_package_info_from_metadata()
+    if metadata_package_info is not None:
+        return metadata_package_info
+    return PACKAGE_INFO["release"]
+
+
+package_info = resolve_package_info()
+package_name = package_info["name"]
+package_version = package_info["version"]
 
 setup (
     name = package_name,


### PR DESCRIPTION
## 问题

nightly 的 sdist 在安装阶段会重新执行 `setup.py` 生成 metadata。
当前逻辑只通过 `FASTLLM_NIGHTLY` 环境变量决定包名和版本；当这个环境变量不存在时，会退回 release 的 `ftllm / 0.1.5.1`，导致 metadata 与 sdist 中实际的 `ftllm-nightly / 0.0.0.3` 不一致，安装时会报 metadata name mismatch。

## 修复

当 `FASTLLM_NIGHTLY` 未设置时，优先从当前目录已有的 `PKG-INFO` 读取 `Name` 和 `Version`。
只有拿不到已有元数据时，才回退到默认的 release 配置。

## 验证

- 修复前可复现：nightly sdist 解包后，无环境变量时 `setup.py --name` 返回 `ftllm`
- 修复后验证通过：同样场景下返回 `ftllm-nightly`
- release 路径验证通过：仍返回 `ftllm / 0.1.5.1`

Issue: #655
