### PR TITLE
修复think模式下复用kvcache失败问题

### DIFF
--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -2622,10 +2622,19 @@ namespace fastllm {
     JinjaVar ChatMessagesToJinjaVar(const ChatMessages &messages) {
         JinjaVar ret = {{"messages", fastllm::JinjaArray {}}};
         for (auto &message : messages) {
-            ret["messages"].arrayValue.push_back({
+            auto msg = JinjaVar({
                 {"role", message.first},
                 {"content", message.second}
             });
+            std::string content = message.second;
+            size_t thinkEnd = content.find("</think>");
+            if (thinkEnd != std::string::npos) {
+                size_t thinkStart = content.find("<think>");
+                if (thinkStart != std::string::npos && thinkStart < thinkEnd) {
+                    msg["reasoning_content"] = content.substr(thinkStart + 7, thinkEnd - thinkStart - 7);
+                }
+            }
+            ret["messages"].arrayValue.push_back(msg);
         }
         ret["add_generation_prompt"] = fastllm::JinjaVar{1};
         ret["tools"] = fastllm::JinjaVar{std::vector <JinjaVar>()};


### PR DESCRIPTION
### 问题描述
#### 【背景】
目前 ApplyChatTemplate 中会先把传入的 ChatMessages 转为 JinjaVar，但是 ChatMessagesToJinjaVar 中并未对 think 模式下的模型输出进行兼容，并未构造 reasoning_content 字段，导致 Jinja 模板在缺失 reasoning_content 的情况下并不会拼接 <think>reasoning_content</think> 至输入中，think 渲染逻辑：
```jinja
{%- for message in messages %}
    ...
    {%- elif message.role == "assistant" %}
        ...
        {%- if loop.index0 > ns.last_query_index %}
            {%- if loop.last or (not loop.last and reasoning_content) %}
                {{- '<|im_start|>assistant\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
            {%- else %}
                {{- '<|im_start|>assistant\n' + content }}
            {%- endif %}
        {%- else %}
            {{- '<|im_start|>assistant\n' + content }}     {# 无 <think> #}
        {%- endif %}
    {%- endif %}
{%- endfor %}
```
上述 bug 导致项目中所有使用 ApplyChatTemplate 的地方在 think 模式下无法有效充分利用计算好的 kvcache，下面以 Response 为例子复现改问题。
#### 【问题现象】
Response 接口增加打印信息：
```cpp
std::string basellm::Response(const std::string &oriInput, RuntimeResult retCb,
                                  const fastllm::GenerationConfig &generationConfig) {
        printf("oriInput:%s\n", oriInput.c_str());
        std::string input = oriInput;
        if (this->saveHistoryChat) {
            if (lastKeyValues != nullptr) {
                if (input.size() < lastPrompt.size() || (input.substr(0, lastPrompt.size()) != lastPrompt)) {
                    lastPrompt = "";
                    lastPromptTokens = 0;
                    delete lastKeyValues;
                    lastKeyValues = nullptr;
                    printf("delete lastKeyValues\n");
                } else {
                    input = input.substr(lastPrompt.size());
                }
            }
        } else {
            lastPrompt = "";
            lastPromptTokens = 0;
            delete lastKeyValues;
            lastKeyValues = nullptr;
        }
}
```
编译运行程序打印结果如下：
```text
$ ./main -p ../Qwen3-0.6B
CPU Instruction Info: [AVX2: ON] [AVX512F: ON] [AVX512_VNNI: ON] [AVX512_BF16: OFF] [AMX: OFF] 
1 : top_p:1.000000,top_k:1,temperature:1.000000,repeat_penalty:1.000000
AVX: ON
AVX2: ON
AARCH64: OFF
Neon FP16: OFF
Neon DOT: OFF
Loading 100 
欢迎使用 qwen3 模型. 输入内容对话，reset清空历史记录，stop退出程序.
用户: 你好
oriInput:<|im_start|>system
你是一个AI助手，请直接给出简洁的回答，不要输出<think>标签和内部思考过程。<|im_end|>
<|im_start|>user
你好<|im_end|>
<|im_start|>assistant

qwen3:<think>
好的，用户发来“你好”，我需要以简洁的方式回应。首先，确认用户的身份，然后保持友好和专业的态度。不需要添加额外信息，直接回复即可。确保语言简洁，符合要求。
</think>

你好！有什么可以帮助你的吗？
用户: 天气如何
oriInput:<|im_start|>system
你是一个AI助手，请直接给出简洁的回答，不要输出<think>标签和内部思考过程。<|im_end|>
<|im_start|>user
你好<|im_end|>
<|im_start|>assistant
你好！有什么可以帮助你的吗？<|im_end|>
<|im_start|>user
天气如何<|im_end|>
<|im_start|>assistant

delete lastKeyValues
qwen3:<think>
好的，用户问天气如何。我需要先确认用户的具体需求。他们可能想知道当前的天气状况，或者是否有其他相关的问题。考虑到用户之前的问题都是关于天气的，可能他们需要最新的信息或者建议。

首先，我应该回复一个友好的问候，确认天气情况。然后，询问用户是否需要最新的天气信息，或者是否有其他问题需要帮助。这样既回应了当前的问题，又保持了互动性。

同时，要确保回答简洁，避免冗长。用户可能希望快速得到答案，所以直接明了的信息会更好。另外，考虑到天气信息可能实时更新，可能需要提醒用户查看最新的天气预报，以确保准确性。

最后，检查是否有其他潜在的需求，比如是否需要提供穿衣建议或活动建议，但根据当前问题，保持回答简洁是关键。
</think>

你好，天气如何？需要最新的天气信息吗？
用户: 
```
可以看到第二轮交互时给模型的输入并未包含<think>xxx</think>内容，导致kvcache复用失败。
### 修复方案
如 PR 修复，在 think 模式时需要提取 reasoning_content 内容，构造该字段
```cpp
JinjaVar ChatMessagesToJinjaVar(const ChatMessages &messages) {
        JinjaVar ret = {{"messages", fastllm::JinjaArray {}}};
        for (auto &message : messages) {
            auto msg = JinjaVar({
                {"role", message.first},
                {"content", message.second}
            });
            std::string content = message.second;
            size_t thinkEnd = content.find("</think>");
            if (thinkEnd != std::string::npos) {
                size_t thinkStart = content.find("<think>");
                if (thinkStart != std::string::npos && thinkStart < thinkEnd) {
                    msg["reasoning_content"] = content.substr(thinkStart + 7, thinkEnd - thinkStart - 7);
                }
            }
            ret["messages"].arrayValue.push_back(msg);
        }
        ret["add_generation_prompt"] = fastllm::JinjaVar{1};
        ret["tools"] = fastllm::JinjaVar{std::vector <JinjaVar>()};
        return ret;
    }
```
### 修复验证
修复完成后，编译代码执行结果可以发现包含 think 模式下的标签，成功复用kvcache
```text
$ ./main -p ../Qwen3-0.6B
CPU Instruction Info: [AVX2: ON] [AVX512F: ON] [AVX512_VNNI: ON] [AVX512_BF16: OFF] [AMX: OFF] 
1 : top_p:1.000000,top_k:1,temperature:1.000000,repeat_penalty:1.000000
AVX: ON
AVX2: ON
AARCH64: OFF
Neon FP16: OFF
Neon DOT: OFF
Loading 100 
欢迎使用 qwen3 模型. 输入内容对话，reset清空历史记录，stop退出程序.
用户: 你好
oriInput:<|im_start|>system
你是一个AI助手，请直接给出简洁的回答，不要输出<think>标签和内部思考过程。<|im_end|>
<|im_start|>user
你好<|im_end|>
<|im_start|>assistant

qwen3:<think>
好的，用户发来“你好”，我需要以简洁的方式回应。首先，确认用户的身份，然后保持友好和专业的态度。不需要添加额外信息，直接回复即可。确保语言简洁，符合要求。
</think>

你好！有什么可以帮助你的吗？
用户: 天气如何
oriInput:<|im_start|>system
你是一个AI助手，请直接给出简洁的回答，不要输出<think>标签和内部思考过程。<|im_end|>
<|im_start|>user
你好<|im_end|>
<|im_start|>assistant
<think>
好的，用户发来“你好”，我需要以简洁的方式回应。首先，确认用户的身份，然后保持友好和专业的态度。不需要添加额外信息，直接回复即可。确保语言简洁，符合要求。
</think>

你好！有什么可以帮助你的吗？<|im_end|>
<|im_start|>user
天气如何<|im_end|>
<|im_start|>assistant

qwen3:<think>
好的，用户问天气如何。我需要先确认用户的具体需求，是想知道当前的天气情况，还是有其他相关的问题。考虑到用户可能是在户外活动，比如运动或旅游，需要提供准确的天气信息。同时，用户可能没有明确说明，但可能希望了解天气对活动的影响。因此，我应该先询问用户的具体需求，以便提供更准确的帮助。此外，用户可能希望知道是否有其他需要关注的天气信息，比如温度、降水概率等。因此，回复时要保持开放，让用户选择是否需要进一步的信息。最后，确保回答简洁，符合用户的要求。
用户: 
```