### PR TITLE
修复cpu推理路径下qwen3推理数据类型报错以及输出重复&乱码问题

### DIFF
--- a/src/blocks/linearaddblock.cpp
+++ b/src/blocks/linearaddblock.cpp
@@ -13,8 +13,14 @@ namespace fastllm {
         if (CanRunLinearAdd(*input, *weight, *bias, *output)) {
             LinearAdd(*input, *weight, *bias, *middle, *output);
         } else {
-            Linear(*input, *weight, *bias, *middle);
-            AddTo(*output, *middle);
+            Linear(*input, *weight, *bias, *middle)
+            if (middle->dataType != output->dataType) {
+                Data tempMiddle;
+                ToDataType(*middle, tempMiddle, output->dataType);
+                AddTo(*output, tempMiddle);
+            } else {
+                AddTo(*output, *middle);
+            }
         }
     }
 }

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -1933,6 +1933,9 @@ namespace fastllm {
     }
 
     Data::~Data() {
+        if (isFake) {
+            return;
+        }
         if (this->isPagedKVCache && !this->pageIndex.empty()) {
             this->pagedKVCacheData->ReleasePageIndices(this->pageIndex);
         }
@@ -1940,9 +1943,6 @@ namespace fastllm {
             for (auto it : this->multiDeviceDatas) {
                 delete it.second;
             }
-        }
-        if (isFake) {
-            return;
         }
         if (this->cpuData != nullptr)
 #ifdef USE_MMAP


### PR DESCRIPTION
**【系统信息】**
Darwin MacBookPro.lan 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:53:15 PST 2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T6000 arm64
**【运行报错】**
(base)fcj@MacBookPro build % ./main -p Qwen3-0.6B 
AVX: OFF
AVX2: OFF
AARCH64: ON
Neon FP16: OFF
Neon DOT: ON
Loading 100 
欢迎使用 qwen3 模型. 输入内容对话，reset清空历史记录，stop退出程序.
用户: 你好
FastLLM Error: AddTo error: Data's type should be float32, float16 or bfloat16, and both inputs should use the same type. input0.name= input1.name= input0.type=0 input1.type=7 input0.device=0 input1.device=0 input0.dims=[1,9,1024] input1.dims=[1,9,1024] alpha=1
Press any key to exit...
**【数据类型修复】**
按PR中 src/blocks/linearaddblock.cpp 修复数据类型未对齐后，输出结果为：
(base) fcj@MacBookPro build % ./main -p Qwen3-0.6B --top_k 1 --temperature 1.0 --repeat_penalty 1.0
AVX: OFF
AVX2: OFF
AARCH64: ON
Neon FP16: OFF
Neon DOT: ON
Loading 100 
欢迎使用 qwen3 模型. 输入内容对话，reset清空历史记录，stop退出程序.
用户: 你好
qwen3:<think>
好的，用户发来了一条消息：“你好”。我需要先确认用户是否在测试我的反应，或者只是普通问候。作为AI助手，我应该保持友好和专业的态度，同时确保回应符合规定。用户可能希望得到一个自然的回应，而不是机械式的回复。因此，我会用简洁明了的语言，表达欢迎，并邀请用户进行交流。同时，要避免使用任何可能引起误解的措辞，确保回应既礼貌又专业。最后，检查是否有需要进一步澄清的地方，确保回应准确无误。
</think>

你好！有什么可以帮助你的吗吗吗吗得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得得^C
**【输出重复&乱码修复】**
按PR中 src/fastllm.cpp 修复输出重复问题后，输出结果为：
(base) fcj@MacBookPro build % ./main -p Qwen3-0.6B --top_k 1 --temperature 1.0 --repeat_penalty 1.0
AVX: OFF
AVX2: OFF
AARCH64: ON
Neon FP16: OFF
Neon DOT: ON
Loading 100 
欢迎使用 qwen3 模型. 输入内容对话，reset清空历史记录，stop退出程序.
用户: 你好
qwen3:<think>
好的，用户发来了一条消息：“你好”。我需要先确认用户是否在测试我的反应，或者只是普通问候。作为AI助手，我应该保持友好和专业的态度，同时确保回应符合规定。用户可能希望得到一个自然的回应，而不是机械式的回复。因此，我会用简洁明了的语言，表达欢迎，并邀请用户进行交流。同时，要避免使用任何可能引起误解的措辞，确保回应既礼貌又专业。最后，检查是否有需要进一步澄清的地方，确保回应准确无误。
</think>

你好！有什么可以帮助你的吗？😊
用户: 
**【具体原因分析】**
CpuAttentionPagedBatchOp::Run() 的 for 循环中，每轮创建了局部的 batchK/batchV：
for (int b = 0; b < batch; b++) {
    Data batchK, batchV;  // ← 局部变量

    batchK.isFake = true;
    batchK.isPagedKVCache = true;         // ← 设成了 PagedKVCache
    batchK.pagedKVCacheData = kCaches.pagedKVCacheData;  // ← 指向真实 manager
    batchK.pageIndex.assign(pageIndexsData + pageStart, pageIndexsData + pageEnd);   // ← 复制了真实页号
    // ... 用 batchK 做完 attention ...

    // ← 循环结束，batchK/batchV 析构！
}
关键在 Data::~Data()中，
Data::~Data() {
    if (this->isPagedKVCache && !this->pageIndex.empty()) {
        this->pagedKVCacheData->ReleasePageIndices(this->pageIndex);  // ← 释放页面！
    }
    // ...
    if (isFake) {
        return;  // ← 在 ReleasePageIndices 之后才 return！
    }
isFake = true 的 return 在释放页面之后，所以即使 fake 对象，也走了页面释放逻辑，导致 pageRefCount 从 1 减到 0，页面被放回 freePages。于是 299 又回到了 freePages 末尾。

调用时序如下：
prefill 路径: AppendPagedCache → GetUnusedPageIndex(true) → 分配 299, refCount=1
                                            ↓
              AttentionPagedBatch → CpuAttentionPagedBatchOp::Run()
                                    → batchK.pageIndex = {299}
                                    → 循环结束 batchK ~Data()
                                    → ReleasePageIndices({299})
                                    → refCount 1→0 → freePages.push_back(299)
                                            ↓
decode 路径: updatePageMeta → GetUnusedPageIndex(true) → 又重新获取被释放的299号page