### PR TITLE
修复 OpenAI 工具调用多轮消息的结构化 content 兼容问题

### DIFF
--- a/tools/fastllm_pytools/openai_server/fastllm_completion.py
+++ b/tools/fastllm_pytools/openai_server/fastllm_completion.py
@@ -459,6 +459,14 @@ class FastLLmCompletion:
       empty_media = LoadedMedia()
       if content is None and tool_calls is None and tool_call_id is None:
           return [], empty_media
+      if role == "tool" and isinstance(content, dict):
+          return [ConversationMessage(
+              role = role,
+              content = self._serialize_tool_arguments(content),
+              tool_calls = tool_calls,
+              tool_call_id = tool_call_id,
+              name = name,
+          )], empty_media
       if content is None or isinstance(content, str):
           return [ConversationMessage(role=role, content=content or "",
                                       tool_calls=tool_calls,

--- a/tools/fastllm_pytools/openai_server/protocal/openai_protocol.py
+++ b/tools/fastllm_pytools/openai_server/protocal/openai_protocol.py
@@ -81,8 +81,7 @@ class ChatCompletionRequest(BaseModel):
     model: str
     messages: Optional[Union[
         str,
-        List[Dict[str, str]],
-        List[Dict[str, Union[str, List[Dict[str, Union[str, Dict[str, str]]]]]]],
+        List[Dict[str, Any]],
     ]] = []
     prompt: Optional[str] = ""
     temperature: Optional[float] = None


### PR DESCRIPTION
问题背景

- 当前 OpenAI 兼容接口在工具调用多轮场景下，对消息结构的兼容不完整
- 当客户端传入这类常见消息时，会在请求解析阶段报 `Complex input not supported yet`
- 具体有两层问题：
  - `tool` 消息中的对象型 `content` 不被接受
  - `ChatCompletionRequest.messages` 的类型定义过窄，连现有 `test/api/openai.py` 中使用的 `assistant.content = None` / `tool.content = { ... }` 这类形态也无法兼容

修改内容

- 放宽 `ChatCompletionRequest.messages` 的消息类型定义，使其能够接收现有 OpenAI 工具调用多轮消息结构
- 在 OpenAI parser 中兼容 `role=tool` 且 `content` 为对象的情况，将其序列化为 JSON 字符串继续处理
- 保持其他角色的原有解析口径不变，不额外扩大兼容范围

验证

- 使用本地最小复现验证：
  - `tool.content` 为字符串时可正常通过
  - `tool.content` 为对象时修复前会报错，修复后可正常通过
  - `user.content` 为对象时仍保持不支持，避免误放宽
- 使用构造的 `ChatCompletionRequest` 跑通 `create_chat_completion(...)`，确认以下消息结构现在可以正常进入处理流程：
  - `assistant.content = None`
  - `assistant.tool_calls = [...]`
  - `tool.content = { ... }`

Issue

- #596
