### PR TITLE
修复 CPU 宿主上 Docker CUDA 镜像无法构建的问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,11 @@ option(BUILD_CLI "build cli" OFF)
 option(UNIT_TEST "build unit tests" OFF)
 
 if(NOT DEFINED CUDA_ARCH)
-    set(CUDA_ARCH "native")
+    if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CUDA_ARCH "${CMAKE_CUDA_ARCHITECTURES}")
+    else()
+        set(CUDA_ARCH "native")
+    endif()
 endif()
 
 # ROCm device detection function
@@ -237,6 +241,8 @@ endif()
 
 if (USE_CUDA)
     enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 20)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
     add_compile_definitions(USE_CUDA)
     if (CUDA_NO_TENSOR_CORE)
         add_compile_definitions(CUDA_NO_TENSOR_CORE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
 RUN apt-get update 
 
 # Install and configure Python
-RUN apt-get -y --no-install-recommends install wget build-essential python3.10 python3-pip
+RUN apt-get -y --no-install-recommends install wget build-essential libnuma-dev python3.10 python3-pip
 RUN update-alternatives --install /usr/bin/python  python /usr/bin/python3.10 1
 RUN pip install setuptools streamlit-chat
 
@@ -17,6 +17,6 @@ RUN wget -c https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.2
 WORKDIR $WORKDIR
 ADD . $WORKDIR/
 
-RUN mkdir $WORKDIR/build && cd build && cmake .. -DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=native && make -j && cd tools && python setup.py install
+RUN mkdir $WORKDIR/build && cd build && cmake .. -DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90" && make -j && cd tools && python setup.py install
 
 CMD /fastllm/build/webui -p /models/chatglm2-6b-int8.flm

--- a/src/devices/cuda/linear/fastllm-linear-bf16.cu
+++ b/src/devices/cuda/linear/fastllm-linear-bf16.cu
@@ -89,7 +89,7 @@ __global__ void FastllmGemvBf16Bf16Kernel2MultiRow(__nv_bfloat16 *A, __nv_bfloat
         if (bias != nullptr) {
 #pragma unroll
             for (int x = 0; x < PART; x++)
-                C[p + k * x] = __float2bfloat16_rn(sdata[x][0] + __bfloat162float(__ldg(bias + p)));
+                C[p + k * x] = __float2bfloat16_rn(sdata[x][0] + __bfloat162float(bias[p]));
         } else {
 #pragma unroll
             for (int x = 0; x < PART; x++)

--- a/src/devices/cuda/linear/fastllm-linear-fp16.cu
+++ b/src/devices/cuda/linear/fastllm-linear-fp16.cu
@@ -74,7 +74,7 @@ __global__ void FastllmGemvBf16Fp16Kernel2MultiRow(__nv_bfloat16 *A, half *B, __
         if (bias != nullptr) {
 #pragma unroll
             for (int x = 0; x < PART; x++)
-                C[p + k * x] = __float2bfloat16_rn(sdata[x][0] + __bfloat162float(__ldg(bias + p)));
+                C[p + k * x] = __float2bfloat16_rn(sdata[x][0] + __bfloat162float(bias[p]));
         } else {
 #pragma unroll
             for (int x = 0; x < PART; x++)


### PR DESCRIPTION
## 问题

当前 `Dockerfile` 在 CPU 宿主上执行 `docker build` 时会失败。

主要有两类原因：

1. 构建命令使用了 `-DCMAKE_CUDA_ARCHITECTURES=native`
   - 容器构建阶段拿不到宿主 GPU 信息
   - `native` 不能稳定用于镜像构建

2. Docker 构建环境与当前默认构建配置不一致
   - 默认启用了 `USE_NUMAS`
   - 镜像里没有安装 `libnuma-dev`
   - 同时 CUDA 代码里已经使用了 C++20 的模板 lambda，但 CUDA 构建标准没有显式提升

## 修复

- `CMakeLists.txt` 中优先继承外部传入的 `CMAKE_CUDA_ARCHITECTURES`
- 为 CUDA 构建显式设置 `CMAKE_CUDA_STANDARD 20`
- `Dockerfile` 中补充安装 `libnuma-dev`
- `Dockerfile` 中将 CUDA 架构改为固定值 `80;86;89;90`，避免依赖宿主 GPU 探测
- 修正两处 BF16 bias 读取方式，避免对应 CUDA 构建报错

## 验证

本地实际执行：

```bash
docker build -t fastllm-issue646-test .
```

验证结果：
- 构建日志中 `USE_CUDA: ON`
- 构建日志中 `CUDA_ARCH: 80;86;89;90`
- `fastllm` / `fastllm_tools` / `webui` 等目标均成功编译
- 镜像最终成功产出

Issue: #646
