### PR TITLE
Bound ModelLoader::ReadString/ReadBytes against the mapped file size (OOB read on crafted .flm)

### DIFF
--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -655,6 +655,9 @@ namespace fastllm {
 
     std::string ModelLoader::ReadString() {
         int length = ReadInt();
+        if (length < 0 || (size_t)(ptr - data) + (size_t)length > size) {
+            ErrorInFastLLM("ModelLoader::ReadString: string length out of file bounds (corrupt model).");
+        }
         std::string s(ptr, ptr + length);
         ptr += length;
         return s;
@@ -670,6 +673,9 @@ namespace fastllm {
 
     uint8_t* ModelLoader::ReadBytes(uint64_t bytes){
         // memcpy(buffer, ptr, bytes);
+        if ((size_t)(ptr - data) + bytes > size) {
+            ErrorInFastLLM("ModelLoader::ReadBytes: length out of file bounds (corrupt model).");
+        }
         uint8_t* buffer = (uint8_t *) ptr;
         ptr += bytes;
         return buffer;


### PR DESCRIPTION
Loading a crafted `.flm` triggers an out-of-bounds read: `ModelLoader::ReadString` reads a length directly from the file and builds `std::string(ptr, ptr + length)` with no check against the mapped extent (`ModelLoader` is constructed with `mapped_file->size` but never consults it); `ReadBytes` is likewise unchecked. Reachable from `WeightMap::LoadFromFile` on file-controlled key/value entries.

This PR adds the missing bounds checks (reject `length < 0` and `ptr + length > data + size`) using the size the loader already holds. See the accompanying issue #701 for the ASan-witnessed PoC and details.

Reported/fixed by Professor Moody (Halo Forge Labs), found with Crucible.