### PR TITLE
支持 Qwen3.5/3.6 GGUF 与 V100 SM70 IQ4_XS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ if (USE_CUDA)
         src/devices/cuda/fastllm-iq4xs-sm70.cu
         src/devices/cuda/attention/fastllm-attention.cu
         src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
+        src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
         src/devices/cuda/linear/fastllm-linear-fp32.cu
         src/devices/cuda/linear/fastllm-linear-fp16.cu
         src/devices/cuda/linear/fastllm-linear-bf16.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ if (USE_CUDA)
         src/devices/cuda/attention/fastllm-attention.cu
         src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
         src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
+        src/devices/cuda/attention/paged/fastllm-turboquant-kv.cu
         src/devices/cuda/linear/fastllm-linear-fp32.cu
         src/devices/cuda/linear/fastllm-linear-fp16.cu
         src/devices/cuda/linear/fastllm-linear-bf16.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ if (USE_CUDA)
         src/devices/cuda/fastllm-cuda.cu 
         src/devices/cuda/fastllm-triton-cuda.cu
         src/devices/cuda/fastllm-ggml-cuda.cu
+        src/devices/cuda/fastllm-iq4xs-sm70.cu
         src/devices/cuda/attention/fastllm-attention.cu
         src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
         src/devices/cuda/linear/fastllm-linear-fp32.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,10 @@ if (UNIT_TEST)
     if (USE_CUDA AND NOT USE_ROCM)
         target_include_directories(regressionOps PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
     endif()
+
+    add_executable(testApiServerSocket
+        test/apiserver/socketWriteTest.cpp
+        third_party/json11/json11.cpp)
 endif()
 
 add_executable(webui example/webui/webui.cpp)

--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -342,15 +342,15 @@ struct WorkQueue {
 
             std::string output = "";
             bool rawPrompt = node->config["raw_prompt"].is_bool() && node->config["raw_prompt"].bool_value();
-            fastllm::Data inputs;
+            std::string prompt;
             if (rawPrompt) {
-                inputs = model->weight.tokenizer.Encode(node->config["prompt"].string_value());
+                prompt = node->config["prompt"].string_value();
             } else {
                 fastllm::ChatMessages messages;
                 messages.push_back({"user", node->config["prompt"].string_value()});
-                auto prompt = model->ApplyChatTemplate(messages);
-                inputs = model->weight.tokenizer.Encode(prompt);
+                prompt = model->ApplyChatTemplate(messages);
             }
+            fastllm::Data inputs = model->weight.tokenizer.Encode(prompt);
             std::vector<int> tokens;
             for (int i = 0; i < inputs.Count(0); i++) {
                 tokens.push_back(((float *) inputs.cpuData)[i]);
@@ -407,16 +407,15 @@ struct WorkQueue {
             }
 
             bool rawPrompt = node->config["raw_prompt"].is_bool() && node->config["raw_prompt"].bool_value();
-            fastllm::Data inputs;
+            std::string prompt;
             if (rawPrompt) {
                 if (!node->config["prompt"].is_string()) {
                     node->error = "raw_prompt requires a string prompt.\n";
                 } else {
-                    inputs = model->weight.tokenizer.Encode(node->config["prompt"].string_value());
+                    prompt = node->config["prompt"].string_value();
                 }
             } else {
-                auto prompt = model->ApplyChatTemplate(chatMessages);
-                inputs = model->weight.tokenizer.Encode(prompt);
+                prompt = model->ApplyChatTemplate(chatMessages);
             }
             if (node->error != "") {
                 message += node->error;
@@ -424,6 +423,7 @@ struct WorkQueue {
                 close(node->client);
                 return;
             }
+            fastllm::Data inputs = model->weight.tokenizer.Encode(prompt);
             std::vector<int> tokens;
             for (int i = 0; i < inputs.Count(0); i++) {
                 tokens.push_back(((float *) inputs.cpuData)[i]);
@@ -734,14 +734,23 @@ int main(int argc, char** argv) {
         }
 
         int size = 0;
-        while (true) {
-            int cur = read(client, buff + size, sizeof(buff) - size);
+        bool requestReady = false;
+        while (size < (int)sizeof(buff) - 1) {
+            int cur = read(client, buff + size, sizeof(buff) - 1 - size);
+            if (cur <= 0) {
+                break;
+            }
             size += cur;
+            buff[size] = 0;
             if (httpChecker.IsValid(buff, size)) {
+                requestReady = true;
                 break;
             }
         }
-        buff[size] = 0;
+        if (!requestReady) {
+            close(client);
+            continue;
+        }
 
         while (workQueue.q.size() > workQueue.maxActivateQueryNumber) {
             fastllm::MySleep(0);

--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -164,6 +164,7 @@ struct APIConfig {
     int batch = 256; // batch数限制
     fastllm::DataType dtype = fastllm::DataType::FLOAT16;
     fastllm::DataType atype = fastllm::DataType::FLOAT32;
+    fastllm::DataType kvCacheDtype = fastllm::DataType::DATA_AUTO_NONE;
     int groupCnt = -1;
 
     std::map <std::string, int> devices;
@@ -620,6 +621,7 @@ void Usage() {
     std::cout << "<-l|--low>:                   使用低内存模式" << std::endl;
     std::cout << "<--dtype> <args>:             设置权重类型(读取hf文件时生效)" << std::endl;
     std::cout << "<--atype> <args>:             设置推理使用的数据类型(float32/float16)" << std::endl;
+    std::cout << "<--kv_cache_dtype> <args>:    设置KV Cache数据类型(auto/float32/float16/bfloat16/fp8_e4m3)" << std::endl;
     std::cout << "<--batch> <args>:             最大batch数" << std::endl;
     std::cout << "<--tokens> <args>:            最大tokens容量" << std::endl;
     std::cout << "<--model_name> <args>:        模型名(openai api中使用)" << std::endl;
@@ -665,6 +667,12 @@ void ParseArgs(int argc, char **argv, APIConfig &config) {
             fastllm::AssertInFastLLM(dataTypeDict.find(atypeStr) != dataTypeDict.end(),
                                     "Unsupport act type: " + atypeStr);
             config.atype = dataTypeDict[atypeStr];
+        } else if (sargv[i] == "--kv_cache_dtype") {
+            try {
+                config.kvCacheDtype = fastllm::ParseKVCacheDataType(sargv[++i]);
+            } catch (const std::invalid_argument &error) {
+                fastllm::AssertInFastLLM(false, error.what());
+            }
         } else if (sargv[i] == "--model_name") {
             config.modelName = sargv[++i];
         } else if (sargv[i] == "--device") {
@@ -696,8 +704,11 @@ int main(int argc, char** argv) {
     bool isHFDir = fastllm::FileExists(config.path + "/config.json") || fastllm::FileExists(config.path + "config.json");
     workQueue.model = isHFDir ? fastllm::CreateLLMModelFromHF(config.path, config.dtype, config.groupCnt)
         : fastllm::CreateLLMModelFromFile(config.path);
-    workQueue.model->tokensLimit = config.tokens;
+    workQueue.model->SetTokenLimit(config.tokens);
     workQueue.model->SetDataType(config.atype);
+    if (config.kvCacheDtype != fastllm::DataType::DATA_AUTO_NONE) {
+        workQueue.model->SetKVCacheDataType(config.kvCacheDtype);
+    }
     workQueue.maxActivateQueryNumber = std::max(1, std::min(256, config.batch));
     workQueue.Start();
 

--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -120,7 +120,9 @@ using socket_t = int;
 #include <sys/stat.h>
 #include <thread>
 #include "model.h"
+#include "http_request_reader.h"
 #include "socket_writer.h"
+#include "openai_output_parser.h"
 #include "stop_parser.h"
 #include "utils/stop_string_matcher.h"
 
@@ -310,13 +312,16 @@ struct WorkQueue {
                     printf("totalQueryNumber = %d\n", ts->totalQueryNumber);
 //printf("activate = %d, q.size() = %d\n", ts->activateQueryNumber, (int) ts->q.size());
 
-                    std::thread *t = new std::thread([](WorkQueue *ts, WorkNode *now) {
+                    std::thread([ts](WorkNode *now) {
                         ts->Deal(now);
                         printf("Response client %d finish\n", now->client);
-                        ts->locker.lock();
-                        ts->activateQueryNumber--;
-                        ts->locker.unlock();
-                    }, ts, now);
+                        delete now;
+                        {
+                            std::lock_guard<std::mutex> lock(ts->locker);
+                            ts->activateQueryNumber--;
+                        }
+                        ts->cv.notify_all();
+                    }, now).detach();
                 }
             }
         }, this);
@@ -482,24 +487,67 @@ struct WorkQueue {
                 return;
             }
 
-            std::string output = "";
-            int handleId = model->LaunchResponseTokens(tokens, config);
-            bool isStream = false;
-            if (node->config["stream"].is_bool() && node->config["stream"].bool_value()) {
-                isStream = true;
+            bool toolsEnabled = node->config["tools"].is_array();
+            if (node->config["tool_choice"].is_string() &&
+                node->config["tool_choice"].string_value() == "none") {
+                toolsEnabled = false;
+            }
+            std::string selectedToolName;
+            if (node->config["tool_choice"].is_object()) {
+                selectedToolName =
+                    node->config["tool_choice"]["function"]["name"].string_value();
+            }
+            if (toolsEnabled) {
+                for (const auto &tool : node->config["tools"].array_items()) {
+                    const std::string name = tool["function"]["name"].string_value();
+                    if (!name.empty() &&
+                        (selectedToolName.empty() || name == selectedToolName)) {
+                        config.tool_call_allowed_names.push_back(name);
+                    }
+                }
+                toolsEnabled = !config.tool_call_allowed_names.empty();
+            }
+            if (toolsEnabled) {
+                config.tool_call_name_constraint_enabled = true;
+                config.tool_call_invoke_name_prefixes = {
+                    "<function=", "<fuction="
+                };
+                config.tool_call_name_terminator = ">";
             }
 
-            std::string curId = "fastllm-" + GenerateRandomID();
-            auto createTime = _GetCurrentTime();
+            int handleId = model->LaunchResponseTokens(tokens, config);
+            const bool isStream = node->config["stream"].is_bool() &&
+                                  node->config["stream"].bool_value();
+            const std::string curId = "fastllm-" + GenerateRandomID();
+            const auto createTime = _GetCurrentTime();
+            OpenAIOutputParser outputParser(
+                OpenAIReasoningParser::PromptEndsInReasoning(prompt),
+                toolsEnabled);
+
+            auto serializeToolCall = [&](const OpenAIParsedToolCall &call,
+                                         const std::string &id,
+                                         int index,
+                                         bool includeIndex) {
+                json11::Json::object toolCall = {
+                    {"id", id},
+                    {"type", "function"},
+                    {"function", json11::Json::object {
+                        {"name", call.name},
+                        {"arguments", call.arguments}
+                    }}
+                };
+                if (includeIndex) {
+                    toolCall["index"] = index;
+                }
+                return json11::Json(toolCall);
+            };
 
             if (isStream) {
-                message = "";
-                message += "HTTP/1.1 200 OK\r\n";
+                message = "HTTP/1.1 200 OK\r\n";
                 message += "Content-Type:text/event-stream\r\n";
                 message += "Cache-Control:no-cache\r\n";
                 message += "server:fastllm api server\r\n";
-                message += "Transfer-Encoding: chunked\r\n";
-                message += "\r\n";
+                message += "Transfer-Encoding: chunked\r\n\r\n";
 
                 auto abortDisconnectedStream = [&]() {
                     model->AbortResponse(handleId);
@@ -534,38 +582,62 @@ struct WorkQueue {
                 }
 
                 int outputTokens = 0;
+                int toolCallIndex = 0;
+                bool hasToolCalls = false;
                 std::vector<float> results;
                 std::string pendingStopText;
+                bool matchedStopString = false;
+                auto sendParsedDelta = [&](const OpenAIOutputDelta &parsed) {
+                    if (parsed.Empty()) {
+                        return true;
+                    }
+                    json11::Json::object delta;
+                    if (!parsed.reasoningContent.empty()) {
+                        delta["reasoning_content"] = parsed.reasoningContent;
+                    }
+                    if (!parsed.content.empty()) {
+                        delta["content"] = parsed.content;
+                    }
+                    if (!parsed.toolCalls.empty()) {
+                        json11::Json::array toolCalls;
+                        for (const auto &call : parsed.toolCalls) {
+                            toolCalls.push_back(serializeToolCall(
+                                call, "call_" + GenerateRandomID(),
+                                toolCallIndex++, true));
+                        }
+                        delta["tool_calls"] = toolCalls;
+                        hasToolCalls = true;
+                    }
+                    json11::Json partResult = json11::Json::object {
+                        {"id", curId},
+                        {"object", "chat.completion.chunk"},
+                        {"created", createTime},
+                        {"model", ::config.modelName},
+                        {"choices", json11::Json::array {
+                            json11::Json::object {
+                                {"index", 0},
+                                {"delta", delta},
+                                {"logprobs", nullptr},
+                                {"finish_reason", nullptr},
+                                {"stop_reason", nullptr}
+                            }
+                        }}
+                    };
+                    return WriteHttpChunk(
+                        node->client, FormatSseData(partResult.dump()));
+                };
+
                 while (true) {
                     int result = model->FetchResponseTokens(handleId);
                     if (result == -1) {
                         std::string trailingText;
                         FlushPendingStopText(pendingStopText, trailingText);
-                        if (!trailingText.empty()) {
-                            json11::Json trailingResult = json11::Json::object {
-                                {"id", curId},
-                                {"object", "chat.completion.chunk"},
-                                {"created", createTime},
-                                {"model", ::config.modelName},
-                                {"choices", json11::Json::array {
-                                    json11::Json::object {
-                                        {"index", 0},
-                                        {"delta", json11::Json::object {
-                                            {"content", trailingText}
-                                        }},
-                                        {"logprobs", nullptr},
-                                        {"finish_reason", nullptr},
-                                        {"stop_reason", nullptr}
-                                    }
-                                }}
-                            };
-                            if (!WriteHttpChunk(node->client,
-                                    FormatSseData(trailingResult.dump()))) {
-                                close(node->client);
-                                return;
-                            }
+                        if (!sendParsedDelta(outputParser.Push(trailingText)) ||
+                            !sendParsedDelta(outputParser.Flush())) {
+                            close(node->client);
+                            return;
                         }
-                        json11::Json partResult = json11::Json::object {
+                        json11::Json finishResult = json11::Json::object {
                             {"id", curId},
                             {"object", "chat.completion.chunk"},
                             {"created", createTime},
@@ -577,7 +649,10 @@ struct WorkQueue {
                                         {"content", ""}
                                     }},
                                     {"logprobs", nullptr},
-                                    {"finish_reason", "stop"},
+                                    {"finish_reason", ResolveOpenAIFinishReason(
+                                        hasToolCalls, matchedStopString,
+                                        outputTokens,
+                                        config.output_token_limit)},
                                     {"stop_reason", nullptr}
                                 }
                             }},
@@ -588,7 +663,7 @@ struct WorkQueue {
                             }}
                         };
                         if (!WriteHttpChunk(node->client,
-                                            FormatSseData(partResult.dump()))) {
+                                FormatSseData(finishResult.dump()))) {
                             close(node->client);
                             return;
                         }
@@ -596,50 +671,25 @@ struct WorkQueue {
                     }
 
                     outputTokens++;
-                    results.clear();
-                    results.push_back(result);
+                    results.assign(1, static_cast<float>(result));
                     std::string now = model->weight.tokenizer.Decode(
                         fastllm::Data(fastllm::DataType::FLOAT32,
                                       {(int)results.size()}, results));
                     std::string filtered;
                     bool matchedStop = PushStopText(
                         config.stop_strings, pendingStopText, now, filtered);
-                    now = filtered;
+                    matchedStopString = matchedStopString || matchedStop;
                     if (matchedStop) {
                         model->AbortResponse(handleId);
                     }
-                    if (now.empty()) {
-                        if (matchedStop) {
-                            continue;
-                        }
-                        continue;
-                    }
-                    json11::Json partResult = json11::Json::object {
-                        {"id", curId},
-                        {"object", "chat.completion.chunk"},
-                        {"created", createTime},
-                        {"model", ::config.modelName},
-                        {"choices", json11::Json::array {
-                            json11::Json::object {
-                                {"index", 0},
-                                {"delta", json11::Json::object {
-                                    {"content", now}
-                                }},
-                                {"logprobs", nullptr},
-                                {"finish_reason", nullptr},
-                                {"stop_reason", nullptr}
-                            }
-                        }}
-                    };
-                    if (!WriteHttpChunk(node->client,
-                                        FormatSseData(partResult.dump()))) {
+                    if (!sendParsedDelta(outputParser.Push(filtered))) {
                         abortDisconnectedStream();
                         return;
                     }
                 }
 
-                if (!WriteHttpChunk(node->client, FormatSseData("[DONE]"))
-                        || !WriteAllToSocket(node->client, "0\r\n\r\n", 5)) {
+                if (!WriteHttpChunk(node->client, FormatSseData("[DONE]")) ||
+                    !WriteAllToSocket(node->client, "0\r\n\r\n", 5)) {
                     close(node->client);
                     return;
                 }
@@ -648,31 +698,57 @@ struct WorkQueue {
                 int outputTokens = 0;
                 std::vector<float> results;
                 std::string pendingStopText;
+                bool matchedStopString = false;
+                std::string reasoningOutput;
+                std::string output;
+                std::vector<OpenAIParsedToolCall> parsedToolCalls;
+                auto appendParsedDelta = [&](const OpenAIOutputDelta &parsed) {
+                    reasoningOutput += parsed.reasoningContent;
+                    output += parsed.content;
+                    parsedToolCalls.insert(parsedToolCalls.end(),
+                                           parsed.toolCalls.begin(),
+                                           parsed.toolCalls.end());
+                };
                 while (true) {
                     int result = model->FetchResponseTokens(handleId);
                     if (result == -1) {
                         break;
-                    } else {
-                        results.clear();
-                        results.push_back(result);
-                        std::string now = model->weight.tokenizer.Decode(
-                            fastllm::Data(fastllm::DataType::FLOAT32,
-                                          {(int)results.size()}, results));
-                        std::string filtered;
-                        bool matchedStop = PushStopText(
-                            config.stop_strings, pendingStopText, now, filtered);
-                        output += filtered;
-                        outputTokens++;
-                        if (matchedStop) {
-                            model->AbortResponse(handleId);
-                        }
+                    }
+                    outputTokens++;
+                    results.assign(1, static_cast<float>(result));
+                    std::string now = model->weight.tokenizer.Decode(
+                        fastllm::Data(fastllm::DataType::FLOAT32,
+                                      {(int)results.size()}, results));
+                    std::string filtered;
+                    bool matchedStop = PushStopText(
+                        config.stop_strings, pendingStopText, now, filtered);
+                    matchedStopString = matchedStopString || matchedStop;
+                    appendParsedDelta(outputParser.Push(filtered));
+                    if (matchedStop) {
+                        model->AbortResponse(handleId);
                     }
                 }
                 std::string trailingText;
                 FlushPendingStopText(pendingStopText, trailingText);
-                output += trailingText;
+                appendParsedDelta(outputParser.Push(trailingText));
+                appendParsedDelta(outputParser.Flush());
 
-                json11::Json result = json11::Json::object {
+                json11::Json::object responseMessage = {
+                    {"role", "assistant"},
+                    {"content", output}
+                };
+                if (!reasoningOutput.empty()) {
+                    responseMessage["reasoning_content"] = reasoningOutput;
+                }
+                if (!parsedToolCalls.empty()) {
+                    json11::Json::array toolCalls;
+                    for (const auto &call : parsedToolCalls) {
+                        toolCalls.push_back(serializeToolCall(
+                            call, "call_" + GenerateRandomID(), 0, false));
+                    }
+                    responseMessage["tool_calls"] = toolCalls;
+                }
+                json11::Json response = json11::Json::object {
                     {"id", curId},
                     {"object", "chat.completion"},
                     {"created", createTime},
@@ -680,12 +756,11 @@ struct WorkQueue {
                     {"choices", json11::Json::array {
                         json11::Json::object {
                             {"index", 0},
-                            {"message", json11::Json::object {
-                                {"role", "assistant"},
-                                {"content", output}
-                            }},
+                            {"message", responseMessage},
                             {"logprobs", nullptr},
-                            {"finish_reason", nullptr},
+                            {"finish_reason", ResolveOpenAIFinishReason(
+                                !parsedToolCalls.empty(), matchedStopString,
+                                outputTokens, config.output_token_limit)},
                             {"stop_reason", nullptr}
                         }
                     }},
@@ -695,9 +770,8 @@ struct WorkQueue {
                         {"completion_tokens", outputTokens}
                     }}
                 };
-
-                message += result.dump();
-                int ret = write(node->client, message.c_str(), message.length()); //返回message
+                message += response.dump();
+                WriteAllToSocket(node->client, message);
                 close(node->client);
             }
             return;
@@ -805,6 +879,7 @@ int main(int argc, char** argv) {
         workQueue.model->SetKVCacheDataType(config.kvCacheDtype);
     }
     workQueue.maxActivateQueryNumber = std::max(1, std::min(256, config.batch));
+    workQueue.model->maxBatch = workQueue.maxActivateQueryNumber;
     workQueue.Start();
 
     int local_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -839,6 +914,17 @@ int main(int argc, char** argv) {
             exit(-1);
         }
 
+#ifdef _WIN32
+        DWORD receiveTimeoutMs = 15000;
+        setsockopt(client, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const char *>(&receiveTimeoutMs),
+                   sizeof(receiveTimeoutMs));
+#else
+        struct timeval receiveTimeout = {15, 0};
+        setsockopt(client, SOL_SOCKET, SO_RCVTIMEO,
+                   &receiveTimeout, sizeof(receiveTimeout));
+#endif
+
         int size = 0;
         bool requestReady = false;
         while (size < (int)sizeof(buff) - 1) {
@@ -848,7 +934,7 @@ int main(int argc, char** argv) {
             }
             size += cur;
             buff[size] = 0;
-            if (httpChecker.IsValid(buff, size)) {
+            if (IsHttpRequestComplete(buff, static_cast<size_t>(size))) {
                 requestReady = true;
                 break;
             }
@@ -858,9 +944,6 @@ int main(int argc, char** argv) {
             continue;
         }
 
-        while (workQueue.q.size() > workQueue.maxActivateQueryNumber) {
-            fastllm::MySleep(0);
-        }
         workQueue.Push(buff, client);
     }
 

--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -790,7 +790,7 @@ void Usage() {
     std::cout << "<-l|--low>:                   使用低内存模式" << std::endl;
     std::cout << "<--dtype> <args>:             设置权重类型(读取hf文件时生效)" << std::endl;
     std::cout << "<--atype> <args>:             设置推理使用的数据类型(float32/float16)" << std::endl;
-    std::cout << "<--kv_cache_dtype> <args>:    设置KV Cache数据类型(auto/float32/float16/bfloat16/fp8_e4m3)" << std::endl;
+    std::cout << "<--kv_cache_dtype> <args>:    设置KV Cache数据类型(auto/float32/float16/bfloat16/fp8_e4m3/turbo3; Qwen3.5/3.6 turbo3 uses q8_0 K + TurboQuant3 V)" << std::endl;
     std::cout << "<--batch> <args>:             最大batch数" << std::endl;
     std::cout << "<--tokens> <args>:            最大tokens容量" << std::endl;
     std::cout << "<--model_name> <args>:        模型名(openai api中使用)" << std::endl;

--- a/example/apiserver/apiserver.cpp
+++ b/example/apiserver/apiserver.cpp
@@ -120,6 +120,9 @@ using socket_t = int;
 #include <sys/stat.h>
 #include <thread>
 #include "model.h"
+#include "socket_writer.h"
+#include "stop_parser.h"
+#include "utils/stop_string_matcher.h"
 
 long long _GetCurrentTime() {
     auto now = std::chrono::high_resolution_clock::now();
@@ -445,6 +448,40 @@ struct WorkQueue {
                 config.top_k = node->config["top_k"].number_value();
             }
 
+            auto exactTokenLookup = [&](const std::string &stop,
+                                        int &tokenId) {
+                auto &tokenizer = model->weight.tokenizer;
+                auto it = tokenizer.stringToTokenDict.find(stop);
+                if (it == tokenizer.stringToTokenDict.end()) {
+                    return false;
+                }
+                tokenId = it->second;
+                return true;
+            };
+            auto fallbackEncode = [&](const std::string &stop) {
+                fastllm::Data stopTokens = model->weight.tokenizer.Encode(stop);
+                std::vector<int> tokenIds;
+                tokenIds.reserve(stopTokens.Count(0));
+                for (int i = 0; i < stopTokens.Count(0); i++) {
+                    tokenIds.push_back(
+                        static_cast<int>(((float *)stopTokens.cpuData)[i]));
+                }
+                return tokenIds;
+            };
+            auto encodeStop = [&](const std::string &stop) {
+                return EncodeOpenAIStop(stop, exactTokenLookup,
+                                        fallbackEncode);
+            };
+            if (!ParseOpenAIStop(node->config["stop"], encodeStop,
+                                 config.stop_token_ids,
+                                 config.stop_token_sequences,
+                                 config.stop_strings, node->error)) {
+                message += node->error + "\n";
+                WriteAllToSocket(node->client, message);
+                close(node->client);
+                return;
+            }
+
             std::string output = "";
             int handleId = model->LaunchResponseTokens(tokens, config);
             bool isStream = false;
@@ -458,12 +495,21 @@ struct WorkQueue {
             if (isStream) {
                 message = "";
                 message += "HTTP/1.1 200 OK\r\n";
-                message += "Content-Type:application/json\r\n";
+                message += "Content-Type:text/event-stream\r\n";
+                message += "Cache-Control:no-cache\r\n";
                 message += "server:fastllm api server\r\n";
                 message += "Transfer-Encoding: chunked\r\n";
                 message += "\r\n";
-                int ret = write(node->client, message.c_str(), message.length()); //返回初始信息
-            
+
+                auto abortDisconnectedStream = [&]() {
+                    model->AbortResponse(handleId);
+                    close(node->client);
+                };
+                if (!WriteAllToSocket(node->client, message)) {
+                    abortDisconnectedStream();
+                    return;
+                }
+
                 json11::Json startResult = json11::Json::object {
                     {"id", curId},
                     {"object", "chat.completion.chunk"},
@@ -481,19 +527,44 @@ struct WorkQueue {
                         }
                     }}
                 };
-                std::string cur = ("data: " + startResult.dump() + "\r\n");
-
-                char chunk_header[50];
-                sprintf(chunk_header, "%zx\r\n", cur.size());
-                ret = write(node->client, chunk_header, strlen(chunk_header));
-                ret = write(node->client, cur.data(), cur.size());
-                ret = write(node->client, "\r\n", 2);
+                if (!WriteHttpChunk(node->client,
+                                    FormatSseData(startResult.dump()))) {
+                    abortDisconnectedStream();
+                    return;
+                }
 
                 int outputTokens = 0;
                 std::vector<float> results;
+                std::string pendingStopText;
                 while (true) {
                     int result = model->FetchResponseTokens(handleId);
                     if (result == -1) {
+                        std::string trailingText;
+                        FlushPendingStopText(pendingStopText, trailingText);
+                        if (!trailingText.empty()) {
+                            json11::Json trailingResult = json11::Json::object {
+                                {"id", curId},
+                                {"object", "chat.completion.chunk"},
+                                {"created", createTime},
+                                {"model", ::config.modelName},
+                                {"choices", json11::Json::array {
+                                    json11::Json::object {
+                                        {"index", 0},
+                                        {"delta", json11::Json::object {
+                                            {"content", trailingText}
+                                        }},
+                                        {"logprobs", nullptr},
+                                        {"finish_reason", nullptr},
+                                        {"stop_reason", nullptr}
+                                    }
+                                }}
+                            };
+                            if (!WriteHttpChunk(node->client,
+                                    FormatSseData(trailingResult.dump()))) {
+                                close(node->client);
+                                return;
+                            }
+                        }
                         json11::Json partResult = json11::Json::object {
                             {"id", curId},
                             {"object", "chat.completion.chunk"},
@@ -506,7 +577,7 @@ struct WorkQueue {
                                         {"content", ""}
                                     }},
                                     {"logprobs", nullptr},
-                                    {"finish_reason", nullptr},
+                                    {"finish_reason", "stop"},
                                     {"stop_reason", nullptr}
                                 }
                             }},
@@ -516,55 +587,67 @@ struct WorkQueue {
                                 {"completion_tokens", outputTokens}
                             }}
                         };
-
-                        std::string cur = ("data: " + partResult.dump() + "\r\n");
-                        sprintf(chunk_header, "%zx\r\n", cur.size());
-                        ret = write(node->client, chunk_header, strlen(chunk_header));
-                        ret = write(node->client, cur.data(), cur.size());
-                        ret = write(node->client, "\r\n", 2);
+                        if (!WriteHttpChunk(node->client,
+                                            FormatSseData(partResult.dump()))) {
+                            close(node->client);
+                            return;
+                        }
                         break;
-                    } else {
-                        outputTokens++;
-                        results.clear();
-                        results.push_back(result);
-                        std::string now = model->weight.tokenizer.Decode(fastllm::Data (fastllm::DataType::FLOAT32, {(int)results.size()}, results));
-                        json11::Json partResult = json11::Json::object {
-                            {"id", curId},
-                            {"object", "chat.completion.chunk"},
-                            {"created", createTime},
-                            {"model", ::config.modelName},
-                            {"choices", json11::Json::array {
-                                json11::Json::object {
-                                    {"index", 0},
-                                    {"delta", json11::Json::object {
-                                        {"content", now}
-                                    }},
-                                    {"logprobs", nullptr},
-                                    {"finish_reason", nullptr},
-                                    {"stop_reason", nullptr}
-                                }
-                            }}
-                        };
+                    }
 
-                        std::string cur = ("data: " + partResult.dump() + "\r\n");
-                        sprintf(chunk_header, "%zx\r\n", cur.size());
-                        ret = write(node->client, chunk_header, strlen(chunk_header));
-                        ret = write(node->client, cur.data(), cur.size());
-                        ret = write(node->client, "\r\n", 2);
+                    outputTokens++;
+                    results.clear();
+                    results.push_back(result);
+                    std::string now = model->weight.tokenizer.Decode(
+                        fastllm::Data(fastllm::DataType::FLOAT32,
+                                      {(int)results.size()}, results));
+                    std::string filtered;
+                    bool matchedStop = PushStopText(
+                        config.stop_strings, pendingStopText, now, filtered);
+                    now = filtered;
+                    if (matchedStop) {
+                        model->AbortResponse(handleId);
+                    }
+                    if (now.empty()) {
+                        if (matchedStop) {
+                            continue;
+                        }
+                        continue;
+                    }
+                    json11::Json partResult = json11::Json::object {
+                        {"id", curId},
+                        {"object", "chat.completion.chunk"},
+                        {"created", createTime},
+                        {"model", ::config.modelName},
+                        {"choices", json11::Json::array {
+                            json11::Json::object {
+                                {"index", 0},
+                                {"delta", json11::Json::object {
+                                    {"content", now}
+                                }},
+                                {"logprobs", nullptr},
+                                {"finish_reason", nullptr},
+                                {"stop_reason", nullptr}
+                            }
+                        }}
+                    };
+                    if (!WriteHttpChunk(node->client,
+                                        FormatSseData(partResult.dump()))) {
+                        abortDisconnectedStream();
+                        return;
                     }
                 }
 
-                cur = ("data: [DONE]");
-                sprintf(chunk_header, "%zx\r\n", cur.size());
-                ret = write(node->client, chunk_header, strlen(chunk_header));
-                ret = write(node->client, cur.data(), cur.size());
-                ret = write(node->client, "\r\n", 2);
-
-                ret = write(node->client, "0\r\n\r\n", 5);
+                if (!WriteHttpChunk(node->client, FormatSseData("[DONE]"))
+                        || !WriteAllToSocket(node->client, "0\r\n\r\n", 5)) {
+                    close(node->client);
+                    return;
+                }
                 close(node->client);
             } else {
                 int outputTokens = 0;
                 std::vector<float> results;
+                std::string pendingStopText;
                 while (true) {
                     int result = model->FetchResponseTokens(handleId);
                     if (result == -1) {
@@ -572,10 +655,22 @@ struct WorkQueue {
                     } else {
                         results.clear();
                         results.push_back(result);
-                        output += model->weight.tokenizer.Decode(fastllm::Data (fastllm::DataType::FLOAT32, {(int)results.size()}, results));
+                        std::string now = model->weight.tokenizer.Decode(
+                            fastllm::Data(fastllm::DataType::FLOAT32,
+                                          {(int)results.size()}, results));
+                        std::string filtered;
+                        bool matchedStop = PushStopText(
+                            config.stop_strings, pendingStopText, now, filtered);
+                        output += filtered;
                         outputTokens++;
+                        if (matchedStop) {
+                            model->AbortResponse(handleId);
+                        }
                     }
                 }
+                std::string trailingText;
+                FlushPendingStopText(pendingStopText, trailingText);
+                output += trailingText;
 
                 json11::Json result = json11::Json::object {
                     {"id", curId},

--- a/example/apiserver/http_request_reader.h
+++ b/example/apiserver/http_request_reader.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <string>
+
+inline bool IsHttpRequestComplete(const char *buffer, size_t size) {
+    if (buffer == nullptr || size == 0) {
+        return false;
+    }
+
+    const std::string request(buffer, size);
+    const size_t headerEnd = request.find("\r\n\r\n");
+    if (headerEnd == std::string::npos) {
+        return false;
+    }
+
+    size_t contentLength = 0;
+    bool hasContentLength = false;
+    size_t lineStart = request.find("\r\n");
+    if (lineStart == std::string::npos || lineStart >= headerEnd) {
+        return false;
+    }
+    lineStart += 2;
+
+    while (lineStart < headerEnd) {
+        const size_t lineEnd = request.find("\r\n", lineStart);
+        if (lineEnd == std::string::npos || lineEnd > headerEnd) {
+            return false;
+        }
+        const size_t colon = request.find(':', lineStart);
+        if (colon != std::string::npos && colon < lineEnd) {
+            std::string name = request.substr(lineStart, colon - lineStart);
+            for (char &c : name) {
+                c = static_cast<char>(std::tolower(
+                    static_cast<unsigned char>(c)));
+            }
+            if (name == "content-length") {
+                size_t valueStart = colon + 1;
+                while (valueStart < lineEnd &&
+                       std::isspace(static_cast<unsigned char>(request[valueStart]))) {
+                    valueStart++;
+                }
+                if (valueStart == lineEnd) {
+                    return false;
+                }
+                errno = 0;
+                char *valueEnd = nullptr;
+                const char *value = request.c_str() + valueStart;
+                unsigned long long parsed = std::strtoull(value, &valueEnd, 10);
+                if (errno != 0 || valueEnd != request.c_str() + lineEnd ||
+                    parsed > std::numeric_limits<size_t>::max()) {
+                    return false;
+                }
+                contentLength = static_cast<size_t>(parsed);
+                hasContentLength = true;
+            }
+        }
+        lineStart = lineEnd + 2;
+    }
+
+    const size_t bodyStart = headerEnd + 4;
+    return !hasContentLength ||
+           (contentLength <= size - bodyStart);
+}

--- a/example/apiserver/openai_output_parser.h
+++ b/example/apiserver/openai_output_parser.h
@@ -1,0 +1,393 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <map>
+
+#include "json11.hpp"
+#include <vector>
+
+inline std::string ResolveOpenAIFinishReason(bool hasToolCalls,
+                                             bool matchedStop,
+                                             int outputTokens,
+                                             int outputTokenLimit) {
+    if (hasToolCalls) {
+        return "tool_calls";
+    }
+    if (matchedStop) {
+        return "stop";
+    }
+    if (outputTokenLimit > 0 && outputTokens >= outputTokenLimit) {
+        return "length";
+    }
+    return "stop";
+}
+
+struct OpenAIReasoningDelta {
+    std::string reasoningContent;
+    std::string content;
+
+    bool Empty() const {
+        return reasoningContent.empty() && content.empty();
+    }
+};
+
+class OpenAIReasoningParser {
+public:
+    explicit OpenAIReasoningParser(bool inReasoning)
+        : inReasoning(inReasoning) {}
+
+    static bool PromptEndsInReasoning(const std::string &prompt) {
+        const size_t start = prompt.rfind("<think>");
+        if (start == std::string::npos) {
+            return false;
+        }
+        const size_t shortEnd = prompt.rfind("</think>");
+        const size_t longEnd = prompt.rfind("</thinking>");
+        const size_t end = shortEnd == std::string::npos ? longEnd :
+            (longEnd == std::string::npos ? shortEnd :
+             std::max(shortEnd, longEnd));
+        return end == std::string::npos || start > end;
+    }
+
+    OpenAIReasoningDelta Push(const std::string &fragment) {
+        OpenAIReasoningDelta delta;
+        if (fragment.empty()) {
+            return delta;
+        }
+        if (!inReasoning) {
+            delta.content = fragment;
+            return delta;
+        }
+
+        pending += fragment;
+        size_t markerPosition = std::string::npos;
+        size_t markerLength = 0;
+        for (const std::string &marker : EndMarkers()) {
+            const size_t position = pending.find(marker);
+            if (position != std::string::npos &&
+                (markerPosition == std::string::npos ||
+                 position < markerPosition)) {
+                markerPosition = position;
+                markerLength = marker.size();
+            }
+        }
+        if (markerPosition != std::string::npos) {
+            delta.reasoningContent = pending.substr(0, markerPosition);
+            delta.content = pending.substr(markerPosition + markerLength);
+            pending.clear();
+            inReasoning = false;
+            return delta;
+        }
+
+        size_t held = 0;
+        for (const std::string &marker : EndMarkers()) {
+            const size_t maxPrefix = std::min(marker.size() - 1,
+                                              pending.size());
+            for (size_t length = maxPrefix; length > 0; --length) {
+                if (pending.compare(pending.size() - length, length,
+                                    marker, 0, length) == 0) {
+                    held = std::max(held, length);
+                    break;
+                }
+            }
+        }
+        delta.reasoningContent = pending.substr(0, pending.size() - held);
+        pending.erase(0, pending.size() - held);
+        return delta;
+    }
+
+    OpenAIReasoningDelta Flush() {
+        OpenAIReasoningDelta delta;
+        if (inReasoning) {
+            delta.reasoningContent.swap(pending);
+        } else {
+            delta.content.swap(pending);
+        }
+        return delta;
+    }
+
+    bool InReasoning() const {
+        return inReasoning;
+    }
+
+private:
+    static const std::vector<std::string> &EndMarkers() {
+        static const std::vector<std::string> markers = {
+            "</think>", "</thinking>"
+        };
+        return markers;
+    }
+
+    bool inReasoning = false;
+    std::string pending;
+};
+
+struct OpenAIParsedToolCall {
+    std::string name;
+    std::string arguments;
+};
+
+struct OpenAIToolCallDelta {
+    std::string content;
+    std::vector<OpenAIParsedToolCall> toolCalls;
+
+    bool Empty() const {
+        return content.empty() && toolCalls.empty();
+    }
+};
+
+class OpenAIToolCallParser {
+public:
+    explicit OpenAIToolCallParser(bool enabled) : enabled(enabled) {}
+
+    OpenAIToolCallDelta Push(const std::string &fragment) {
+        OpenAIToolCallDelta delta;
+        if (fragment.empty()) {
+            return delta;
+        }
+        if (!enabled) {
+            delta.content = fragment;
+            return delta;
+        }
+
+        pending += fragment;
+        while (true) {
+            if (!inToolCall) {
+                const size_t open = pending.find(OpenMarker());
+                if (open == std::string::npos) {
+                    const size_t held = HeldOpenMarkerPrefix(pending);
+                    delta.content += pending.substr(0, pending.size() - held);
+                    pending.erase(0, pending.size() - held);
+                    return delta;
+                }
+                delta.content += pending.substr(0, open);
+                toolBuffer = pending.substr(open);
+                pending.clear();
+                inToolCall = true;
+            } else if (!pending.empty()) {
+                toolBuffer += pending;
+                pending.clear();
+            }
+
+            const size_t close = toolBuffer.find(CloseMarker());
+            if (close == std::string::npos) {
+                return delta;
+            }
+            const size_t blockEnd = close + CloseMarker().size();
+            const std::string block = toolBuffer.substr(0, blockEnd);
+            OpenAIParsedToolCall parsed;
+            if (ParseBlock(block, parsed)) {
+                delta.toolCalls.push_back(std::move(parsed));
+            } else {
+                delta.content += block;
+            }
+            pending = toolBuffer.substr(blockEnd);
+            toolBuffer.clear();
+            inToolCall = false;
+        }
+    }
+
+    OpenAIToolCallDelta Flush() {
+        OpenAIToolCallDelta delta;
+        if (inToolCall) {
+            delta.content = toolBuffer + pending;
+        } else {
+            delta.content = pending;
+        }
+        pending.clear();
+        toolBuffer.clear();
+        inToolCall = false;
+        return delta;
+    }
+
+private:
+    static const std::string &OpenMarker() {
+        static const std::string marker = "<tool_call>";
+        return marker;
+    }
+
+    static const std::string &CloseMarker() {
+        static const std::string marker = "</tool_call>";
+        return marker;
+    }
+
+    static std::string Trim(const std::string &value) {
+        const size_t first = value.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos) {
+            return "";
+        }
+        const size_t last = value.find_last_not_of(" \t\r\n");
+        return value.substr(first, last - first + 1);
+    }
+
+    static size_t HeldOpenMarkerPrefix(const std::string &value) {
+        const size_t maxPrefix = std::min(OpenMarker().size() - 1,
+                                          value.size());
+        for (size_t length = maxPrefix; length > 0; --length) {
+            if (value.compare(value.size() - length, length,
+                              OpenMarker(), 0, length) == 0) {
+                return length;
+            }
+        }
+        return 0;
+    }
+
+    static json11::Json ParseParameterValue(const std::string &raw) {
+        const std::string value = Trim(raw);
+        std::string error;
+        json11::Json parsed = json11::Json::parse(value, error);
+        if (error.empty()) {
+            return parsed;
+        }
+        return json11::Json(value);
+    }
+
+    static std::string CompactJson(const json11::Json &value) {
+        if (value.is_object()) {
+            std::string result = "{";
+            bool first = true;
+            for (const auto &item : value.object_items()) {
+                if (!first) {
+                    result += ",";
+                }
+                result += json11::Json(item.first).dump();
+                result += ":";
+                result += CompactJson(item.second);
+                first = false;
+            }
+            result += "}";
+            return result;
+        }
+        if (value.is_array()) {
+            std::string result = "[";
+            bool first = true;
+            for (const auto &item : value.array_items()) {
+                if (!first) {
+                    result += ",";
+                }
+                result += CompactJson(item);
+                first = false;
+            }
+            result += "]";
+            return result;
+        }
+        return value.dump();
+    }
+
+    static bool ParseBlock(const std::string &block,
+                           OpenAIParsedToolCall &parsed) {
+        static const std::vector<std::string> functionOpenMarkers = {
+            "<function=", "<fuction="
+        };
+        const std::string functionClose = "</function>";
+        size_t function = std::string::npos;
+        const std::string *functionOpen = nullptr;
+        for (const auto &marker : functionOpenMarkers) {
+            const size_t position = block.find(marker);
+            if (position != std::string::npos &&
+                (function == std::string::npos || position < function)) {
+                function = position;
+                functionOpen = &marker;
+            }
+        }
+        if (function == std::string::npos || functionOpen == nullptr) {
+            return false;
+        }
+        const size_t nameStart = function + functionOpen->size();
+        const size_t nameEnd = block.find('>', nameStart);
+        const size_t bodyEnd = block.find(functionClose, nameEnd);
+        if (nameEnd == std::string::npos || bodyEnd == std::string::npos) {
+            return false;
+        }
+        parsed.name = Trim(block.substr(nameStart, nameEnd - nameStart));
+        if (parsed.name.empty()) {
+            return false;
+        }
+
+        const std::string parameterOpen = "<parameter=";
+        const std::string parameterClose = "</parameter>";
+        std::map<std::string, json11::Json> arguments;
+        size_t cursor = nameEnd + 1;
+        while (true) {
+            const size_t parameter = block.find(parameterOpen, cursor);
+            if (parameter == std::string::npos || parameter >= bodyEnd) {
+                break;
+            }
+            const size_t parameterNameStart = parameter + parameterOpen.size();
+            const size_t parameterNameEnd = block.find('>', parameterNameStart);
+            if (parameterNameEnd == std::string::npos ||
+                parameterNameEnd >= bodyEnd) {
+                return false;
+            }
+            const size_t parameterValueEnd =
+                block.find(parameterClose, parameterNameEnd + 1);
+            if (parameterValueEnd == std::string::npos ||
+                parameterValueEnd > bodyEnd) {
+                return false;
+            }
+            const std::string name = Trim(block.substr(
+                parameterNameStart, parameterNameEnd - parameterNameStart));
+            if (name.empty()) {
+                return false;
+            }
+            arguments[name] = ParseParameterValue(block.substr(
+                parameterNameEnd + 1,
+                parameterValueEnd - parameterNameEnd - 1));
+            cursor = parameterValueEnd + parameterClose.size();
+        }
+        parsed.arguments = CompactJson(json11::Json(arguments));
+        return true;
+    }
+
+    bool enabled = false;
+    bool inToolCall = false;
+    std::string pending;
+    std::string toolBuffer;
+};
+
+struct OpenAIOutputDelta {
+    std::string reasoningContent;
+    std::string content;
+    std::vector<OpenAIParsedToolCall> toolCalls;
+
+    bool Empty() const {
+        return reasoningContent.empty() && content.empty() && toolCalls.empty();
+    }
+};
+
+class OpenAIOutputParser {
+public:
+    OpenAIOutputParser(bool inReasoning, bool toolsEnabled)
+        : reasoningParser(inReasoning), toolCallParser(toolsEnabled) {}
+
+    OpenAIOutputDelta Push(const std::string &fragment) {
+        OpenAIOutputDelta output;
+        OpenAIReasoningDelta reasoning = reasoningParser.Push(fragment);
+        output.reasoningContent = std::move(reasoning.reasoningContent);
+        OpenAIToolCallDelta tools = toolCallParser.Push(reasoning.content);
+        output.content = std::move(tools.content);
+        output.toolCalls = std::move(tools.toolCalls);
+        return output;
+    }
+
+    OpenAIOutputDelta Flush() {
+        OpenAIOutputDelta output;
+        OpenAIReasoningDelta reasoning = reasoningParser.Flush();
+        output.reasoningContent = std::move(reasoning.reasoningContent);
+        OpenAIToolCallDelta tools = toolCallParser.Push(reasoning.content);
+        output.content = std::move(tools.content);
+        output.toolCalls = std::move(tools.toolCalls);
+        OpenAIToolCallDelta trailing = toolCallParser.Flush();
+        output.content += trailing.content;
+        output.toolCalls.insert(output.toolCalls.end(),
+                                trailing.toolCalls.begin(),
+                                trailing.toolCalls.end());
+        return output;
+    }
+
+private:
+    OpenAIReasoningParser reasoningParser;
+    OpenAIToolCallParser toolCallParser;
+};

--- a/example/apiserver/socket_writer.h
+++ b/example/apiserver/socket_writer.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cerrno>
+#include <cstdio>
+#include <string>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
+
+inline bool WriteAllToSocket(int socket, const char *data, size_t size) {
+    size_t written = 0;
+    while (written < size) {
+#ifdef _WIN32
+        int ret = send(socket, data + written,
+                       static_cast<int>(size - written), 0);
+        if (ret == SOCKET_ERROR) {
+            return false;
+        }
+#else
+        int flags = 0;
+#ifdef MSG_NOSIGNAL
+        flags |= MSG_NOSIGNAL;
+#endif
+        ssize_t ret = send(socket, data + written, size - written, flags);
+        if (ret < 0 && errno == EINTR) {
+            continue;
+        }
+        if (ret < 0) {
+            return false;
+        }
+#endif
+        if (ret == 0) {
+            return false;
+        }
+        written += static_cast<size_t>(ret);
+    }
+    return true;
+}
+
+inline bool WriteAllToSocket(int socket, const std::string &data) {
+    return WriteAllToSocket(socket, data.data(), data.size());
+}
+
+
+inline std::string FormatSseData(const std::string &payload) {
+    std::string event;
+    size_t lineStart = 0;
+    while (true) {
+        size_t lineEnd = payload.find('\n', lineStart);
+        event += "data: ";
+        event.append(payload, lineStart,
+                     lineEnd == std::string::npos
+                         ? std::string::npos
+                         : lineEnd - lineStart);
+        event += "\r\n";
+        if (lineEnd == std::string::npos) {
+            break;
+        }
+        lineStart = lineEnd + 1;
+    }
+    event += "\r\n";
+    return event;
+}
+
+inline bool WriteHttpChunk(int socket, const std::string &payload) {
+    char header[32];
+    int headerLength = std::snprintf(header, sizeof(header), "%zx\r\n",
+                                     payload.size());
+    return headerLength > 0
+        && WriteAllToSocket(socket, header, static_cast<size_t>(headerLength))
+        && WriteAllToSocket(socket, payload)
+        && WriteAllToSocket(socket, "\r\n", 2);
+}

--- a/example/apiserver/stop_parser.h
+++ b/example/apiserver/stop_parser.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "json11.hpp"
+
+struct OpenAIStopEncoding {
+    int exactTokenId = -1;
+    std::vector<int> tokenSequence;
+};
+
+template <typename ExactTokenLookup, typename FallbackEncode>
+inline OpenAIStopEncoding EncodeOpenAIStop(
+        const std::string &stop,
+        ExactTokenLookup exactTokenLookup,
+        FallbackEncode fallbackEncode) {
+    OpenAIStopEncoding encoding;
+    exactTokenLookup(stop, encoding.exactTokenId);
+    encoding.tokenSequence = fallbackEncode(stop);
+    return encoding;
+}
+
+template <typename EncodeStop>
+inline bool ParseOpenAIStop(
+        const json11::Json &stop,
+        EncodeStop encodeStop,
+        std::multiset<int> &stopTokenIds,
+        std::vector<std::vector<int>> &stopTokenSequences,
+        std::vector<std::string> &parsedStopStrings,
+        std::string &error) {
+    error.clear();
+    if (stop.is_null()) {
+        return true;
+    }
+
+    std::vector<std::string> stopStrings;
+    if (stop.is_string()) {
+        stopStrings.push_back(stop.string_value());
+    } else if (stop.is_array()) {
+        for (const auto &item : stop.array_items()) {
+            if (!item.is_string()) {
+                error = "stop must be a string or an array of strings";
+                return false;
+            }
+            stopStrings.push_back(item.string_value());
+        }
+    } else {
+        error = "stop must be a string or an array of strings";
+        return false;
+    }
+
+    std::set<int> parsedTokenIds;
+    std::set<std::vector<int>> parsedTokenSequences;
+    std::set<std::string> uniqueStopStrings;
+    for (const auto &stopString : stopStrings) {
+        if (stopString.empty()) {
+            error = "stop strings must not be empty";
+            return false;
+        }
+        uniqueStopStrings.insert(stopString);
+        const OpenAIStopEncoding encoding = encodeStop(stopString);
+        if (encoding.exactTokenId >= 0) {
+            parsedTokenIds.insert(encoding.exactTokenId);
+        }
+        if (encoding.tokenSequence.size() == 1) {
+            parsedTokenIds.insert(encoding.tokenSequence.front());
+        } else if (encoding.tokenSequence.size() > 1) {
+            parsedTokenSequences.insert(encoding.tokenSequence);
+        }
+        if (encoding.exactTokenId < 0 && encoding.tokenSequence.empty()) {
+            error = "each stop string must encode to at least one token";
+            return false;
+        }
+    }
+
+    stopTokenIds.insert(parsedTokenIds.begin(), parsedTokenIds.end());
+    stopTokenSequences.insert(stopTokenSequences.end(),
+                              parsedTokenSequences.begin(),
+                              parsedTokenSequences.end());
+    parsedStopStrings.insert(parsedStopStrings.end(),
+                             uniqueStopStrings.begin(),
+                             uniqueStopStrings.end());
+    return true;
+}

--- a/include/devices/cuda/attention/fastllm-paged-attention-native.cuh
+++ b/include/devices/cuda/attention/fastllm-paged-attention-native.cuh
@@ -18,3 +18,10 @@ bool FastllmCudaTrySm70PagedAttentionDecode(
     fastllm::Data &qSizes, fastllm::Data &pageSizes, fastllm::Data &pageIndexs,
     fastllm::Data &lastPageLens, fastllm::Data &output,
     int group, float scale, int attentionType);
+
+// V100 causal prefill specialization transplanted from the SM70 Volta BM32 path.
+bool FastllmCudaTrySm70FlashAttentionPrefill(
+    fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches,
+    fastllm::Data &qSizes, fastllm::Data &pageSizes,
+    fastllm::Data &pageIndexs, fastllm::Data &lastPageLens,
+    fastllm::Data &output, int group, float scale, int attentionType);

--- a/include/devices/cuda/attention/fastllm-paged-attention-native.cuh
+++ b/include/devices/cuda/attention/fastllm-paged-attention-native.cuh
@@ -10,3 +10,11 @@ bool FastllmCudaHalfPagedAttentionBatchFastllmFallback(
     fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches,
     fastllm::Data &qSizes, fastllm::Data &pageSizes, fastllm::Data &pageIndexs,
     fastllm::Data &lastPageLens, fastllm::Data &output, int group, float scale);
+
+// V100 decode specialization for Qwen3.5's FP16 page128 Q24/KV4 D256 GQA6 layout.
+// Enabled by default for the exact shape; FASTLLM_CUDA_SM70_PAGED_XQA=0 disables it.
+bool FastllmCudaTrySm70PagedAttentionDecode(
+    fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches,
+    fastllm::Data &qSizes, fastllm::Data &pageSizes, fastllm::Data &pageIndexs,
+    fastllm::Data &lastPageLens, fastllm::Data &output,
+    int group, float scale, int attentionType);

--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -283,6 +283,19 @@ void FastllmCudaPagedCacheCopyBatch(uint8_t *pagedData, int32_t *pageIdxArray, i
                                     int pageLen, int batch, int numHeads, int headDim,
                                     fastllm::DataType dstType, uint8_t *inputData, fastllm::DataType srcType,
                                     bool sync = true);
+bool FastllmCudaPackedKVCacheCopy(uint8_t *pagedData, int pageIdx, int pageLen,
+                                  int numHeads, int headDim, fastllm::DataType dstType,
+                                  uint8_t *inputData, fastllm::DataType srcType,
+                                  int seqLen, int inputOffset, int copyLen, int pageOffset);
+bool FastllmCudaPackedKVCacheCopyBatch(uint8_t *pagedData, int32_t *pageIdxArray,
+                                       int32_t *pageOffsetArray, int pageLen, int batch,
+                                       int numHeads, int headDim, fastllm::DataType dstType,
+                                       uint8_t *inputData, fastllm::DataType srcType,
+                                       bool sync = true);
+bool FastllmCudaPackedKVCacheGatherHeadRangeToHalf(
+        const uint8_t *pagedData, fastllm::DataType srcType,
+        const int32_t *pageIndices, int kvStart, int chunkLen,
+        int pageLen, int numHeads, int headDim, int head, void *output);
 
 bool FastllmFloatToHalf(void *a, void *b, int len);
 bool FastllmHalfToFloat(void *a, void *b, int len);

--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -524,6 +524,23 @@ bool FastllmCudaMatMulBFloat16(const fastllm::Data &input, fastllm::Data &weight
 bool FastllmCudaMatMulFloatFP8E4M3(const fastllm::Data &input, fastllm::Data &weight, const fastllm::Data &bias, fastllm::Data &output, int n, int m, int k);
 bool FastllmCudaQuantizeLinearWeightFP8E4M3Block128(
     const fastllm::Data &input, fastllm::Data &output);
+// SM70 (V100) IQ4_XS DP4A matrix-multiply-quantized trial path.
+// Eligibility: SM70 device only, GGML_TYPE_IQ4_XS weights, n in [8,64],
+// m % 256 == 0, supported activation/output dtype.  Returns false (leaving
+// output untouched) on any unsupported case or launch failure; the caller
+// must preserve a dequant+cuBLAS / MMVQ fallback.  Env gate:
+// FASTLLM_CUDA_SM70_IQ4XS_MMQ=0 disables.
+#ifdef USE_ROCM
+inline bool FastllmCudaSm70Iq4XsMmqSupported() { return false; }
+inline bool FastllmCudaTrySm70Iq4XsMmq(const void *, const void *, void *,
+                                       fastllm::DataType, int, int, int,
+                                       void * = nullptr) { return false; }
+#else
+bool FastllmCudaSm70Iq4XsMmqSupported();
+bool FastllmCudaTrySm70Iq4XsMmq(const void *weight, const void *input,
+                                void *output, fastllm::DataType dataType,
+                                int n, int m, int k, void *stream = nullptr);
+#endif
 bool FastllmCudaMatMulFloatGGUF(const fastllm::Data &input, fastllm::Data &weight, const fastllm::Data &bias, fastllm::Data &output, int n, int m, int k);
 bool FastllmCudaFloatMergeMOEGGUFBatch1(const fastllm::Data &input, fastllm::Data &w1, fastllm::Data &output,
                                         fastllm::Data **gateups, fastllm::Data **downs, const float *scores,
@@ -907,14 +924,14 @@ void FastllmResetLogitsOfEOSAll(int batch, fastllm::Data *logits, const std::vec
 void FastllmRecurrentGatedDeltaRule(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float qScale = 1.0f);
 bool FastllmLinearAttentionStateTransposeKVToVKFloat16(fastllm::Data &last_recurrent_state);
 bool FastllmLinearAttentionStateTransposeVKToKVFloat16(fastllm::Data &last_recurrent_state);
-bool FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale = 1.0f);
-bool FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &a, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &aLog, fastllm::Data &dtBias, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale = 1.0f);
+bool FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
+bool FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &a, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &aLog, fastllm::Data &dtBias, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 // Benchmark/validation entry for the single-token transposed recurrent kernel.
 bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16WithConfig(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
@@ -927,14 +944,14 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     fastllm::Data **tokenStates, int numTokenStates,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16BatchSnapshots(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
@@ -942,7 +959,7 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16BatchSnaps
     fastllm::Data &coreAttnOut,
     const std::vector<fastllm::Data*> &tokenStates, int numTokenStates,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 void FastllmRecurrentGatedDeltaRuleBatch(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, std::vector<fastllm::Data*> &last_recurrent_states, fastllm::Data &core_attn_out, float qScale = 1.0f);
 bool FastllmRecurrentGatedDeltaRuleBatchDevicePointers(
     fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b,
@@ -953,34 +970,34 @@ void FastllmRecurrentGatedDeltaRuleBatchFromConvBa(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     std::vector<fastllm::Data*> &last_recurrent_states, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposed(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     std::vector<fastllm::Data*> &last_recurrent_states, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaDevicePointers(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &first_recurrent_state, void *cudaStatePointers, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedDevicePointers(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &first_recurrent_state, void *cudaStatePointers, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedSlots(
     fastllm::Data &convOutput, fastllm::Data &ba, fastllm::Data &normWeight,
     fastllm::Data &aLog, fastllm::Data &dtBias,
     void *cudaStatePool, void *cudaSlotIds, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale = 1.0f);
+    float eps, float qScale = 1.0f, bool tiledQKHeadOrder = false);
 void FastllmChunkGatedDeltaRulePrefill(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v,
     fastllm::Data &g, fastllm::Data &attn, fastllm::Data &k_cumdecay,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out);

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -308,6 +308,8 @@ namespace fastllm {
         BASE3_GROUP = 12, // 三元量化，-1 0 1
         INT32 = 13, // int32
         NVFP4 = 14, // packed fp4 e2m1 + compact e8m0 block scales
+        Q8_0_KV = 15, // KV cache: one fp16 scale + 32 int8 values per 32-value block
+        TURBO3_KV = 16, // TurboQuant KV: fp16 norm + packed 3-bit indices per 128-value block
         INT32PARAM = 100, // int32的参数，这种类型的数据永远存在CPU上
         FP8_E4M3_BLOCK_128 = 1000, // fp8e4m3, block = 128
         AWQ_4BIT_128 = 1001, // awq, bits = 4, group = 128
@@ -332,6 +334,8 @@ namespace fastllm {
     std::string GetDataTypeName(DataType type);
 
     size_t GetDataBytes(DataType type, size_t rows, size_t columns);
+    bool IsPackedKVCacheDataType(DataType type);
+    size_t GetKVCacheRowBytes(DataType type, size_t columns);
     constexpr size_t INT4_GROUP32_GROUP_SIZE = 32;
     constexpr size_t INT4_GROUP32_PACKED_BYTES = 16;
     constexpr size_t INT4_GROUP32_BLOCK_GROUPS = 4;

--- a/include/fastllm.h
+++ b/include/fastllm.h
@@ -163,6 +163,8 @@ namespace fastllm {
         bool enable_hash_id = false; // 给会话添加hash id
         bool add_special_tokens = true; // prompt添加special tokens（chatglm模型生效）
         std::multiset <int> stop_token_ids;
+        std::vector<std::vector<int>> stop_token_sequences;
+        std::vector<std::string> stop_strings;
         bool tool_call_name_constraint_enabled = false;
         std::vector <std::string> tool_call_allowed_names;
         std::vector <std::string> tool_call_invoke_name_prefixes;

--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -29,6 +29,24 @@ namespace fastllm {
     };
 
     class basellm;
+    struct Qwen35LongPrefillProgress {
+        bool inProgress = false;
+        int total = 0;
+        int cursor = 0;
+        bool mtpViable = true;
+        uint64_t ticket = 0;
+        std::map<PagedCacheManager*, int> reservedPages;
+
+        void Reset() {
+            inProgress = false;
+            total = 0;
+            cursor = 0;
+            mtpViable = true;
+            ticket = 0;
+            reservedPages.clear();
+        }
+    };
+
 
     struct ResponseContext {
         bool isEnding = false; // 代表这个请求已经处理完成了，不需要再forward了，但生成的token可能还没有被fetch
@@ -53,6 +71,7 @@ namespace fastllm {
         std::map <std::string, int> intParams;
 
         int cacheLen = 0;
+        Qwen35LongPrefillProgress longPrefill;
 
         ~ResponseContext();
 

--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -168,6 +168,8 @@ namespace fastllm {
         std::map<std::string, std::vector<Data*>> dataPtrVectorMap;
     };
 
+    DataType ParseKVCacheDataType(const std::string &value);
+
     class basellm {
     public:
         basellm() {};
@@ -410,6 +412,8 @@ namespace fastllm {
         // per-request chunks for recurrent-state snapshots while retaining a
         // larger aggregate batching limit.
         virtual int GetBatchedPrefillTokenLimit();
+
+        virtual void SetTokenLimit(int tokens);
 
         virtual void SetDataType(DataType dataType);
 

--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -44,6 +44,8 @@ namespace fastllm {
         LastTokensUnit tokens;
         ResponseContextError error = ResponseContextErrorNone;
         std::string toolCallConstraintGeneratedText;
+        std::vector<int> pendingStopTokens;
+        std::string pendingStopText;
 
         int preTokens = 0;
         int curTokens = 0;

--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -75,7 +75,7 @@ namespace fastllm {
 
         ~ResponseContext();
 
-        void Init(int blocks, DataType dataType, DataType kvCacheDataType);
+        void Init(basellm *model);
         void TryRecord(basellm *model);
         void TryRecordPagedCache(basellm *model);
     };
@@ -397,6 +397,10 @@ namespace fastllm {
 
         virtual PagedCacheManager* GetPagedKVCacheManager(int layerIndex, bool isKey) const;
         virtual std::vector<std::pair<int, PagedCacheManager*> > GetPagedKVCacheManagers(int layerIndex, bool isKey) const;
+        virtual std::pair<DataType, DataType> GetKVCacheDataTypes(int layerIndex) const {
+            (void)layerIndex;
+            return {this->kvCacheDataType, this->kvCacheDataType};
+        }
         virtual bool TryRecordPagedPrefixCacheExtra(ResponseContext *context);
         virtual int QueryPagedPrefixCacheExtra(ResponseContext *context, int maxCachedLen) const;
         virtual bool RestorePagedPrefixCacheExtra(ResponseContext *context, int cachedLen) const;

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -39,6 +39,11 @@ namespace fastllm {
             const WeightMap &weight,
             const std::string &layerPrefix);
 
+    int SelectQwen35DecodeTokensForPageBudget(
+            int requestedTokens,
+            const std::vector<std::pair<int, int> > &requestedNeedsAndFree,
+            const std::vector<std::pair<int, int> > &singleNeedsAndFree);
+
 #ifdef USE_CUDA
     using Qwen35DivisionScheme =
         std::map<int, std::vector<std::pair<int, int> > >;

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -16,6 +16,8 @@
 #include <set>
 #include <unordered_map>
 #include <vector>
+#include <tuple>
+
 
 namespace fastllm {
     enum class Qwen35GdnProjectionLayout {
@@ -43,6 +45,55 @@ namespace fastllm {
             int requestedTokens,
             const std::vector<std::pair<int, int> > &requestedNeedsAndFree,
             const std::vector<std::pair<int, int> > &singleNeedsAndFree);
+
+    enum class Qwen35RequestPhase {
+        NewPrefill,
+        ContinuedPrefill,
+        Decode
+    };
+
+    struct Qwen35LongPrefillQuantum {
+        int cursor = 0;
+        int length = 0;
+        int baseTokens = 0;
+        bool isLast = false;
+        bool producesOutput = false;
+    };
+
+    struct Qwen35PageReservationBudget {
+        int reserved = 0;
+        int needed = 0;
+        int free = 0;
+    };
+
+    bool Qwen35InterleaveLongPrefillEnabled();
+    bool Qwen35BatchedMtpEnabled();
+
+    Qwen35RequestPhase ClassifyQwen35RequestPhase(const ResponseContext &context);
+
+    bool BeginQwen35LongPrefill(
+            ResponseContext &context,
+            int total,
+            uint64_t ticket,
+            const std::map<PagedCacheManager*, int> &reservedPages = {});
+
+    Qwen35LongPrefillQuantum PlanQwen35LongPrefillQuantum(
+            const ResponseContext &context,
+            int chunkSize);
+
+    bool CommitQwen35LongPrefillQuantum(
+            ResponseContext &context,
+            const Qwen35LongPrefillQuantum &quantum,
+            bool mtpViable);
+
+    int SelectQwen35LongPrefillHandle(
+            const std::vector<std::tuple<int, uint64_t> > &candidates,
+            uint64_t lastTicket);
+
+    bool CanAdmitQwen35LongPrefill(int residentRequests, int schedulerLanes);
+
+    bool CanReserveQwen35LongPrefillPages(
+            const std::vector<Qwen35PageReservationBudget> &budgets);
 
 #ifdef USE_CUDA
     using Qwen35DivisionScheme =

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -68,6 +68,10 @@ namespace fastllm {
 
     bool Qwen35InterleaveLongPrefillEnabled();
     bool Qwen35BatchedMtpEnabled();
+    bool Qwen35Turbo3KvEnabled();
+    DataType ResolveQwen35CudaCacheType(DataType cacheType, DataType computeType);
+    size_t Qwen35PagedCachePageBytes(
+            DataType type, int pageLen, int numHeads, int headDim);
 
     Qwen35RequestPhase ClassifyQwen35RequestPhase(const ResponseContext &context);
 
@@ -188,6 +192,8 @@ namespace fastllm {
 
         virtual PagedCacheManager* GetPagedKVCacheManager(int layerIndex, bool isKey) const override;
         virtual std::vector<std::pair<int, PagedCacheManager*> > GetPagedKVCacheManagers(int layerIndex, bool isKey) const override;
+        virtual std::pair<DataType, DataType> GetKVCacheDataTypes(int layerIndex) const override;
+        virtual void SetKVCacheDataType(DataType dataType) override;
         virtual bool TryRecordPagedPrefixCacheExtra(ResponseContext *context) override;
         virtual int QueryPagedPrefixCacheExtra(ResponseContext *context, int maxCachedLen) const override;
         virtual bool RestorePagedPrefixCacheExtra(ResponseContext *context, int cachedLen) const override;

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -18,6 +18,38 @@
 #include <vector>
 
 namespace fastllm {
+    enum class Qwen35GdnProjectionLayout {
+        Missing,
+        Qkvzba,
+        QkvzBa,
+        QkvZBa
+    };
+
+    Qwen35GdnProjectionLayout ResolveQwen35GdnProjectionLayout(
+            const WeightMap &weight,
+            const std::string &layerPrefix);
+
+    enum class Qwen35AttentionProjectionLayout {
+        Missing,
+        MergedQkv,
+        SplitQkv
+    };
+
+    Qwen35AttentionProjectionLayout ResolveQwen35AttentionProjectionLayout(
+            const WeightMap &weight,
+            const std::string &layerPrefix);
+
+#ifdef USE_CUDA
+    using Qwen35DivisionScheme =
+        std::map<int, std::vector<std::pair<int, int> > >;
+    Qwen35DivisionScheme BuildQwen35LinearOutProjScheme(
+            const Qwen35DivisionScheme &keyHeadScheme,
+            int numKHeads,
+            int numVHeads,
+            int headVDim,
+            int quantBlock,
+            bool tiledColumns);
+#endif
     class Qwen3_5Model: public basellm {
     public:
     Qwen3_5Model (); // 构造函数
@@ -135,6 +167,7 @@ namespace fastllm {
     protected:
         bool IsThreadTensorParallelEnabled() const;
 
+
         std::vector <int> ForwardGPUWithHiddenStates(
                 int batch,
                 const Data &inputIds,
@@ -212,6 +245,8 @@ namespace fastllm {
         bool mergeSwiglu = false;
 
         bool initialized_add1 = false;
+        bool ggufNormsPreOffset = false;      // converter already +1'd norms
+        bool ggufOutProjColumnsTiled = false;  // out_proj columns stay tiled (runtime activation reorder)
 
         int num_k_heads, num_v_heads, head_k_dim, head_v_dim;
         int mtp_num_hidden_layers = 0;
@@ -241,8 +276,8 @@ namespace fastllm {
         std::atomic<bool> mtpLogPrinted{false};
         std::atomic<bool> mtpSkipLogPrinted{false};
         std::atomic<long long> mtpValidationCount{0};
-        std::array<std::atomic<long long>, 8> mtpDraftPositionAttempts{};
-        std::array<std::atomic<long long>, 8> mtpDraftPositionAccepts{};
+        std::array<std::atomic<long long>, 9> mtpDraftPositionAttempts{};
+        std::array<std::atomic<long long>, 9> mtpDraftPositionAccepts{};
 
         Data inv_scale_data;
 

--- a/include/models/qwen3_cuda_common.h
+++ b/include/models/qwen3_cuda_common.h
@@ -674,6 +674,23 @@ namespace fastllm {
                             {"cache", &cache}, {"input", &input}},
                    FloatDict(), IntDict());
     }
+    inline void Qwen3CudaAppendPagedCacheBatch(
+            Qwen3CudaDirectRunner &runner,
+            PagedCacheManager &pagedCacheManager,
+            const std::vector<Data*> &currentCaches,
+            Data &input,
+            Data &insertIndexs,
+            Data &insertPositions) {
+        runner.Run("AppendPagedCacheBatch",
+                   DataDict{{"pagedCacheManager", (Data*)&pagedCacheManager},
+                            {"currentCaches", (Data*)currentCaches.data()},
+                            {"input", &input},
+                            {"insertIndexs", &insertIndexs},
+                            {"insertPositions", &insertPositions}},
+                   FloatDict(),
+                   IntDict{{"currentCaches___batch", (int)currentCaches.size()}});
+    }
+
 
     inline void Qwen3CudaGenerateAppendPagedCacheBatchParams(
             Qwen3CudaDirectRunner &runner,

--- a/include/utils/stop_string_matcher.h
+++ b/include/utils/stop_string_matcher.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+inline bool PushStopText(const std::vector<std::string> &stopStrings,
+                         std::string &pendingText,
+                         const std::string &text,
+                         std::string &readyText) {
+    readyText.clear();
+    pendingText += text;
+
+    size_t matchPos = std::string::npos;
+    for (const auto &stop : stopStrings) {
+        if (stop.empty()) {
+            continue;
+        }
+        size_t pos = pendingText.find(stop);
+        if (pos != std::string::npos &&
+            (matchPos == std::string::npos || pos < matchPos)) {
+            matchPos = pos;
+        }
+    }
+    if (matchPos != std::string::npos) {
+        readyText = pendingText.substr(0, matchPos);
+        pendingText.clear();
+        return true;
+    }
+
+    size_t keepLength = 0;
+    for (const auto &stop : stopStrings) {
+        size_t candidateLength = std::min(stop.size(), pendingText.size());
+        while (candidateLength > keepLength) {
+            if (pendingText.compare(pendingText.size() - candidateLength,
+                                    candidateLength, stop, 0,
+                                    candidateLength) == 0) {
+                keepLength = candidateLength;
+                break;
+            }
+            candidateLength--;
+        }
+    }
+
+    readyText = pendingText.substr(0, pendingText.size() - keepLength);
+    pendingText.erase(0, pendingText.size() - keepLength);
+    return false;
+}
+
+inline void FlushPendingStopText(std::string &pendingText,
+                                 std::string &readyText) {
+    readyText = pendingText;
+    pendingText.clear();
+}

--- a/include/utils/stop_token_matcher.h
+++ b/include/utils/stop_token_matcher.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+inline int PushStopToken(const std::vector<std::vector<int>> &stopSequences,
+                         std::vector<int> &pendingTokens,
+                         int token,
+                         std::vector<int> &readyTokens) {
+    readyTokens.clear();
+    pendingTokens.push_back(token);
+
+    size_t matchedLength = 0;
+    for (const auto &sequence : stopSequences) {
+        if (sequence.empty() || sequence.size() > pendingTokens.size()) {
+            continue;
+        }
+        auto suffix = pendingTokens.end() - sequence.size();
+        if (std::equal(sequence.begin(), sequence.end(), suffix) &&
+            sequence.size() > matchedLength) {
+            matchedLength = sequence.size();
+        }
+    }
+    if (matchedLength > 0) {
+        readyTokens.insert(readyTokens.end(), pendingTokens.begin(),
+                           pendingTokens.end() - matchedLength);
+        pendingTokens.clear();
+        return static_cast<int>(matchedLength);
+    }
+
+    size_t keepLength = 0;
+    for (const auto &sequence : stopSequences) {
+        size_t candidateLength = std::min(sequence.size(), pendingTokens.size());
+        while (candidateLength > keepLength) {
+            auto suffix = pendingTokens.end() - candidateLength;
+            if (std::equal(suffix, pendingTokens.end(), sequence.begin())) {
+                keepLength = candidateLength;
+                break;
+            }
+            candidateLength--;
+        }
+    }
+
+    readyTokens.insert(readyTokens.end(), pendingTokens.begin(),
+                       pendingTokens.end() - keepLength);
+    if (keepLength == 0) {
+        pendingTokens.clear();
+    } else {
+        pendingTokens.erase(pendingTokens.begin(),
+                            pendingTokens.end() - keepLength);
+    }
+    return 0;
+}
+
+inline void FlushPendingStopTokens(std::vector<int> &pendingTokens,
+                                   std::vector<int> &readyTokens) {
+    readyTokens = pendingTokens;
+    pendingTokens.clear();
+}
+
+template <typename EmitToken>
+inline void FlushPendingStopTokensTo(
+        std::vector<int> &pendingTokens,
+        EmitToken emitToken) {
+    for (int token : pendingTokens) {
+        emitToken(token);
+    }
+    pendingTokens.clear();
+}

--- a/src/devices/cpu/cpudevice.cpp
+++ b/src/devices/cpu/cpudevice.cpp
@@ -4687,11 +4687,19 @@ ops += (long long)lines * inputDim * interDim * 2;
         }
 
         int unitSize = weight.unitSize;
-        if (GetLowMemMode()) {
+        AssertInFastLLM(vocabSize > 0 && embSize > 0,
+                        "EmbeddingDirect error: invalid weight dims ["
+                        + std::to_string(vocabSize) + ", " + std::to_string(embSize) + "].\n");
+        if (GetLowMemMode() && !weight.fileName.empty()) {
             FILE *fi = fopen(weight.fileName.c_str(), "rb");
+            AssertInFastLLM(fi != nullptr,
+                            "EmbeddingDirect error: can't open weight file " + weight.fileName + ".\n");
             uint8_t *outputData = (uint8_t *) output.cpuData;
             for (int i = 0; i < inputLen; i++) {
                 int token = (int) (inputData[i] + 1e-9);
+                AssertInFastLLM(token >= 0 && token < vocabSize,
+                                "EmbeddingDirect error: token " + std::to_string(token)
+                                + " out of range [0, " + std::to_string(vocabSize) + ").\n");
 #if defined(_WIN32) or defined(_WIN64)
                 _fseeki64(fi, (long long)token * embSize * unitSize + weight.filePos, 0);
 #else
@@ -4701,10 +4709,18 @@ ops += (long long)lines * inputDim * interDim * 2;
             }
             fclose(fi);
         } else {
+            AssertInFastLLM(weight.cpuData != nullptr,
+                            "EmbeddingDirect error: in-memory weight has null cpuData"
+                            " (dims = [" + std::to_string(vocabSize) + ", "
+                            + std::to_string(embSize) + "], fileName = \""
+                            + weight.fileName + "\").\n");
             uint8_t *outputData = (uint8_t *) output.cpuData;
             uint8_t *weightData = (uint8_t *) weight.cpuData;
             for (int i = 0; i < inputLen; i++) {
                 int token = (int) (inputData[i] + 1e-9);
+                AssertInFastLLM(token >= 0 && token < vocabSize,
+                                "EmbeddingDirect error: token " + std::to_string(token)
+                                + " out of range [0, " + std::to_string(vocabSize) + ").\n");
                 memcpy(outputData + (uint64_t)i * embSize * unitSize, weightData + (uint64_t)token * embSize * unitSize, (uint64_t)embSize * unitSize);
             }
         }

--- a/src/devices/cuda/attention/fastllm-attention.cu
+++ b/src/devices/cuda/attention/fastllm-attention.cu
@@ -1882,6 +1882,14 @@ void FastllmCudaPagedCacheCopy(
     int inputOffset,
     int copyLen,
     int pageOffset) {
+    if (fastllm::IsPackedKVCacheDataType(dstType)) {
+        if (!FastllmCudaPackedKVCacheCopy(
+                pagedData, pageIdx, pageLen, numHeads, headDim, dstType,
+                inputData, srcType, seqLen, inputOffset, copyLen, pageOffset)) {
+            fastllm::ErrorInFastLLM("FastllmCudaPagedCacheCopy: packed KV cache copy failed.\n");
+        }
+        return;
+    }
     if (srcType == fastllm::DataType::FLOAT32) {
         if (dstType == fastllm::DataType::FLOAT32) {
             FastllmCudaPagedCacheCopyTyped<float, float>(pagedData, pageIdx, pageLen, numHeads, headDim,
@@ -2024,6 +2032,14 @@ void FastllmCudaPagedCacheCopyBatch(
     uint8_t *inputData,
     fastllm::DataType srcType,
     bool sync) {
+    if (fastllm::IsPackedKVCacheDataType(dstType)) {
+        if (!FastllmCudaPackedKVCacheCopyBatch(
+                pagedData, pageIdxArray, pageOffsetArray, pageLen, batch,
+                numHeads, headDim, dstType, inputData, srcType, sync)) {
+            fastllm::ErrorInFastLLM("FastllmCudaPagedCacheCopyBatch: packed KV cache copy failed.\n");
+        }
+        return;
+    }
     if (srcType == fastllm::DataType::FLOAT32) {
         if (dstType == fastllm::DataType::FLOAT32) {
             FastllmCudaPagedCacheCopyBatchTyped<float, float>(pagedData, pageIdxArray, pageOffsetArray,
@@ -2370,6 +2386,11 @@ bool FastllmCudaHalfPagedAttention(fastllm::Data &q, fastllm::Data &k, fastllm::
     if (pagedKVCacheK == nullptr || pagedKVCacheV == nullptr) {
         printf("DoCudaAttentionPaged: pagedKVCacheData is nullptr\n");
         exit(0);
+    }
+    if (fastllm::IsPackedKVCacheDataType(pagedKVCacheK->dataType) ||
+        fastllm::IsPackedKVCacheDataType(pagedKVCacheV->dataType)) {
+        return FastllmCudaHalfPagedAttentionFastllmFallback(
+            q, k, v, output, group, scale);
     }
     
     int pageLen = k.pageLen;

--- a/src/devices/cuda/attention/fastllm-attention.cu
+++ b/src/devices/cuda/attention/fastllm-attention.cu
@@ -2602,6 +2602,14 @@ bool FastllmCudaHalfPagedAttention(fastllm::Data &q, fastllm::Data &k, fastllm::
 }
 
 bool FastllmCudaHalfPagedAttentionBatch(fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches, fastllm::Data &qSizes, fastllm::Data &pageSizes, fastllm::Data &pageIndexs, fastllm::Data &lastPageLens, fastllm::Data &output, int group, float scale, int attentionType, bool inited, bool sync, bool enableCudaGraph, int flashInferCudaGraph) {
+    if (FastllmCudaTrySm70PagedAttentionDecode(
+            q, kCaches, vCaches, qSizes, pageSizes, pageIndexs, lastPageLens,
+            output, group, scale, attentionType)) {
+        if (sync) {
+            FastllmCudaSyncCurrentThreadStream();
+        }
+        return true;
+    }
 #ifndef FASTLLM_ENABLE_FLASHINFER
     bool ok = FastllmCudaHalfPagedAttentionBatchFastllmFallback(
         q, kCaches, vCaches, qSizes, pageSizes, pageIndexs, lastPageLens, output, group, scale);

--- a/src/devices/cuda/attention/fastllm-attention.cu
+++ b/src/devices/cuda/attention/fastllm-attention.cu
@@ -2610,6 +2610,14 @@ bool FastllmCudaHalfPagedAttentionBatch(fastllm::Data &q, fastllm::Data &kCaches
         }
         return true;
     }
+    if (FastllmCudaTrySm70FlashAttentionPrefill(
+            q, kCaches, vCaches, qSizes, pageSizes, pageIndexs, lastPageLens,
+            output, group, scale, attentionType)) {
+        if (sync) {
+            FastllmCudaSyncCurrentThreadStream();
+        }
+        return true;
+    }
 #ifndef FASTLLM_ENABLE_FLASHINFER
     bool ok = FastllmCudaHalfPagedAttentionBatchFastllmFallback(
         q, kCaches, vCaches, qSizes, pageSizes, pageIndexs, lastPageLens, output, group, scale);

--- a/src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
+++ b/src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
@@ -7,7 +7,9 @@
 #include "attention/fastllm-attention-dtype.cuh"
 #include "attention/fastllm-paged-attention-native.cuh"
 
+#include <algorithm>
 #include <cuda_fp8.h>
+#include <cstring>
 #include <cstdlib>
 #include <map>
 #include <memory>
@@ -1044,6 +1046,41 @@ static float *FastllmGetPagedSplitScratch(int device, int H, int maxBatch, int h
     return entry.ptr;
 }
 
+// The XQA route always uses cudaStreamPerThread. A thread-local cache therefore gives each
+// concurrently active per-thread stream independent storage while retaining stable addresses
+// across CUDA graph capture and replay. Capacity covers every allowed batch and split target.
+static float *FastllmGetSm70PagedXqaScratch(int device, size_t &capacitySlots, bool capturing) {
+    constexpr int kH = 24;
+    constexpr int kNumKvHeads = 4;
+    constexpr int kHeadDim = 256;
+    constexpr int kMaxBatch = 32;
+    constexpr int kMaxSplitTarget = 4096;
+    struct ScratchEntry {
+        float *ptr = nullptr;
+        size_t slots = 0;
+    };
+    static thread_local std::map<int, ScratchEntry> cache;
+    ScratchEntry &entry = cache[device];
+    size_t worstSlots = 0;
+    for (int batch = 1; batch <= kMaxBatch; batch++) {
+        int parallel = batch * kNumKvHeads;
+        int splits = (kMaxSplitTarget + parallel - 1) / parallel;
+        splits = std::max(1, std::min(splits, FASTLLM_PAGED_MAX_SPLITS));
+        worstSlots = std::max(worstSlots, (size_t)batch * kH * splits);
+    }
+    if (entry.ptr == nullptr) {
+        if (capturing) {
+            capacitySlots = 0;
+            return nullptr;
+        }
+        entry.ptr = (float*)FastllmCudaMalloc(
+            worstSlots * (size_t)(kHeadDim + 2) * sizeof(float));
+        entry.slots = worstSlots;
+    }
+    capacitySlots = entry.slots;
+    return entry.ptr;
+}
+
 // phase1：每个 block 处理 (b, h, split)，计算该 KV 段的部分在线 softmax 状态写入 scratch。
 // DIMS_PER_LANE=4 覆盖 headDim<=128，DIMS_PER_LANE=8 覆盖 headDim<=256。
 template <typename QType, typename KVType, int DIMS_PER_LANE>
@@ -1278,6 +1315,176 @@ __device__ __forceinline__ void FastllmPagedGqaAttnKvRange(
     }
 }
 
+
+// Qwen3.5/Qwen3.6 V100 decode specialization: one 4-warp block scans a KV range for one
+// KV head and shares every 256-D K/V load across its six query heads. Each lane owns eight
+// contiguous dimensions, so a warp covers D256 with coalesced FP16 loads.
+__global__ void __launch_bounds__(128, 2) FastllmSm70PagedXqaSplitKernel(
+    const half *qd, const half *pagedK, const half *pagedV, float *scratch,
+    const int32_t *qSizes, const int32_t *pageSizes, const int32_t *pageIndexs,
+    const int32_t *lastPageLens, int qStrideH, int qStrideN, float scale, int splits) {
+    constexpr int kH = 24;
+    constexpr int kGroup = 6;
+    constexpr int kNumKvHeads = 4;
+    constexpr int kHeadDim = 256;
+    constexpr int kPageLen = 128;
+    constexpr int kWarps = 4;
+    constexpr int kDimsPerLane = 8;
+
+    int batch = blockIdx.x;
+    int kvHead = blockIdx.y;
+    int split = blockIdx.z;
+    int tid = threadIdx.x;
+    int lane = tid & 31;
+    int warp = tid >> 5;
+    int tokenStart = qSizes[batch];
+    int qoLen = qSizes[batch + 1] - tokenStart;
+    int pageStart = pageSizes[batch];
+    int numPages = pageSizes[batch + 1] - pageStart;
+    int kvLen = numPages > 0 ? (numPages - 1) * kPageLen + lastPageLens[batch] : 0;
+    int chunk = kvLen > 0 ? (kvLen + splits - 1) / splits : 0;
+    int kvStart = split * chunk;
+    int kvEnd = min(kvStart + chunk, kvLen);
+    int headDimPlus = kHeadDim + 2;
+
+    if (qoLen != 1 || numPages <= 0 || kvLen <= 0 || kvStart >= kvEnd) {
+        for (int g = 0; g < kGroup; g++) {
+            int h = kvHead * kGroup + g;
+            float *slot = scratch + ((size_t)(batch * kH + h) * splits + split) * headDimPlus;
+            for (int d = tid; d < kHeadDim; d += blockDim.x) {
+                slot[d] = 0.0f;
+            }
+            if (tid == 0) {
+                slot[kHeadDim] = -1e30f;
+                slot[kHeadDim + 1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    __shared__ float sQ[kGroup * kHeadDim];
+    __shared__ float sM[kGroup * kWarps];
+    __shared__ float sL[kGroup * kWarps];
+    __shared__ float sAcc[kGroup * kWarps * kHeadDim];
+
+    int token = tokenStart;
+    for (int idx = tid; idx < kGroup * kHeadDim; idx += blockDim.x) {
+        int g = idx / kHeadDim;
+        int d = idx - g * kHeadDim;
+        int h = kvHead * kGroup + g;
+        sQ[idx] = __half2float(qd[(size_t)h * qStrideH + (size_t)token * qStrideN + d]);
+    }
+    __syncthreads();
+
+    size_t pageStride = (size_t)kPageLen * kNumKvHeads * kHeadDim;
+    size_t tokenStride = (size_t)kNumKvHeads * kHeadDim;
+    size_t kvHeadOffset = (size_t)kvHead * kHeadDim;
+    bool linearKv = FastllmPagedIsLinearPageLayout(pageStart, numPages, pageIndexs);
+    int d0 = lane * kDimsPerLane;
+    float m[kGroup], l[kGroup], acc[kGroup * kDimsPerLane];
+    #pragma unroll
+    for (int g = 0; g < kGroup; g++) {
+        m[g] = -1e30f;
+        l[g] = 0.0f;
+    }
+    #pragma unroll
+    for (int i = 0; i < kGroup * kDimsPerLane; i++) {
+        acc[i] = 0.0f;
+    }
+    const float scaleLog2 = scale * 1.4426950408889634f;
+
+    for (int j = kvStart + warp; j < kvEnd; j += kWarps) {
+        size_t base = linearKv
+            ? (size_t)j * tokenStride + kvHeadOffset
+            : FastllmPagedKvTokenBase(j, pageStart, kPageLen, numPages, pageIndexs,
+                                      pageStride, tokenStride, kvHeadOffset);
+        float kreg[kDimsPerLane], vreg[kDimsPerLane];
+        FastllmKvLoad4Contig<half>(pagedK + base, d0, kHeadDim, kreg);
+        FastllmKvLoad4Contig<half>(pagedK + base, d0 + 4, kHeadDim, kreg + 4);
+        FastllmKvLoad4Contig<half>(pagedV + base, d0, kHeadDim, vreg);
+        FastllmKvLoad4Contig<half>(pagedV + base, d0 + 4, kHeadDim, vreg + 4);
+
+        float partial[kGroup];
+        #pragma unroll
+        for (int g = 0; g < kGroup; g++) {
+            float dot = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < kDimsPerLane; i++) {
+                dot += sQ[g * kHeadDim + d0 + i] * kreg[i];
+            }
+            partial[g] = dot;
+        }
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            #pragma unroll
+            for (int g = 0; g < kGroup; g++) {
+                partial[g] += __shfl_xor_sync(0xffffffffu, partial[g], offset);
+            }
+        }
+        #pragma unroll
+        for (int g = 0; g < kGroup; g++) {
+            float score = partial[g] * scaleLog2;
+            if (score > m[g]) {
+                float correction = exp2f(m[g] - score);
+                #pragma unroll
+                for (int i = 0; i < kDimsPerLane; i++) {
+                    acc[g * kDimsPerLane + i] *= correction;
+                }
+                l[g] *= correction;
+                m[g] = score;
+            }
+            float probability = exp2f(score - m[g]);
+            #pragma unroll
+            for (int i = 0; i < kDimsPerLane; i++) {
+                acc[g * kDimsPerLane + i] += probability * vreg[i];
+            }
+            l[g] += probability;
+        }
+    }
+
+    #pragma unroll
+    for (int g = 0; g < kGroup; g++) {
+        if (lane == 0) {
+            sM[g * kWarps + warp] = m[g];
+            sL[g * kWarps + warp] = l[g];
+        }
+        #pragma unroll
+        for (int i = 0; i < kDimsPerLane; i++) {
+            sAcc[(g * kWarps + warp) * kHeadDim + d0 + i] =
+                acc[g * kDimsPerLane + i];
+        }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int g = 0; g < kGroup; g++) {
+        int h = kvHead * kGroup + g;
+        float *slot = scratch + ((size_t)(batch * kH + h) * splits + split) * headDimPlus;
+        float maxScore = -1e30f;
+        #pragma unroll
+        for (int w = 0; w < kWarps; w++) {
+            maxScore = fmaxf(maxScore, sM[g * kWarps + w]);
+        }
+        float sum = 0.0f;
+        #pragma unroll
+        for (int w = 0; w < kWarps; w++) {
+            sum += sL[g * kWarps + w] * exp2f(sM[g * kWarps + w] - maxScore);
+        }
+        for (int d = tid; d < kHeadDim; d += blockDim.x) {
+            float value = 0.0f;
+            #pragma unroll
+            for (int w = 0; w < kWarps; w++) {
+                value += sAcc[(g * kWarps + w) * kHeadDim + d] *
+                         exp2f(sM[g * kWarps + w] - maxScore);
+            }
+            slot[d] = value;
+        }
+        if (tid == 0) {
+            slot[kHeadDim] = maxScore;
+            slot[kHeadDim + 1] = sum;
+        }
+    }
+}
 // SM70(V100) 优化：默认编译该内核用到 ~91 寄存器，被寄存器数限制到每 SM 仅 2 个 block(25% 占用率)，
 // 单 SM 在途访存请求不足以掩盖 HBM 延迟（实测带宽仅 ~31% 峰值）。用 __launch_bounds__ 强约束寄存器，
 // 把每 SM 驻留 block 数提到 5（48 寄存器/线程、无 spill，受 18.7KB 共享内存约束 96KB/18.7KB≈5），
@@ -1601,6 +1808,136 @@ __global__ void FastllmPagedAttentionCombineGQAKernel(
         }
         __syncthreads();
     }
+}
+
+static bool FastllmSm70PagedXqaEnabled() {
+    const char *value = std::getenv("FASTLLM_CUDA_SM70_PAGED_XQA");
+    if (value == nullptr || value[0] == '\0') {
+        return true;
+    }
+    return strcmp(value, "0") != 0 &&
+           strcmp(value, "false") != 0 && strcmp(value, "FALSE") != 0 &&
+           strcmp(value, "off") != 0 && strcmp(value, "OFF") != 0 &&
+           strcmp(value, "disable") != 0 && strcmp(value, "DISABLE") != 0;
+}
+
+
+bool FastllmCudaTrySm70PagedAttentionDecode(
+    fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches,
+    fastllm::Data &qSizes, fastllm::Data &pageSizes, fastllm::Data &pageIndexs,
+    fastllm::Data &lastPageLens, fastllm::Data &output,
+    int group, float scale, int attentionType) {
+#if defined(USE_ROCM)
+    return false;
+#else
+    constexpr int kH = 24;
+    constexpr int kGroup = 6;
+    constexpr int kNumKvHeads = 4;
+    constexpr int kHeadDim = 256;
+    constexpr int kPageLen = 128;
+    constexpr int kMaxBatch = 32;
+    fastllm::Data *pagedK = kCaches.pagedKVCacheData;
+    fastllm::Data *pagedV = vCaches.pagedKVCacheData;
+    if (!FastllmSm70PagedXqaEnabled() || group != kGroup || attentionType != 1 ||
+        q.dataType != fastllm::DataType::FLOAT16 ||
+        output.dataType != fastllm::DataType::FLOAT16 ||
+        q.dataDevice != fastllm::DataDevice::CUDA ||
+        output.dataDevice != fastllm::DataDevice::CUDA ||
+        q.dims.size() != 3 || q.dims[0] != kH || q.dims[2] != kHeadDim ||
+        q.strides.size() < 3 || q.strides[2] != 1 ||
+        kCaches.dims.size() != 3 || vCaches.dims.size() != 3 ||
+        kCaches.dims[0] != kNumKvHeads || vCaches.dims[0] != kNumKvHeads ||
+        kCaches.dims[2] != kHeadDim || vCaches.dims[2] != kHeadDim ||
+        kCaches.pageLen != kPageLen || vCaches.pageLen != kPageLen ||
+        qSizes.dataType != fastllm::DataType::INT32 ||
+        pageSizes.dataType != fastllm::DataType::INT32 ||
+        pageIndexs.dataType != fastllm::DataType::INT32 ||
+        lastPageLens.dataType != fastllm::DataType::INT32 ||
+        qSizes.dataDevice != fastllm::DataDevice::CUDA ||
+        pageSizes.dataDevice != fastllm::DataDevice::CUDA ||
+        pageIndexs.dataDevice != fastllm::DataDevice::CUDA ||
+        lastPageLens.dataDevice != fastllm::DataDevice::CUDA ||
+        qSizes.dims.size() != 1 || pageSizes.dims.size() != 1 ||
+        pageIndexs.dims.size() != 1 || pageIndexs.dims[0] <= 0 ||
+        lastPageLens.dims.size() != 1 || q.cudaData == nullptr ||
+        output.cudaData == nullptr || qSizes.cudaData == nullptr ||
+        pageSizes.cudaData == nullptr || pageIndexs.cudaData == nullptr ||
+        lastPageLens.cudaData == nullptr) {
+        return false;
+    }
+    int batch = qSizes.dims[0] - 1;
+    if (batch <= 0 || batch > kMaxBatch || pageSizes.dims[0] != batch + 1 ||
+        lastPageLens.dims[0] != batch || q.dims[1] != batch ||
+        output.GetBytes() < (uint64_t)batch * kH * kHeadDim * sizeof(half)) {
+        return false;
+    }
+    if (output.dims.size() != 3 || output.dims[0] != kH ||
+        output.dims[1] != batch || output.dims[2] != kHeadDim ||
+        output.strides.size() < 3 ||
+        output.strides[0] != (uint64_t)batch * kHeadDim ||
+        output.strides[1] != kHeadDim || output.strides[2] != 1) {
+        return false;
+    }
+    if (pagedK == nullptr || pagedV == nullptr ||
+        pagedK->dataType != fastllm::DataType::FLOAT16 ||
+        pagedV->dataType != fastllm::DataType::FLOAT16 ||
+        pagedK->dataDevice != fastllm::DataDevice::CUDA ||
+        pagedV->dataDevice != fastllm::DataDevice::CUDA ||
+        pagedK->dims.size() != 4 || pagedV->dims.size() != 4 ||
+        pagedK->dims[1] != kPageLen || pagedV->dims[1] != kPageLen ||
+        pagedK->dims[2] != kNumKvHeads || pagedV->dims[2] != kNumKvHeads ||
+        pagedK->dims[3] != kHeadDim || pagedV->dims[3] != kHeadDim ||
+        pagedK->dims[0] != pagedV->dims[0] ||
+        pagedK->cudaData == nullptr || pagedV->cudaData == nullptr) {
+        return false;
+    }
+    int device = -1, major = 0, minor = 0;
+    if (cudaGetDevice(&device) != cudaSuccess ||
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device) != cudaSuccess ||
+        cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device) != cudaSuccess ||
+        major != 7 || minor != 0) {
+        cudaGetLastError();
+        return false;
+    }
+    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+    cudaError_t captureError = cudaStreamIsCapturing(cudaStreamPerThread, &captureStatus);
+    bool capturing = captureError == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone;
+    if (captureError != cudaSuccess) {
+        cudaGetLastError();
+    }
+    int splits = FastllmChoosePagedSplits((uint32_t)batch, kNumKvHeads, true);
+    size_t capacitySlots = 0;
+    float *scratch = FastllmGetSm70PagedXqaScratch(device, capacitySlots, capturing);
+    if (scratch == nullptr || capacitySlots < (size_t)batch * kH * splits) {
+        return false;
+    }
+
+    dim3 grid((unsigned int)batch, kNumKvHeads, (unsigned int)splits);
+    FastllmSm70PagedXqaSplitKernel<<<grid, 128, 0, cudaStreamPerThread>>>(
+        (const half*)q.cudaData, (const half*)pagedK->cudaData,
+        (const half*)pagedV->cudaData, scratch,
+        (const int32_t*)qSizes.cudaData, (const int32_t*)pageSizes.cudaData,
+        (const int32_t*)pageIndexs.cudaData, (const int32_t*)lastPageLens.cudaData,
+        (int)q.strides[0], (int)q.strides[1], scale, splits);
+    if (cudaGetLastError() != cudaSuccess) {
+        return false;
+    }
+    dim3 combineGrid((unsigned int)batch, kNumKvHeads, 1);
+    FastllmPagedAttentionCombineGQAKernel<half, kGroup>
+        <<<combineGrid, kHeadDim, 0, cudaStreamPerThread>>>(
+            scratch, (half*)output.cudaData, (const int32_t*)qSizes.cudaData,
+            kH, kGroup, kHeadDim, splits);
+    if (cudaGetLastError() != cudaSuccess) {
+        return false;
+    }
+    output.Resize({batch, kH, kHeadDim});
+    static thread_local bool logged = false;
+    if (!logged) {
+        printf("[FastLLM] SM70 paged XQA enabled (FP16 page128 Q24/KV4 D256 GQA6).\n");
+        logged = true;
+    }
+    return true;
+#endif
 }
 
 template <typename QType>

--- a/src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
+++ b/src/devices/cuda/attention/paged/fastllm-paged-attention-native.cu
@@ -172,6 +172,12 @@ static bool FastllmCudaPagedCacheGatherHeadRangeToHalf(
     } else if (pagedKVCache->dataType == fastllm::DataType::FP8_E4M3) {
         FastllmPagedCacheGatherHeadRangeKernel<__nv_fp8_e4m3><<<numBlocks, THREAD_PER_BLOCK>>>(
             pagedBytes, pageIndicesGpu, kvStart, chunkLen, pageLen, numHeads, headDim, kvHead, outData);
+    } else if (fastllm::IsPackedKVCacheDataType(pagedKVCache->dataType)) {
+        if (!FastllmCudaPackedKVCacheGatherHeadRangeToHalf(
+                pagedBytes, pagedKVCache->dataType, pageIndicesGpu,
+                kvStart, chunkLen, pageLen, numHeads, headDim, kvHead, outData)) {
+            return false;
+        }
     } else {
         printf("FastllmCudaPagedCacheGatherHeadRangeToHalf: unsupported paged KV cache dataType=%d\n",
                (int)pagedKVCache->dataType);
@@ -642,18 +648,42 @@ bool FastllmCudaHalfPagedAttentionFastllmFallback(
     float scale) {
     if (!k.isPagedKVCache || !v.isPagedKVCache) {
         printf("FastllmCudaHalfPagedAttentionFastllmFallback: k/v must be paged KV cache.\n");
-        exit(0);
+        return false;
     }
     fastllm::Data *pagedKVCacheK = k.pagedKVCacheData;
     fastllm::Data *pagedKVCacheV = v.pagedKVCacheData;
     if (pagedKVCacheK == nullptr || pagedKVCacheV == nullptr) {
         printf("FastllmCudaHalfPagedAttentionFastllmFallback: pagedKVCacheData is nullptr.\n");
-        exit(0);
+        return false;
     }
     int numKvHeads = k.dims[0];
     int headDim = pagedKVCacheK->dims[3];
-    return FastllmCudaHalfPagedAttentionNative(q, k.pageIndex, k.lastPageLen, pagedKVCacheK, pagedKVCacheV,
-                                               k.pageLen, numKvHeads, headDim, output, group, scale);
+    bool packedKV = fastllm::IsPackedKVCacheDataType(pagedKVCacheK->dataType) ||
+                    fastllm::IsPackedKVCacheDataType(pagedKVCacheV->dataType);
+    if (!packedKV) {
+        return FastllmCudaHalfPagedAttentionNative(
+            q, k.pageIndex, k.lastPageLen, pagedKVCacheK, pagedKVCacheV,
+            k.pageLen, numKvHeads, headDim, output, group, scale);
+    }
+
+    if (q.dims.size() != 3 || output.dims.size() != 3 ||
+        q.dims[2] != headDim || output.dims[2] != headDim) {
+        return false;
+    }
+    int H = q.dims[0];
+    int qoLen = q.dims[1];
+    bool ok = FastllmCudaPagedAttentionNativeChunkedCublasRaw(
+        q.cudaData, q.dataType, H, qoLen, headDim,
+        q.strides[0], q.strides[1], k.pageIndex, nullptr, k.lastPageLen,
+        pagedKVCacheK, pagedKVCacheV, k.pageLen, numKvHeads, headDim,
+        output.cudaData, output.dataType,
+        output.strides[0], output.strides[1], group, scale);
+    if (ok) {
+        output.Resize({H, qoLen, headDim});
+        FastllmCudaPermute(output, {1, 0, 2});
+        DeviceSync();
+    }
+    return ok;
 }
 
 // CUDA-graph 可捕获的分页注意力 kernel（前缀填充 + 解码统一实现）。
@@ -2253,17 +2283,26 @@ bool FastllmCudaHalfPagedAttentionBatchFastllmFallback(
         }
     }
     bool isDecode = (q.dims.size() >= 2 && (int)q.dims[1] == (int)batch_size);
-    if ((capturing || isDecode) &&
+    const bool packedKV = kCaches.pagedKVCacheData != nullptr &&
+                          vCaches.pagedKVCacheData != nullptr &&
+                          (fastllm::IsPackedKVCacheDataType(kCaches.pagedKVCacheData->dataType) ||
+                           fastllm::IsPackedKVCacheDataType(vCaches.pagedKVCacheData->dataType));
+    if (!packedKV && (capturing || isDecode) &&
         kCaches.pagedKVCacheData != nullptr && vCaches.pagedKVCacheData != nullptr &&
         (q.dataType == fastllm::DataType::FLOAT16 || q.dataType == fastllm::DataType::BFLOAT16)) {
         return FastllmCudaHalfPagedAttentionBatchCapturable(
             q, kCaches, vCaches, qSizes, pageSizes, pageIndexs, lastPageLens, output, group, scale);
     }
-    bool useChunkedCublasPrefill = !isDecode;
+    if (packedKV && capturing) {
+        return false;
+    }
+    // The first correctness path decompresses packed K/V in bounded chunks.
+    // Direct split-KV packed loads are added only after numerical validation.
+    bool useChunkedCublasPrefill = !isDecode || packedKV;
     if (useChunkedCublasPrefill) {
         static thread_local bool loggedChunkedCublasPrefill = false;
         if (!loggedChunkedCublasPrefill) {
-            printf("[Fastllm] Native paged prefill uses chunked cublas attention.\n");
+            printf("[Fastllm] Native paged attention uses chunked cublas attention.\n");
             loggedChunkedCublasPrefill = true;
         }
     }
@@ -2283,7 +2322,7 @@ bool FastllmCudaHalfPagedAttentionBatchFastllmFallback(
     fastllm::Data *pagedKVCacheV = vCaches.pagedKVCacheData;
     if (pagedKVCacheK == nullptr || pagedKVCacheV == nullptr) {
         printf("FastllmCudaHalfPagedAttentionBatchFastllmFallback: pagedKVCacheData is nullptr.\n");
-        exit(0);
+        return false;
     }
     int pageLen = kCaches.pageLen;
     int headDim = pagedKVCacheK->dims[3];
@@ -2345,23 +2384,21 @@ bool FastllmCudaHalfPagedAttentionBatchFastllmFallback(
         }
 
         bool decodeLayout = (q.dims.size() >= 2 && q.dims[1] == 1);
-        if (useChunkedCublasPrefill && !decodeLayout) {
+        if (useChunkedCublasPrefill) {
             int qHeadStride = q.strides.size() >= 1 ? (int)q.strides[0] : totalTokens * q2;
             int qTokenStride = q.strides.size() >= 2 ? (int)q.strides[1] : q2;
             size_t qUnit = q.dataType == fastllm::DataType::BFLOAT16 ? sizeof(__nv_bfloat16) : sizeof(half);
             size_t outUnit = output.dataType == fastllm::DataType::BFLOAT16 ? sizeof(__nv_bfloat16) : sizeof(half);
-            void *qBatchBase = (uint8_t*)q.cudaData + (size_t)qo_start * qTokenStride * qUnit;
+            size_t qBatchOffset = decodeLayout ?
+                (size_t)b * H * q2 : (size_t)qo_start * qTokenStride;
+            void *qBatchBase = (uint8_t*)q.cudaData + qBatchOffset * qUnit;
             void *outBatchBase = (uint8_t*)output.cudaData + (size_t)qo_start * H * q2 * outUnit;
             bool okBatch = FastllmCudaPagedAttentionNativeChunkedCublasRaw(
                 qBatchBase, q.dataType, H, qo_len, q2, qHeadStride, qTokenStride,
                 pageIndices, pageIndicesGpu, lastPageLen,
                 pagedKVCacheK, pagedKVCacheV, pageLen, numKvHeads, headDim,
                 outBatchBase, output.dataType, q2, H * q2, group, scale);
-            if (okBatch) {
-                ok = okBatch && ok;
-                continue;
-            }
-            ok = false;
+            ok = okBatch && ok;
             continue;
         }
 

--- a/src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
+++ b/src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
@@ -207,9 +207,8 @@ __global__ void Sm70FlashAttentionFp8PrefillKernel(
         const int row = i / kHeadDim;
         const int dim = i - row * kHeadDim;
         const float invSum = 1.0f / fmaxf(smem.rowSum[row], 1.0e-24f);
-        output[(int64_t)qHead * qStrideHead
-               + (int64_t)(qBegin + row) * qStrideToken + dim] =
-            __float2half_rn(smem.output[i] * invSum);
+        output[((int64_t)(qBegin + row) * kQHeads + qHead) * kHeadDim
+               + dim] = __float2half_rn(smem.output[i] * invSum);
     }
 #endif
 }
@@ -355,6 +354,7 @@ bool FastllmCudaTrySm70FlashAttentionPrefill(
     if (cudaGetLastError() != cudaSuccess) {
         return false;
     }
+    output.Resize({q.dims[1], kQHeads, kHeadDim});
     static thread_local bool logged = false;
     if (!logged) {
         std::printf("[FastLLM] SM70 FlashAttention FP8 paged prefill enabled "

--- a/src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
+++ b/src/devices/cuda/attention/paged/fastllm-sm70-flash-attention.cu
@@ -1,0 +1,366 @@
+// Copyright (c) 2024, flash-attention-v100 contributors.
+// Copyright (c) 2025, FastLLM contributors.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE.
+//
+// The tiled causal/paged online-softmax structure is adapted from the local
+// flash-attention-v100 paged forward kernel. This specialization targets the
+// short-query FP8-KV validation shape used by Qwen3.5/3.6 MTP on Volta.
+
+#include "devices/cuda/attention/fastllm-paged-attention-native.cuh"
+
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <mma.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+using namespace nvcuda::wmma;
+
+constexpr int kHeadDim = 256;
+constexpr int kTile = 16;
+constexpr int kThreads = 512;
+constexpr int kQHeads = 24;
+constexpr int kKvHeads = 4;
+constexpr int kGroup = 6;
+constexpr int kPageLen = 128;
+
+struct alignas(128) Sm70FlashPrefillSmem {
+    half q[kTile * kHeadDim];
+    half k[kTile * kHeadDim];
+    half v[kTile * kHeadDim];
+    float scores[kTile * kTile];
+    half probabilities[kTile * kTile];
+    float output[kTile * kHeadDim];
+    float rowMax[kTile];
+    float rowSum[kTile];
+    float rescale[kTile];
+};
+
+__device__ __forceinline__ half LoadFp8Half(const __nv_fp8_e4m3 *base,
+                                             int64_t offset) {
+    __nv_fp8_e4m3 value;
+    value.__x = __ldg(reinterpret_cast<const unsigned char *>(base) + offset);
+    return __float2half_rn(static_cast<float>(value));
+}
+
+__global__ void Sm70FlashAttentionFp8PrefillKernel(
+    const half *__restrict__ q,
+    const __nv_fp8_e4m3 *__restrict__ kCache,
+    const __nv_fp8_e4m3 *__restrict__ vCache,
+    half *__restrict__ output,
+    const int32_t *__restrict__ qSizes,
+    const int32_t *__restrict__ pageSizes,
+    const int32_t *__restrict__ pageIndices,
+    const int32_t *__restrict__ lastPageLens,
+    int qStrideHead,
+    int qStrideToken,
+    float softmaxScale) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 700
+    extern __shared__ char rawSmem[];
+    Sm70FlashPrefillSmem &smem =
+        *reinterpret_cast<Sm70FlashPrefillSmem *>(rawSmem);
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5;
+    const int request = blockIdx.x;
+    const int qHead = blockIdx.y;
+    const int kvHead = qHead / kGroup;
+    const int qBegin = qSizes[request];
+    const int qLen = qSizes[request + 1] - qBegin;
+    const int pageBegin = pageSizes[request];
+    const int pageCount = pageSizes[request + 1] - pageBegin;
+    const int kvLen = pageCount > 0
+        ? (pageCount - 1) * kPageLen + lastPageLens[request]
+        : 0;
+
+    for (int i = tid; i < kTile * kHeadDim; i += kThreads) {
+        const int row = i / kHeadDim;
+        const int dim = i - row * kHeadDim;
+        smem.q[i] = row < qLen
+            ? q[(int64_t)qHead * qStrideHead
+                + (int64_t)(qBegin + row) * qStrideToken + dim]
+            : __float2half(0.0f);
+        smem.output[i] = 0.0f;
+    }
+    if (tid < kTile) {
+        smem.rowMax[tid] = -1.0e30f;
+        smem.rowSum[tid] = 0.0f;
+        smem.rescale[tid] = 0.0f;
+    }
+    __syncthreads();
+
+    const int causalOffset = kvLen - qLen;
+    for (int tileStart = 0; tileStart < kvLen; tileStart += kTile) {
+        const int tileRows = min(kTile, kvLen - tileStart);
+        for (int i = tid; i < kTile * kHeadDim; i += kThreads) {
+            const int tokenInTile = i / kHeadDim;
+            const int dim = i - tokenInTile * kHeadDim;
+            half kValue = __float2half(0.0f);
+            half vValue = __float2half(0.0f);
+            if (tokenInTile < tileRows) {
+                const int logicalToken = tileStart + tokenInTile;
+                const int logicalPage = logicalToken / kPageLen;
+                const int pageOffset = logicalToken - logicalPage * kPageLen;
+                const int physicalPage = pageIndices[pageBegin + logicalPage];
+                const int64_t cacheOffset =
+                    (((int64_t)physicalPage * kPageLen + pageOffset) * kKvHeads
+                        + kvHead) * kHeadDim + dim;
+                kValue = LoadFp8Half(kCache, cacheOffset);
+                vValue = LoadFp8Half(vCache, cacheOffset);
+            }
+            smem.k[i] = kValue;
+            smem.v[i] = vValue;
+        }
+        __syncthreads();
+
+        if (warp == 0) {
+            fragment<matrix_a, kTile, kTile, kTile, half, row_major> qFrag;
+            fragment<matrix_b, kTile, kTile, kTile, half, col_major> kFrag;
+            fragment<accumulator, kTile, kTile, kTile, float> scoreFrag;
+            fill_fragment(scoreFrag, 0.0f);
+#pragma unroll
+            for (int dim = 0; dim < kHeadDim; dim += kTile) {
+                load_matrix_sync(qFrag, smem.q + dim, kHeadDim);
+                load_matrix_sync(kFrag, smem.k + dim, kHeadDim);
+                mma_sync(scoreFrag, qFrag, kFrag, scoreFrag);
+            }
+            store_matrix_sync(smem.scores, scoreFrag, kTile, mem_row_major);
+        }
+        __syncthreads();
+
+        if (tid < qLen) {
+            float tileMax = -1.0e30f;
+#pragma unroll
+            for (int col = 0; col < kTile; ++col) {
+                const int keyPosition = tileStart + col;
+                if (col < tileRows && keyPosition <= causalOffset + tid) {
+                    tileMax = fmaxf(tileMax,
+                                    smem.scores[tid * kTile + col]
+                                        * softmaxScale);
+                }
+            }
+            const float oldMax = smem.rowMax[tid];
+            const float newMax = fmaxf(oldMax, tileMax);
+            const float rescale = __expf(oldMax - newMax);
+            float tileSum = 0.0f;
+#pragma unroll
+            for (int col = 0; col < kTile; ++col) {
+                const int keyPosition = tileStart + col;
+                float probability = 0.0f;
+                if (col < tileRows && keyPosition <= causalOffset + tid) {
+                    probability = __expf(
+                        smem.scores[tid * kTile + col] * softmaxScale - newMax);
+                }
+                smem.probabilities[tid * kTile + col] =
+                    __float2half_rn(probability);
+                tileSum += probability;
+            }
+            smem.rowMax[tid] = newMax;
+            smem.rowSum[tid] = smem.rowSum[tid] * rescale + tileSum;
+            smem.rescale[tid] = rescale;
+        }
+        __syncthreads();
+
+        for (int i = tid; i < qLen * kHeadDim; i += kThreads) {
+            const int row = i / kHeadDim;
+            smem.output[i] *= smem.rescale[row];
+        }
+        __syncthreads();
+
+        if (warp < kHeadDim / kTile) {
+            fragment<matrix_a, kTile, kTile, kTile, half, row_major> pFrag;
+            fragment<matrix_b, kTile, kTile, kTile, half, row_major> vFrag;
+            fragment<accumulator, kTile, kTile, kTile, float> outFrag;
+            const int dim = warp * kTile;
+            load_matrix_sync(pFrag, smem.probabilities, kTile);
+            load_matrix_sync(vFrag, smem.v + dim, kHeadDim);
+            load_matrix_sync(outFrag, smem.output + dim, kHeadDim, mem_row_major);
+            mma_sync(outFrag, pFrag, vFrag, outFrag);
+            store_matrix_sync(smem.output + dim, outFrag, kHeadDim, mem_row_major);
+        }
+        __syncthreads();
+    }
+
+    for (int i = tid; i < qLen * kHeadDim; i += kThreads) {
+        const int row = i / kHeadDim;
+        const int dim = i - row * kHeadDim;
+        const float invSum = 1.0f / fmaxf(smem.rowSum[row], 1.0e-24f);
+        output[(int64_t)qHead * qStrideHead
+               + (int64_t)(qBegin + row) * qStrideToken + dim] =
+            __float2half_rn(smem.output[i] * invSum);
+    }
+#endif
+}
+
+bool EnvEnabled(const char *name) {
+    const char *value = std::getenv(name);
+    return value != nullptr && std::strcmp(value, "0") != 0;
+}
+
+int MaxKvTokens() {
+    const char *value = std::getenv("FASTLLM_CUDA_SM70_FLASH_ATTN_MAX_KV");
+    if (value == nullptr) {
+        return 512;
+    }
+    char *end = nullptr;
+    const long parsed = std::strtol(value, &end, 10);
+    return end != value && *end == '\0' && parsed > 0 && parsed <= INT_MAX
+        ? static_cast<int>(parsed)
+        : 512;
+}
+
+bool IsCudaInt32Vector(const fastllm::Data &data) {
+    return data.dataType == fastllm::DataType::INT32
+        && data.dataDevice == fastllm::DataDevice::CUDA
+        && data.dims.size() == 1 && data.cudaData != nullptr;
+}
+
+} // namespace
+
+bool FastllmCudaTrySm70FlashAttentionPrefill(
+    fastllm::Data &q, fastllm::Data &kCaches, fastllm::Data &vCaches,
+    fastllm::Data &qSizes, fastllm::Data &pageSizes,
+    fastllm::Data &pageIndexs, fastllm::Data &lastPageLens,
+    fastllm::Data &output, int group, float scale, int attentionType) {
+    if (!EnvEnabled("FASTLLM_CUDA_SM70_FLASH_ATTN")
+        || attentionType != 1 || group != kGroup
+        || q.dataType != fastllm::DataType::FLOAT16
+        || output.dataType != fastllm::DataType::FLOAT16
+        || q.dataDevice != fastllm::DataDevice::CUDA
+        || output.dataDevice != fastllm::DataDevice::CUDA
+        || q.cudaData == nullptr || output.cudaData == nullptr
+        || q.dims.size() != 3 || output.dims != q.dims
+        || q.dims[0] != kQHeads || q.dims[1] < 2 || q.dims[1] > 50
+        || q.dims[2] != kHeadDim
+        || q.strides.size() != 3 || output.strides.size() != 3
+        || q.strides[2] != 1 || output.strides != q.strides
+        || qSizes.dims.size() != 1 || qSizes.dims[0] < 2
+        || qSizes.dims[0] > 6
+        || pageSizes.dims.size() != 1
+        || pageSizes.dims[0] != qSizes.dims[0]
+        || lastPageLens.dims.size() != 1
+        || lastPageLens.dims[0] != qSizes.dims[0] - 1
+        || !IsCudaInt32Vector(qSizes) || !IsCudaInt32Vector(pageSizes)
+        || !IsCudaInt32Vector(pageIndexs) || !IsCudaInt32Vector(lastPageLens)) {
+        return false;
+    }
+    fastllm::PagedCacheManager *pagedK = kCaches.pagedKVCacheData;
+    fastllm::PagedCacheManager *pagedV = vCaches.pagedKVCacheData;
+    if (!kCaches.isPagedKVCache || !vCaches.isPagedKVCache
+        || pagedK == nullptr || pagedV == nullptr
+        || pagedK->dataType != fastllm::DataType::FP8_E4M3
+        || pagedV->dataType != fastllm::DataType::FP8_E4M3
+        || pagedK->dataDevice != fastllm::DataDevice::CUDA
+        || pagedV->dataDevice != fastllm::DataDevice::CUDA
+        || pagedK->cudaData == nullptr || pagedV->cudaData == nullptr
+        || pagedK->dims.size() != 4 || pagedV->dims != pagedK->dims
+        || pagedK->dims[1] != kPageLen || pagedK->dims[2] != kKvHeads
+        || pagedK->dims[3] != kHeadDim) {
+        return false;
+    }
+
+    const int batch = qSizes.dims[0] - 1;
+    if (!std::isfinite(scale) || scale <= 0.0f
+        || (int)qSizes.cpuIntDatas.size() != batch + 1
+        || (int)pageSizes.cpuIntDatas.size() != batch + 1
+        || (int)pageIndexs.cpuIntDatas.size() < pageIndexs.dims[0]
+        || (int)lastPageLens.cpuIntDatas.size() != batch
+        || qSizes.cpuIntDatas.front() != 0
+        || pageSizes.cpuIntDatas.front() != 0
+        || qSizes.cpuIntDatas.back() != q.dims[1]
+        || pageSizes.cpuIntDatas.back() != pageIndexs.dims[0]) {
+        return false;
+    }
+    for (int request = 0; request < batch; ++request) {
+        const int qLen = qSizes.cpuIntDatas[request + 1]
+            - qSizes.cpuIntDatas[request];
+        const int pages = pageSizes.cpuIntDatas[request + 1]
+            - pageSizes.cpuIntDatas[request];
+        const int lastPageLen = lastPageLens.cpuIntDatas[request];
+        const int kvLen = pages > 0 ? (pages - 1) * kPageLen + lastPageLen : 0;
+        if (qLen < 2 || qLen > 10 || pages <= 0
+            || lastPageLen <= 0 || lastPageLen > kPageLen
+            || kvLen < qLen || kvLen > MaxKvTokens()) {
+            return false;
+        }
+        for (int page = pageSizes.cpuIntDatas[request];
+             page < pageSizes.cpuIntDatas[request + 1]; ++page) {
+            const int physicalPage = pageIndexs.cpuIntDatas[page];
+            if (physicalPage < 0 || physicalPage >= pagedK->dims[0]) {
+                return false;
+            }
+        }
+    }
+
+    int device = -1;
+    int major = 0;
+    int minor = 0;
+    if (cudaGetDevice(&device) != cudaSuccess
+        || cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor,
+                                  device) != cudaSuccess
+        || cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor,
+                                  device) != cudaSuccess
+        || major != 7 || minor != 0) {
+        cudaGetLastError();
+        return false;
+    }
+    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+    if (cudaStreamIsCapturing(cudaStreamPerThread, &captureStatus) != cudaSuccess
+        || captureStatus != cudaStreamCaptureStatusNone) {
+        cudaGetLastError();
+        return false;
+    }
+
+    const size_t smemBytes = sizeof(Sm70FlashPrefillSmem);
+    if (cudaFuncSetAttribute(Sm70FlashAttentionFp8PrefillKernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             static_cast<int>(smemBytes)) != cudaSuccess) {
+        cudaGetLastError();
+        return false;
+    }
+    dim3 grid(batch, kQHeads, 1);
+    Sm70FlashAttentionFp8PrefillKernel<<<grid, kThreads, smemBytes,
+                                         cudaStreamPerThread>>>(
+        reinterpret_cast<const half *>(q.cudaData),
+        reinterpret_cast<const __nv_fp8_e4m3 *>(pagedK->cudaData),
+        reinterpret_cast<const __nv_fp8_e4m3 *>(pagedV->cudaData),
+        reinterpret_cast<half *>(output.cudaData),
+        reinterpret_cast<const int32_t *>(qSizes.cudaData),
+        reinterpret_cast<const int32_t *>(pageSizes.cudaData),
+        reinterpret_cast<const int32_t *>(pageIndexs.cudaData),
+        reinterpret_cast<const int32_t *>(lastPageLens.cudaData),
+        static_cast<int>(q.strides[0]), static_cast<int>(q.strides[1]), scale);
+    if (cudaGetLastError() != cudaSuccess) {
+        return false;
+    }
+    static thread_local bool logged = false;
+    if (!logged) {
+        std::printf("[FastLLM] SM70 FlashAttention FP8 paged prefill enabled "
+                    "(Volta WMMA, page128, batch1..5, qLen2..10, "
+                    "KV<=%d, Q24/KV4 D256 GQA6).\n", MaxKvTokens());
+        logged = true;
+    }
+    return true;
+}

--- a/src/devices/cuda/attention/paged/fastllm-turboquant-kv.cu
+++ b/src/devices/cuda/attention/paged/fastllm-turboquant-kv.cu
@@ -1,0 +1,399 @@
+//
+// TurboQuant-derived packed paged KV cache primitives for FastLLM.
+//
+// Source algorithm: llama.cpp-turboquant (MIT), GGML_TYPE_TURBO3_0.
+// This file implements only the Qwen3.5/3.6 SM70 closure used here:
+//   K: q8_0 (fp16 scale + 32 int8 values per 32-value block)
+//   V: Turbo3 (fp16 corrected norm + 3-bit indices per 128-value block)
+// Every (page, token, head) owns an independent packed row.
+//
+#include "fastllm-cuda.cuh"
+#include "fastllm.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+namespace {
+constexpr int kHeadDim = 256;
+constexpr int kQ8BlockValues = 32;
+constexpr int kQ8BlockBytes = 34;
+constexpr int kTurbo3BlockValues = 128;
+constexpr int kTurbo3BlockBytes = 50;
+constexpr int kQ8RowBytes = (kHeadDim / kQ8BlockValues) * kQ8BlockBytes;
+constexpr int kTurbo3RowBytes = (kHeadDim / kTurbo3BlockValues) * kTurbo3BlockBytes;
+static_assert(kQ8RowBytes == 272 && kTurbo3RowBytes == 100,
+              "Qwen3.5 TurboQuant packed KV row bytes changed");
+
+struct Q8KvBlock {
+    uint16_t scale;
+    int8_t values[kQ8BlockValues];
+};
+static_assert(sizeof(Q8KvBlock) == kQ8BlockBytes, "Q8 KV block layout changed");
+
+struct Turbo3KvBlock {
+    uint16_t norm;
+    uint8_t low2[kTurbo3BlockValues / 4];
+    uint8_t high1[kTurbo3BlockValues / 8];
+};
+static_assert(sizeof(Turbo3KvBlock) == kTurbo3BlockBytes,
+              "Turbo3 KV must remain 50 bytes per 128 values");
+
+__device__ __constant__ float kTurbo3Centroids[8] = {
+    -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+     0.021663f,  0.066822f,  0.118786f,  0.190207f
+};
+__device__ __constant__ float kTurbo3Midpoints[7] = {
+    -0.154496f, -0.092804f, -0.044243f, 0.0f,
+     0.044243f,  0.092804f,  0.154496f
+};
+__device__ __constant__ float kWhtSigns1[128] = {
+    -1,1,1,-1,-1,1,-1,1,-1,-1,1,1,1,1,1,1,
+    1,-1,1,-1,1,-1,-1,1,1,1,-1,1,1,-1,-1,-1,
+    -1,1,1,-1,1,1,-1,1,-1,1,1,-1,-1,1,-1,1,
+    1,1,1,-1,-1,-1,-1,-1,1,-1,1,1,1,1,-1,1,
+    -1,-1,1,-1,-1,-1,1,-1,-1,-1,1,-1,-1,-1,1,1,
+    1,-1,-1,1,1,1,-1,-1,1,1,-1,1,1,-1,1,-1,
+    -1,1,1,-1,1,-1,1,-1,1,1,1,1,-1,1,-1,1,
+    1,-1,1,1,-1,-1,-1,-1,-1,1,1,-1,1,1,-1,1
+};
+__device__ __constant__ float kWhtSigns2[128] = {
+    1,1,1,1,-1,1,1,-1,1,-1,-1,-1,1,-1,-1,-1,
+    1,1,-1,-1,1,-1,1,-1,1,-1,-1,1,-1,1,1,1,
+    1,1,-1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,1,-1,
+    1,-1,1,1,1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,
+    1,-1,1,-1,-1,-1,-1,1,-1,1,-1,1,-1,-1,1,1,
+    -1,1,-1,1,1,-1,1,-1,-1,-1,-1,1,-1,-1,1,-1,
+    1,-1,1,1,1,-1,-1,1,-1,1,-1,1,1,-1,-1,1,
+    -1,1,-1,1,1,-1,1,-1,1,-1,-1,-1,-1,-1,1,-1
+};
+
+template <typename T>
+__device__ __forceinline__ float ToFloat(T value) { return static_cast<float>(value); }
+template <>
+__device__ __forceinline__ float ToFloat<float>(float value) { return value; }
+
+template <typename T>
+__device__ __forceinline__ float LoadSource(const T *src, size_t index) {
+    return ToFloat(src[index]);
+}
+
+__device__ __forceinline__ uint16_t FloatToHalfBits(float value) {
+    union { half h; uint16_t bits; } packed;
+    packed.h = __float2half_rn(value);
+    return packed.bits;
+}
+__device__ __forceinline__ float HalfBitsToFloat(uint16_t bits) {
+    union { half h; uint16_t bits; } packed;
+    packed.bits = bits;
+    return __half2float(packed.h);
+}
+
+__device__ __forceinline__ uint8_t NearestTurbo3(float value) {
+    if (value < kTurbo3Midpoints[0]) return 0;
+    if (value < kTurbo3Midpoints[1]) return 1;
+    if (value < kTurbo3Midpoints[2]) return 2;
+    if (value < kTurbo3Midpoints[3]) return 3;
+    if (value < kTurbo3Midpoints[4]) return 4;
+    if (value < kTurbo3Midpoints[5]) return 5;
+    if (value < kTurbo3Midpoints[6]) return 6;
+    return 7;
+}
+
+__device__ __forceinline__ void WhtStage(float *x, int lane, int h) {
+    if ((lane % (2 * h)) < h) {
+        float a = x[lane];
+        float b = x[lane + h];
+        x[lane] = a + b;
+        x[lane + h] = a - b;
+    }
+    __syncthreads();
+}
+
+__device__ __forceinline__ void ForwardWht128(float *x, int lane) {
+    x[lane] *= kWhtSigns1[lane];
+    __syncthreads();
+    WhtStage(x, lane, 1); WhtStage(x, lane, 2); WhtStage(x, lane, 4);
+    WhtStage(x, lane, 8); WhtStage(x, lane, 16); WhtStage(x, lane, 32);
+    WhtStage(x, lane, 64);
+    x[lane] *= 0.08838834764831845f * kWhtSigns2[lane];
+    __syncthreads();
+}
+
+__device__ __forceinline__ void InverseWht128(float *x, int lane) {
+    x[lane] *= kWhtSigns2[lane];
+    __syncthreads();
+    WhtStage(x, lane, 1); WhtStage(x, lane, 2); WhtStage(x, lane, 4);
+    WhtStage(x, lane, 8); WhtStage(x, lane, 16); WhtStage(x, lane, 32);
+    WhtStage(x, lane, 64);
+    x[lane] *= 0.08838834764831845f * kWhtSigns1[lane];
+    __syncthreads();
+}
+
+template <typename SrcT>
+__global__ void QuantizeQ8RowsKernel(
+        const SrcT *src, uint8_t *dst, const int32_t *pageIds,
+        const int32_t *pageOffsets, int rows, int sourceSeqLen,
+        int pageLen, int numHeads, int headDim, bool batchLayout,
+        int sourceTokenOffset) {
+    int row = blockIdx.x;
+    int block = blockIdx.y;
+    int lane = threadIdx.x;
+    if (row >= rows || block >= headDim / kQ8BlockValues || lane >= 32) return;
+    int copiedTokens = rows / numHeads;
+    int token = batchLayout ? row / numHeads : row % copiedTokens;
+    int head = batchLayout ? row % numHeads : row / copiedTokens;
+    int page = pageIds[batchLayout ? token : 0];
+    int pageOffset = pageOffsets[batchLayout ? token : 0] +
+                     (batchLayout ? 0 : token);
+    if (pageOffset < 0 || pageOffset >= pageLen) return;
+    size_t sourceRow = batchLayout
+        ? (size_t)token * numHeads + head
+        : (size_t)head * sourceSeqLen + sourceTokenOffset + token;
+    float value = LoadSource(src, sourceRow * headDim + block * 32 + lane);
+    float maxAbs = fabsf(value);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        maxAbs = fmaxf(maxAbs, __shfl_down_sync(0xffffffff, maxAbs, offset));
+    maxAbs = __shfl_sync(0xffffffff, maxAbs, 0);
+    float scale = maxAbs > 0.0f ? maxAbs / 127.0f : 0.0f;
+    int q = scale > 0.0f ? __float2int_rn(value / scale) : 0;
+    q = max(-127, min(127, q));
+    constexpr size_t rowBytes = kQ8RowBytes;
+    size_t dstRow = ((size_t)page * pageLen + pageOffset) * numHeads + head;
+    Q8KvBlock *out = reinterpret_cast<Q8KvBlock *>(dst + dstRow * rowBytes) + block;
+    if (lane == 0) out->scale = FloatToHalfBits(scale);
+    out->values[lane] = static_cast<int8_t>(q);
+}
+
+template <typename SrcT>
+__global__ void QuantizeTurbo3RowsKernel(
+        const SrcT *src, uint8_t *dst, const int32_t *pageIds,
+        const int32_t *pageOffsets, int rows, int sourceSeqLen,
+        int pageLen, int numHeads, int headDim, bool batchLayout,
+        int sourceTokenOffset) {
+    int row = blockIdx.x;
+    int group = blockIdx.y;
+    int lane = threadIdx.x;
+    if (row >= rows || group >= headDim / 128 || lane >= 128) return;
+    int copiedTokens = rows / numHeads;
+    int token = batchLayout ? row / numHeads : row % copiedTokens;
+    int head = batchLayout ? row % numHeads : row / copiedTokens;
+    int page = pageIds[batchLayout ? token : 0];
+    int pageOffset = pageOffsets[batchLayout ? token : 0] +
+                     (batchLayout ? 0 : token);
+    if (pageOffset < 0 || pageOffset >= pageLen) return;
+    size_t sourceRow = batchLayout
+        ? (size_t)token * numHeads + head
+        : (size_t)head * sourceSeqLen + sourceTokenOffset + token;
+    __shared__ float x[128];
+    __shared__ float warpSums[4];
+    x[lane] = LoadSource(src, sourceRow * headDim + group * 128 + lane);
+    __syncthreads();
+    float sq = x[lane] * x[lane];
+    for (int off = 16; off > 0; off >>= 1)
+        sq += __shfl_down_sync(0xffffffff, sq, off);
+    if ((lane & 31) == 0) warpSums[lane >> 5] = sq;
+    __syncthreads();
+    float normSq = warpSums[0] + warpSums[1] + warpSums[2] + warpSums[3];
+    float norm = sqrtf(normSq);
+    x[lane] = norm > 1.0e-10f ? x[lane] / norm : 0.0f;
+    __syncthreads();
+    ForwardWht128(x, lane);
+    uint8_t index = NearestTurbo3(x[lane]);
+    float reconSq = kTurbo3Centroids[index] * kTurbo3Centroids[index];
+    for (int off = 16; off > 0; off >>= 1)
+        reconSq += __shfl_down_sync(0xffffffff, reconSq, off);
+    if ((lane & 31) == 0) warpSums[lane >> 5] = reconSq;
+    __syncthreads();
+    float totalRecon = warpSums[0] + warpSums[1] + warpSums[2] + warpSums[3];
+    float correctedNorm = totalRecon > 1.0e-10f ? norm / sqrtf(totalRecon) : norm;
+    constexpr size_t rowBytes = kTurbo3RowBytes;
+    size_t dstRow = ((size_t)page * pageLen + pageOffset) * numHeads + head;
+    Turbo3KvBlock *out = reinterpret_cast<Turbo3KvBlock *>(dst + dstRow * rowBytes) + group;
+    if (lane == 0) out->norm = FloatToHalfBits(correctedNorm);
+    unsigned warpMask = 0xffffffffu;
+    uint8_t low = index & 3;
+    uint8_t packedLow = 0;
+    int warpLane = lane & 31;
+    #pragma unroll
+    for (int i = 0; i < 4; i++)
+        packedLow |= static_cast<uint8_t>(__shfl_sync(warpMask, low, (warpLane & ~3) + i)) << (2 * i);
+    if ((warpLane & 3) == 0) out->low2[lane / 4] = packedLow;
+    unsigned high = __ballot_sync(warpMask, (index & 4) != 0);
+    if ((warpLane & 7) == 0)
+        out->high1[lane / 8] = static_cast<uint8_t>((high >> ((warpLane / 8) * 8)) & 0xff);
+}
+
+__global__ void GatherQ8HeadRangeKernel(
+        const uint8_t *src, const int32_t *pageIndices, int kvStart,
+        int chunkLen, int pageLen, int numHeads, int headDim, int head,
+        half *out) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = chunkLen * headDim;
+    if (idx >= total) return;
+    int tokenInChunk = idx / headDim;
+    int dim = idx % headDim;
+    int logicalToken = kvStart + tokenInChunk;
+    int pageList = logicalToken / pageLen;
+    int pageOffset = logicalToken % pageLen;
+    int page = pageIndices[pageList];
+    constexpr size_t rowBytes = kQ8RowBytes;
+    size_t row = ((size_t)page * pageLen + pageOffset) * numHeads + head;
+    const Q8KvBlock *block = reinterpret_cast<const Q8KvBlock *>(src + row * rowBytes) + dim / 32;
+    float scale = HalfBitsToFloat(block->scale);
+    out[idx] = __float2half_rn(scale * static_cast<float>(block->values[dim & 31]));
+}
+
+__global__ void GatherTurbo3HeadRangeKernel(
+        const uint8_t *src, const int32_t *pageIndices, int kvStart,
+        int chunkLen, int pageLen, int numHeads, int headDim, int head,
+        half *out) {
+    int tokenInChunk = blockIdx.x;
+    int group = blockIdx.y;
+    int lane = threadIdx.x;
+    if (tokenInChunk >= chunkLen || lane >= 128) return;
+    int logicalToken = kvStart + tokenInChunk;
+    int pageList = logicalToken / pageLen;
+    int pageOffset = logicalToken % pageLen;
+    int page = pageIndices[pageList];
+    constexpr size_t rowBytes = kTurbo3RowBytes;
+    size_t row = ((size_t)page * pageLen + pageOffset) * numHeads + head;
+    const Turbo3KvBlock *block = reinterpret_cast<const Turbo3KvBlock *>(src + row * rowBytes) + group;
+    uint8_t index = static_cast<uint8_t>((block->low2[lane / 4] >> (2 * (lane & 3))) & 3);
+    index |= static_cast<uint8_t>(((block->high1[lane / 8] >> (lane & 7)) & 1) << 2);
+    __shared__ float x[128];
+    x[lane] = kTurbo3Centroids[index] * HalfBitsToFloat(block->norm);
+    __syncthreads();
+    InverseWht128(x, lane);
+    out[(size_t)tokenInChunk * headDim + group * 128 + lane] = __float2half_rn(x[lane]);
+}
+
+template <typename SrcT>
+bool LaunchCopy(uint8_t *pagedData, int pageIdx, int pageLen, int numHeads,
+                int headDim, fastllm::DataType dstType, const SrcT *inputData,
+                int seqLen, int inputOffset, int copyLen, int pageOffset) {
+    if (headDim != kHeadDim || copyLen <= 0 || inputOffset < 0 ||
+        pageOffset < 0 || pageOffset + copyLen > pageLen) return false;
+    int32_t *meta = static_cast<int32_t *>(FastllmCudaMalloc(2 * sizeof(int32_t)));
+    if (meta == nullptr) return false;
+    int32_t host[2] = {pageIdx, pageOffset};
+    cudaError_t error = cudaMemcpyAsync(meta, host, sizeof(host), cudaMemcpyHostToDevice,
+                                        cudaStreamPerThread);
+    if (error != cudaSuccess) { FastllmCudaFree(meta); cudaGetLastError(); return false; }
+    int rows = numHeads * copyLen;
+    if (dstType == fastllm::DataType::Q8_0_KV) {
+        dim3 grid(rows, headDim / 32, 1);
+        QuantizeQ8RowsKernel<SrcT><<<grid, 32, 0, cudaStreamPerThread>>>(
+            inputData, pagedData, meta, meta + 1, rows, seqLen, pageLen,
+            numHeads, headDim, false, inputOffset);
+    } else if (dstType == fastllm::DataType::TURBO3_KV) {
+        dim3 grid(rows, headDim / 128, 1);
+        QuantizeTurbo3RowsKernel<SrcT><<<grid, 128, 0, cudaStreamPerThread>>>(
+            inputData, pagedData, meta, meta + 1, rows, seqLen, pageLen,
+            numHeads, headDim, false, inputOffset);
+    } else {
+        FastllmCudaFree(meta); return false;
+    }
+    error = cudaGetLastError();
+    cudaError_t syncError = cudaStreamSynchronize(cudaStreamPerThread);
+    FastllmCudaFree(meta);
+    return error == cudaSuccess && syncError == cudaSuccess;
+}
+
+template <typename SrcT>
+bool LaunchCopyBatch(uint8_t *pagedData, int32_t *pageIds,
+                     int32_t *pageOffsets, int pageLen, int batch,
+                     int numHeads, int headDim, fastllm::DataType dstType,
+                     const SrcT *inputData, bool sync) {
+    if (headDim != kHeadDim || batch <= 0 || pageIds == nullptr || pageOffsets == nullptr) return false;
+    int rows = batch * numHeads;
+    if (dstType == fastllm::DataType::Q8_0_KV) {
+        dim3 grid(rows, headDim / 32, 1);
+        QuantizeQ8RowsKernel<SrcT><<<grid, 32, 0, cudaStreamPerThread>>>(
+            inputData, pagedData, pageIds, pageOffsets, rows, 1,
+            pageLen, numHeads, headDim, true, 0);
+    } else if (dstType == fastllm::DataType::TURBO3_KV) {
+        dim3 grid(rows, headDim / 128, 1);
+        QuantizeTurbo3RowsKernel<SrcT><<<grid, 128, 0, cudaStreamPerThread>>>(
+            inputData, pagedData, pageIds, pageOffsets, rows, 1,
+            pageLen, numHeads, headDim, true, 0);
+    } else {
+        return false;
+    }
+    cudaError_t error = cudaGetLastError();
+    if (sync && error == cudaSuccess) error = cudaStreamSynchronize(cudaStreamPerThread);
+    return error == cudaSuccess;
+}
+
+} // namespace
+
+bool FastllmCudaPackedKVCacheCopy(
+        uint8_t *pagedData, int pageIdx, int pageLen, int numHeads,
+        int headDim, fastllm::DataType dstType, uint8_t *inputData,
+        fastllm::DataType srcType, int seqLen, int inputOffset,
+        int copyLen, int pageOffset) {
+    if (!fastllm::IsPackedKVCacheDataType(dstType) || pagedData == nullptr || inputData == nullptr)
+        return false;
+    if (srcType == fastllm::DataType::FLOAT16)
+        return LaunchCopy(pagedData, pageIdx, pageLen, numHeads, headDim, dstType,
+                          reinterpret_cast<const half *>(inputData), seqLen,
+                          inputOffset, copyLen, pageOffset);
+    if (srcType == fastllm::DataType::BFLOAT16)
+        return LaunchCopy(pagedData, pageIdx, pageLen, numHeads, headDim, dstType,
+                          reinterpret_cast<const __nv_bfloat16 *>(inputData), seqLen,
+                          inputOffset, copyLen, pageOffset);
+    if (srcType == fastllm::DataType::FLOAT32)
+        return LaunchCopy(pagedData, pageIdx, pageLen, numHeads, headDim, dstType,
+                          reinterpret_cast<const float *>(inputData), seqLen,
+                          inputOffset, copyLen, pageOffset);
+    return false;
+}
+
+bool FastllmCudaPackedKVCacheCopyBatch(
+        uint8_t *pagedData, int32_t *pageIds, int32_t *pageOffsets,
+        int pageLen, int batch, int numHeads, int headDim,
+        fastllm::DataType dstType, uint8_t *inputData,
+        fastllm::DataType srcType, bool sync) {
+    if (!fastllm::IsPackedKVCacheDataType(dstType) || pagedData == nullptr || inputData == nullptr)
+        return false;
+    if (srcType == fastllm::DataType::FLOAT16)
+        return LaunchCopyBatch(pagedData, pageIds, pageOffsets, pageLen, batch,
+                               numHeads, headDim, dstType,
+                               reinterpret_cast<const half *>(inputData), sync);
+    if (srcType == fastllm::DataType::BFLOAT16)
+        return LaunchCopyBatch(pagedData, pageIds, pageOffsets, pageLen, batch,
+                               numHeads, headDim, dstType,
+                               reinterpret_cast<const __nv_bfloat16 *>(inputData), sync);
+    if (srcType == fastllm::DataType::FLOAT32)
+        return LaunchCopyBatch(pagedData, pageIds, pageOffsets, pageLen, batch,
+                               numHeads, headDim, dstType,
+                               reinterpret_cast<const float *>(inputData), sync);
+    return false;
+}
+
+bool FastllmCudaPackedKVCacheGatherHeadRangeToHalf(
+        const uint8_t *pagedData, fastllm::DataType srcType,
+        const int32_t *pageIndices, int kvStart, int chunkLen,
+        int pageLen, int numHeads, int headDim, int head, void *output) {
+    if (pagedData == nullptr || pageIndices == nullptr || output == nullptr ||
+        headDim != kHeadDim || chunkLen <= 0 || head < 0 || head >= numHeads)
+        return false;
+    if (srcType == fastllm::DataType::Q8_0_KV) {
+        int total = chunkLen * headDim;
+        GatherQ8HeadRangeKernel<<<(total + 255) / 256, 256, 0, cudaStreamPerThread>>>(
+            pagedData, pageIndices, kvStart, chunkLen, pageLen,
+            numHeads, headDim, head, reinterpret_cast<half *>(output));
+    } else if (srcType == fastllm::DataType::TURBO3_KV) {
+        dim3 grid(chunkLen, headDim / 128, 1);
+        GatherTurbo3HeadRangeKernel<<<grid, 128, 0, cudaStreamPerThread>>>(
+            pagedData, pageIndices, kvStart, chunkLen, pageLen,
+            numHeads, headDim, head, reinterpret_cast<half *>(output));
+    } else {
+        return false;
+    }
+    return cudaGetLastError() == cudaSuccess;
+}

--- a/src/devices/cuda/cudadevice.cpp
+++ b/src/devices/cuda/cudadevice.cpp
@@ -6406,8 +6406,9 @@ total += weights[nextExpert * 2 + 1]->GetBytes();
         AssertInFastLLM(cache.dataType == DataType::FLOAT32 ||
                         cache.dataType == DataType::FLOAT16 ||
                         cache.dataType == DataType::BFLOAT16 ||
-                        cache.dataType == DataType::FP8_E4M3,
-                        "CudaAppendPagedCacheOp's cache's type should be float32, float16, bfloat16 or fp8_e4m3.\n");
+                        cache.dataType == DataType::FP8_E4M3 ||
+                        IsPackedKVCacheDataType(cache.dataType),
+                        "CudaAppendPagedCacheOp's cache type should be float32, float16, bfloat16, fp8_e4m3 or packed KV.\n");
         AssertInFastLLM(input.dataType == DataType::FLOAT32 ||
                         input.dataType == DataType::FLOAT16 ||
                         input.dataType == DataType::BFLOAT16,
@@ -6573,8 +6574,9 @@ total += weights[nextExpert * 2 + 1]->GetBytes();
         AssertInFastLLM(((Data*)&manager)->dataType == DataType::FLOAT32 ||
                         ((Data*)&manager)->dataType == DataType::FLOAT16 ||
                         ((Data*)&manager)->dataType == DataType::BFLOAT16 ||
-                        ((Data*)&manager)->dataType == DataType::FP8_E4M3,
-                        "CudaAppendPagedCacheBatchOp's cache type should be float32, float16, bfloat16 or fp8_e4m3.\n");
+                        ((Data*)&manager)->dataType == DataType::FP8_E4M3 ||
+                        IsPackedKVCacheDataType(((Data*)&manager)->dataType),
+                        "CudaAppendPagedCacheBatchOp's cache type should be float32, float16, bfloat16, fp8_e4m3 or packed KV.\n");
         AssertInFastLLM(input.dims.size() == 3,
                         "CudaAppendPagedCacheBatchOp's input should have 3 dimensions [batch, numHeads, headDim].\n");
         AssertInFastLLM(insertIndexs.dims.size() == 1 && insertIndexs.dims[0] == input.dims[0],

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -9056,7 +9056,7 @@ __global__ void FastllmShiftAppendConv1DPerChannelSiluTwoTokenHalfKernel(
 #endif
 }
 
-static constexpr int FASTLLM_CUDA_MTP_FAST_SEQ_MAX = 6;
+static constexpr int FASTLLM_CUDA_MTP_FAST_SEQ_MAX = 10;
 static constexpr int FASTLLM_CUDA_MTP_PREFIX_SNAPSHOT_MAX =
     FASTLLM_CUDA_MTP_FAST_SEQ_MAX - 1;
 // Ordinary batched prefill does not materialize per-token MTP snapshots.  Its
@@ -9163,37 +9163,32 @@ static void **FastllmCudaStagePointers(const std::vector<void*> &pointers) {
     return (void**)scratch.data;
 }
 
-// 处理最多6个新token的conv1d(kernel=4)滑窗更新, 并在处理完第t个token后
-// 把当时的滑窗状态写入对应快照 (用于MTP验证的逐token状态回滚)。
-__global__ void FastllmShiftAppendConv1DPerChannelSiluMultiTokenHalfKernel(
-    half *cache, const half *newTokens, const float *weight, const float *bias,
-    half *output,
-    half *snap0, half *snap1, half *snap2, half *snap3, half *snap4, half *snap5,
-    int numSnaps,
-    int batch, int channels, int numTokens) {
+
+__global__ void FastllmShiftAppendConv1DPerChannelSiluMultiTokenHalfContiguousKernel(
+    half *cache, half **snapshots, const half *newTokens,
+    const float *weight, const float *bias, half *output,
+    int batch, int channels, int numTokens, int numSnaps) {
     int row = blockIdx.x * blockDim.x + threadIdx.x;
     int total = batch * channels;
     if (row >= total) {
         return;
     }
-
-    int c = row % channels;
+    int channel = row % channels;
     half *cacheRow = cache + (size_t)row * 4;
     const half *tokenRow = newTokens + (size_t)row * numTokens;
     half x0 = cacheRow[0];
     half x1 = cacheRow[1];
     half x2 = cacheRow[2];
     half x3 = cacheRow[3];
-
-    const float *curWeight = weight + (size_t)c * 4;
-    float biasVal = bias ? bias[c] : 0.0f;
+    const float *curWeight = weight + (size_t)channel * 4;
+    float biasValue = bias == nullptr ? 0.0f : bias[channel];
     half *outputRow = output + (size_t)row * numTokens;
-    for (int t = 0; t < numTokens; t++) {
+    for (int token = 0; token < numTokens; token++) {
         x0 = x1;
         x1 = x2;
         x2 = x3;
-        x3 = tokenRow[t];
-        float value = biasVal;
+        x3 = tokenRow[token];
+        float value = biasValue;
         value += __half2float(x0) * curWeight[0];
         value += __half2float(x1) * curWeight[1];
         value += __half2float(x2) * curWeight[2];
@@ -9201,31 +9196,19 @@ __global__ void FastllmShiftAppendConv1DPerChannelSiluMultiTokenHalfKernel(
         half conv = __float2half_rn(value);
 #ifdef CUDA_NO_TENSOR_CORE
         float y = __half2float(conv);
-        outputRow[t] = __float2half(y / (1.0f + expf(-y)));
+        outputRow[token] = __float2half(y / (1.0f + expf(-y)));
 #else
-        outputRow[t] = __hdiv(conv, __hadd(__float2half(1.0f), hexp(-conv)));
+        outputRow[token] =
+            __hdiv(conv, __hadd(__float2half(1.0f), hexp(-conv)));
 #endif
-        half *snapBase = nullptr;
-        if (t < numSnaps) {
-            switch (t) {
-                case 0: snapBase = snap0; break;
-                case 1: snapBase = snap1; break;
-                case 2: snapBase = snap2; break;
-                case 3: snapBase = snap3; break;
-                case 4: snapBase = snap4; break;
-                case 5: snapBase = snap5; break;
-                default: break;
-            }
-        }
-        if (snapBase != nullptr) {
-            half *snapRow = snapBase + (size_t)row * 4;
-            snapRow[0] = x0;
-            snapRow[1] = x1;
-            snapRow[2] = x2;
-            snapRow[3] = x3;
+        if (token < numSnaps && snapshots[token] != nullptr) {
+            half *snapshotRow = snapshots[token] + (size_t)row * 4;
+            snapshotRow[0] = x0;
+            snapshotRow[1] = x1;
+            snapshotRow[2] = x2;
+            snapshotRow[3] = x3;
         }
     }
-
     cacheRow[0] = x0;
     cacheRow[1] = x1;
     cacheRow[2] = x2;
@@ -9725,6 +9708,12 @@ bool FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16(
         snaps[t] = (half *) snap->cudaData;
     }
 
+    std::vector<void*> pointers(numTokenCaches);
+    for (int t = 0; t < numTokenCaches; t++) {
+        pointers[t] = snaps[t];
+    }
+    void **devicePointers = FastllmCudaStagePointers(pointers);
+
     int batch = cache.dims[0];
     int channels = cache.dims[1];
     int threadsPerBlock = 256;
@@ -9734,14 +9723,11 @@ bool FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16(
         checkCudaErrors("Error: stale CUDA error before FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16.", pendingState);
         return false;
     }
-    FastllmShiftAppendConv1DPerChannelSiluMultiTokenHalfKernel<<<blocksPerGrid, threadsPerBlock>>>(
-        (half *) cache.cudaData, (const half *) newTokens.cudaData,
-        (const float *) weight.cudaData,
-        bias.dims.size() > 0 ? (const float *) bias.cudaData : nullptr,
-        (half *) output.cudaData,
-        snaps[0], snaps[1], snaps[2], snaps[3], snaps[4], snaps[5],
-        numTokenCaches, batch, channels, numTokens
-    );
+    FastllmShiftAppendConv1DPerChannelSiluMultiTokenHalfContiguousKernel<<<blocksPerGrid, threadsPerBlock>>>(
+        (half *)cache.cudaData, (half **)devicePointers,
+        (const half *)newTokens.cudaData, (const float *)weight.cudaData,
+        bias.dims.size() > 0 ? (const float *)bias.cudaData : nullptr,
+        (half *)output.cudaData, batch, channels, numTokens, numTokenCaches);
     cudaError_t launchState = cudaGetLastError();
     if (launchState != cudaSuccess) {
         checkCudaErrors("Error: CUDA error in FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16.", launchState);
@@ -10601,7 +10587,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleNormBaTransposedHalfWarpKernel(
     const float* a_log,          // [n1]
     const float* dt_bias,        // [n1]
     half* core_attn_out,         // [n0, n1, n3]
-    int n0, int n1, int n2, int n3, int group, float eps, float qScale)
+    int n0, int n1, int n2, int n3, int group, float eps, float qScale,
+    bool tiledQKHeadOrder)
 {
     int batch_idx = blockIdx.x;
     int head_idx = blockIdx.y;
@@ -10613,7 +10600,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleNormBaTransposedHalfWarpKernel(
     int lane_id = tid & 31;
     int base_idx = batch_idx * n1 + head_idx;
     int kv_heads = n1 / group;
-    int qk_base = (batch_idx * kv_heads + head_idx / group) * n2;
+    int qkHead = tiledQKHeadOrder ? head_idx % kv_heads : head_idx / group;
+    int qk_base = (batch_idx * kv_heads + qkHead) * n2;
     int state_base = base_idx * n2 * n3;
     int out_base = base_idx * n3;
 
@@ -10724,7 +10712,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleNormTransposedHalfWarpKernel(
     const half* q_t,             // [n0, n1 / group, n2], unnormalized
     const float* norm_weight,    // [n2]
     half* core_attn_out,         // [n0, n1, n3]
-    int n0, int n1, int n2, int n3, int group, float eps, float qScale)
+    int n0, int n1, int n2, int n3, int group, float eps, float qScale,
+    bool tiledQKHeadOrder)
 {
     int batch_idx = blockIdx.x;
     int head_idx = blockIdx.y;
@@ -10736,7 +10725,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleNormTransposedHalfWarpKernel(
     int lane_id = tid & 31;
     int base_idx = batch_idx * n1 + head_idx;
     int kv_heads = n1 / group;
-    int qk_base = (batch_idx * kv_heads + head_idx / group) * n2;
+    int qkHead = tiledQKHeadOrder ? head_idx % kv_heads : head_idx / group;
+    int qk_base = (batch_idx * kv_heads + qkHead) * n2;
     int state_base = base_idx * n2 * n3;
     int out_base = base_idx * n3;
 
@@ -11042,7 +11032,7 @@ bool FastllmLinearAttentionStateTransposeVKToKVFloat16(fastllm::Data &last_recur
     return FastllmLinearAttentionStateTransposeFloat16(last_recurrent_state, false);
 }
 
-bool FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale) {
+bool FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &g, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale, bool tiledQKHeadOrder) {
     if (q.dataDevice != fastllm::DataDevice::CUDA ||
         k.dataDevice != fastllm::DataDevice::CUDA ||
         v.dataDevice != fastllm::DataDevice::CUDA ||
@@ -11109,13 +11099,13 @@ bool FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(fastllm::Data &q, fastl
         (half*)q.cudaData,
         (float*)normWeight.cudaData,
         (half*)core_attn_out.cudaData,
-        n0, n1, n2, n3, group, eps, qScale
+        n0, n1, n2, n3, group, eps, qScale, tiledQKHeadOrder
     );
     checkCudaErrors("Error: CUDA error in FastllmRecurrentGatedDeltaRuleNormTransposedFloat16.", cudaGetLastError());
     return true;
 }
 
-bool FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &a, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &aLog, fastllm::Data &dtBias, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale) {
+bool FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(fastllm::Data &q, fastllm::Data &k, fastllm::Data &v, fastllm::Data &a, fastllm::Data &b, fastllm::Data &normWeight, fastllm::Data &aLog, fastllm::Data &dtBias, fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out, float eps, float qScale, bool tiledQKHeadOrder) {
     if (q.dataDevice != fastllm::DataDevice::CUDA ||
         k.dataDevice != fastllm::DataDevice::CUDA ||
         v.dataDevice != fastllm::DataDevice::CUDA ||
@@ -11192,7 +11182,7 @@ bool FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(fastllm::Data &q, fas
         (float*)aLog.cudaData,
         (float*)dtBias.cudaData,
         (half*)core_attn_out.cudaData,
-        n0, n1, n2, n3, group, eps, qScale
+        n0, n1, n2, n3, group, eps, qScale, tiledQKHeadOrder
     );
     checkCudaErrors("Error: CUDA error in FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16.", cudaGetLastError());
     return true;
@@ -11288,7 +11278,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaHalfKernel(
     half *core_attn_out,
     int batch, int numKHeads, int numVHeads, int headKDim, int headVDim,
     float eps, float qScale,
-    half *statePool, const int *slotIds, int stateStride) {
+    half *statePool, const int *slotIds, int stateStride,
+    bool tiledQKHeadOrder) {
     int batch_idx = blockIdx.x;
     int head_idx = blockIdx.y;
     if (batch_idx >= batch || head_idx >= numVHeads) return;
@@ -11298,7 +11289,7 @@ __global__ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaHalfKernel(
     int lane_id = tid % 32;
     int numWarps = (blockDim.x + 31) / 32;
     int group = numVHeads / numKHeads;
-    int qHead = head_idx / group;
+    int qHead = tiledQKHeadOrder ? head_idx % numKHeads : head_idx / group;
     int qkvDim = 2 * numKHeads * headKDim + numVHeads * headVDim;
     int convBase = batch_idx * qkvDim;
     int qOffset = convBase + qHead * headKDim;
@@ -11431,7 +11422,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedHalfWarpK
     half *core_attn_out,
     int batch, int numKHeads, int numVHeads, int headKDim, int headVDim,
     float eps, float qScale,
-    half *statePool, const int *slotIds, int stateStride) {
+    half *statePool, const int *slotIds, int stateStride,
+    bool tiledQKHeadOrder) {
     int batch_idx = blockIdx.x;
     int head_idx = blockIdx.y;
     int v_base = blockIdx.z * TILE_V;
@@ -11443,7 +11435,7 @@ __global__ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedHalfWarpK
     int warp_id = tid >> 5;
     int lane_id = tid & 31;
     int group = numVHeads / numKHeads;
-    int qHead = head_idx / group;
+    int qHead = tiledQKHeadOrder ? head_idx % numKHeads : head_idx / group;
     int qkvDim = 2 * numKHeads * headKDim + numVHeads * headVDim;
     int convBase = batch_idx * qkvDim;
     int qOffset = convBase + qHead * headKDim;
@@ -11643,7 +11635,7 @@ static bool LaunchFastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedHalfWar
     int batch, int numKHeads, int numVHeads, int headKDim, int headVDim,
     float eps, float qScale,
     half *statePool, const int *slotIds, int stateStride,
-    int tileV, bool exactNorm128) {
+    int tileV, bool exactNorm128, bool tiledQKHeadOrder) {
     if (headKDim != 128 || tileV != 8) {
         return false;
     }
@@ -11658,7 +11650,7 @@ static bool LaunchFastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedHalfWar
         <<<grid, threads, sharedBytes>>>( \
             lastRecurrentStates, convOutput, ba, normWeight, aLog, dtBias, \
             coreAttnOut, batch, numKHeads, numVHeads, headKDim, headVDim, \
-            eps, qScale, statePool, slotIds, stateStride)
+            eps, qScale, statePool, slotIds, stateStride, tiledQKHeadOrder)
 
     if (useTile32) {
         dim3 grid(batch, numVHeads, (headVDim + 31) / 32);
@@ -11686,7 +11678,8 @@ __global__ void FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedHalfWa
     int seqLen, int numKHeads, int numVHeads, int headKDim, int headVDim,
     float eps, float qScale,
     half *snap0, half *snap1, half *snap2, half *snap3, half *snap4,
-    half **snapshotPointers, int numSnaps) {
+    half **snapshotPointers, int numSnaps,
+    bool tiledQKHeadOrder) {
     int head_idx = blockIdx.x;
     int v_base = blockIdx.y * TILE_V;
     if (head_idx >= numVHeads || v_base >= headVDim) {
@@ -11697,7 +11690,7 @@ __global__ void FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedHalfWa
     int warp_id = tid >> 5;
     int lane_id = tid & 31;
     int group = numVHeads / numKHeads;
-    int qHead = head_idx / group;
+    int qHead = tiledQKHeadOrder ? head_idx % numKHeads : head_idx / group;
     int qkvDim = 2 * numKHeads * headKDim + numVHeads * headVDim;
     int v_col = v_base + warp_id;
     bool activeV = warp_id < TILE_V && v_col < headVDim;
@@ -11842,7 +11835,7 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaDevicePointers(
     fastllm::Data &first_recurrent_state, void *cudaStatePointers, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     if (cudaStatePointers == nullptr || batch <= 0 ||
         convOutput.dataDevice != fastllm::DataDevice::CUDA ||
         ba.dataDevice != fastllm::DataDevice::CUDA ||
@@ -11897,7 +11890,7 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaDevicePointers(
         (const float*)dtBias.cudaData,
         (half*)core_attn_out.cudaData,
         batch, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
-        nullptr, nullptr, 0
+        nullptr, nullptr, 0, tiledQKHeadOrder
     );
 
     checkCudaErrors("Error: CUDA error in FastllmRecurrentGatedDeltaRuleBatchFromConvBaDevicePointers.", cudaGetLastError());
@@ -11910,7 +11903,7 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedDevicePointers(
     fastllm::Data &first_recurrent_state, void *cudaStatePointers, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     if (cudaStatePointers == nullptr || batch <= 0 ||
         convOutput.dataDevice != fastllm::DataDevice::CUDA ||
         ba.dataDevice != fastllm::DataDevice::CUDA ||
@@ -11963,7 +11956,8 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedDevicePointers(
         batch, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
         nullptr, nullptr, 0, 8,
         batch == 1 && numKHeads == 8 && numVHeads == 16 &&
-            headKDim == 128 && headVDim == 128
+            headKDim == 128 && headVDim == 128,
+        tiledQKHeadOrder
     );
 
     checkCudaErrors("Error: CUDA error in FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedDevicePointers.", cudaGetLastError());
@@ -11975,7 +11969,8 @@ static bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16Impl(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale, int tileV, bool exactNorm128) {
+    float eps, float qScale, int tileV, bool exactNorm128,
+    bool tiledQKHeadOrder) {
     if (convOutput.dataDevice != fastllm::DataDevice::CUDA ||
         ba.dataDevice != fastllm::DataDevice::CUDA ||
         normWeight.dataDevice != fastllm::DataDevice::CUDA ||
@@ -12025,7 +12020,8 @@ static bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16Impl(
         (const float*)dtBias.cudaData,
         (half*)core_attn_out.cudaData,
         1, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
-        (half*)last_recurrent_state.cudaData, nullptr, 0, tileV, exactNorm128)) {
+        (half*)last_recurrent_state.cudaData, nullptr, 0, tileV,
+        exactNorm128, tiledQKHeadOrder)) {
         return false;
     }
 
@@ -12043,7 +12039,7 @@ bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16WithConfig(
         convOutput, ba, normWeight, aLog, dtBias,
         last_recurrent_state, core_attn_out,
         numKHeads, numVHeads, headKDim, headVDim,
-        eps, qScale, tileV, exactNorm128);
+        eps, qScale, tileV, exactNorm128, false);
 }
 
 bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16(
@@ -12051,14 +12047,15 @@ bool FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     return FastllmRecurrentGatedDeltaRuleFromConvBaTransposedFloat16Impl(
         convOutput, ba, normWeight, aLog, dtBias,
         last_recurrent_state, core_attn_out,
         numKHeads, numVHeads, headKDim, headVDim,
         eps, qScale, 8,
         numKHeads == 8 && numVHeads == 16 &&
-            headKDim == 128 && headVDim == 128);
+            headKDim == 128 && headVDim == 128,
+        tiledQKHeadOrder);
 }
 
 bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16(
@@ -12066,12 +12063,13 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     return FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
         convOutput, ba, normWeight, aLog, dtBias,
         last_recurrent_state, core_attn_out,
         nullptr, 0,
-        numKHeads, numVHeads, headKDim, headVDim, eps, qScale);
+        numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
+        tiledQKHeadOrder);
 }
 
 bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
@@ -12080,7 +12078,7 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
     fastllm::Data &last_recurrent_state, fastllm::Data &core_attn_out,
     fastllm::Data **tokenStates, int numTokenStates,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     if (!FastllmCudaDataCanShareDevice(last_recurrent_state, convOutput) ||
         !FastllmCudaDataCanShareDevice(last_recurrent_state, ba) ||
         !FastllmCudaDataCanShareDevice(last_recurrent_state, normWeight) ||
@@ -12212,6 +12210,12 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
         snaps[t] = (half*)snap->cudaData;
     }
 
+    std::vector<void*> snapshotPointers(numTokenStates);
+    for (int t = 0; t < numTokenStates; t++) {
+        snapshotPointers[t] = snaps[t];
+    }
+    void **deviceSnapshotPointers = FastllmCudaStagePointers(snapshotPointers);
+
     constexpr int tileV = 8;
     int threadsPerBlock = tileV * 32;
     size_t sharedMemSize = (2 * (size_t)headKDim + 8) * sizeof(float);
@@ -12231,8 +12235,8 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
         (half*)last_recurrent_state.cudaData, nullptr,
         (half*)core_attn_out.cudaData,
         seqLen, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
-        snaps[0], snaps[1], snaps[2], snaps[3], snaps[4],
-        nullptr, numTokenStates
+        nullptr, nullptr, nullptr, nullptr, nullptr,
+        (half **)deviceSnapshotPointers, numTokenStates, tiledQKHeadOrder
     );
 
     cudaError_t launchState = cudaGetLastError();
@@ -12250,7 +12254,7 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16BatchSnaps
     fastllm::Data &coreAttnOut,
     const std::vector<fastllm::Data*> &tokenStates, int numTokenStates,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     if (lastRecurrentStates.empty() || lastRecurrentStates[0] == nullptr ||
         numTokenStates < 0 ||
         numTokenStates > FASTLLM_CUDA_MTP_PREFIX_SNAPSHOT_MAX ||
@@ -12373,7 +12377,8 @@ bool FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16BatchSnaps
             (half*)coreAttnOut.cudaData,
             seqLen, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
             nullptr, nullptr, nullptr, nullptr, nullptr,
-            (half**)(devicePointers + batch), numTokenStates);
+            (half**)(devicePointers + batch), numTokenStates,
+            tiledQKHeadOrder);
     cudaError_t launchState = cudaGetLastError();
     if (launchState != cudaSuccess) {
         checkCudaErrors(
@@ -12390,7 +12395,7 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedSlots(
     void *cudaStatePool, void *cudaSlotIds, int batch,
     fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     if (cudaStatePool == nullptr || cudaSlotIds == nullptr || batch <= 0 ||
         convOutput.dataDevice != fastllm::DataDevice::CUDA ||
         ba.dataDevice != fastllm::DataDevice::CUDA ||
@@ -12436,7 +12441,8 @@ bool FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedSlots(
         batch, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
         (half*)cudaStatePool, (const int*)cudaSlotIds, stateStride, 8,
         batch == 1 && numKHeads == 8 && numVHeads == 16 &&
-            headKDim == 128 && headVDim == 128
+            headKDim == 128 && headVDim == 128,
+        tiledQKHeadOrder
     );
 
     checkCudaErrors("Error: CUDA error in FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedSlots.", cudaGetLastError());
@@ -12448,7 +12454,7 @@ void FastllmRecurrentGatedDeltaRuleBatchFromConvBa(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     std::vector<fastllm::Data*> &last_recurrent_states, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     int batch = (int)last_recurrent_states.size();
     std::vector<void*> pointers(batch);
     for (int i = 0; i < batch; i++) {
@@ -12458,7 +12464,8 @@ void FastllmRecurrentGatedDeltaRuleBatchFromConvBa(
 
     FastllmRecurrentGatedDeltaRuleBatchFromConvBaDevicePointers(
         convOutput, ba, normWeight, aLog, dtBias, *last_recurrent_states[0], cudaPointers, batch,
-        core_attn_out, numKHeads, numVHeads, headKDim, headVDim, eps, qScale);
+        core_attn_out, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
+        tiledQKHeadOrder);
 }
 
 void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposed(
@@ -12466,7 +12473,7 @@ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposed(
     fastllm::Data &aLog, fastllm::Data &dtBias,
     std::vector<fastllm::Data*> &last_recurrent_states, fastllm::Data &core_attn_out,
     int numKHeads, int numVHeads, int headKDim, int headVDim,
-    float eps, float qScale) {
+    float eps, float qScale, bool tiledQKHeadOrder) {
     int batch = (int)last_recurrent_states.size();
     std::vector<void*> pointers(batch);
     for (int i = 0; i < batch; i++) {
@@ -12476,7 +12483,8 @@ void FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposed(
 
     FastllmRecurrentGatedDeltaRuleBatchFromConvBaTransposedDevicePointers(
         convOutput, ba, normWeight, aLog, dtBias, *last_recurrent_states[0], cudaPointers, batch,
-        core_attn_out, numKHeads, numVHeads, headKDim, headVDim, eps, qScale);
+        core_attn_out, numKHeads, numVHeads, headKDim, headVDim, eps, qScale,
+        tiledQKHeadOrder);
 }
 
 template <typename T>

--- a/src/devices/cuda/fastllm-ggml-cuda.cu
+++ b/src/devices/cuda/fastllm-ggml-cuda.cu
@@ -1964,6 +1964,90 @@ static void dequantize_row_q6_K_r4_cuda(const void * vx, dst_t * y, const int64_
     const int64_t nblocks = (nrows / 4) * (n_per_row / QK_K);
     dequantize_block_q6_K_r4<<<nblocks, 128, 0, stream>>>(vx, y, n_per_row);
 }
+// ---------------------------------------------------------------------------
+// IQ4_XS dequantization (GGML_TYPE_IQ4_XS)
+//
+// Reference: third_party/gguf/ggml-dequantize.cpp dequantize_row_iq4_xs.
+// Each block_iq4_xs covers QK_K (256) values split into QK_K/32 (8) sub-blocks.
+// For sub-block ib: ls = (scales_l[ib/2] >> 4*(ib%2)) & 0xf  |  ((scales_h >> 2*ib) & 3) << 4
+//                   dl = d * (ls - 32)
+// Each of the 16 qs bytes in the sub-block yields two values via kvalues_iq4nl:
+//   y[j+0]  = dl * kvalues_iq4nl[qs[j] & 0xf]
+//   y[j+16] = dl * kvalues_iq4nl[qs[j] >>  4]
+// One CUDA block per iq4_xs block, 256 threads (one output element each).
+template<typename dst_t>
+static __global__ void dequantize_block_iq4_xs(const void * __restrict__ vx, dst_t * __restrict__ yy) {
+    const block_iq4_xs * x = (const block_iq4_xs *) vx;
+
+    const int64_t i  = blockIdx.x;
+    const int     tid = threadIdx.x;        // 0 .. 255 -> output element within block
+
+    const float d = __half2float(x[i].d);
+
+    const int ib = tid >> 5;                 // sub-block index 0 .. 7
+    const int p  = tid & 31;                 // position within sub-block 0 .. 31
+    const int j  = p & 15;                   // qs byte index within sub-block 0 .. 15
+
+    const uint8_t qbyte = x[i].qs[ib * 16 + j];
+    const uint8_t nibble = (p < 16) ? (uint8_t)(qbyte & 0x0f) : (uint8_t)(qbyte >> 4);
+
+    // six-bit scale: 4 low bits from scales_l, 2 high bits from scales_h
+    const int ls = ((x[i].scales_l[ib >> 1] >> (4 * (ib & 1))) & 0x0f)
+                 | (((x[i].scales_h >> (2 * ib)) & 0x3) << 4);
+    const float dl = d * (float)(ls - 32);
+
+    yy[i * QK_K + tid] = DequantizeCast<dst_t>::cast(dl * (float)kvalues_iq4nl[nibble]);
+}
+
+template<typename dst_t>
+static void dequantize_row_iq4_xs_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int64_t nb = k / QK_K;
+    dequantize_block_iq4_xs<<<nb, QK_K, 0, stream>>>(vx, y);
+}
+
+// ---------------------------------------------------------------------------
+// Q5_0 dequantization (GGML_TYPE_Q5_0)
+//
+// Reference: third_party/gguf/ggml-dequantize.cpp dequantize_row_q5_0.
+// Each block_q5_0 covers QK5_0 (32) values.  qs[16] holds low 4 bits;
+// qh[4] (uint32) holds the 5th bits.  value = d * (five_bit_q - 16).
+// Positions 0..15  use low nibbles of qs[0..15] with 5th bits qh[0..15].
+// Positions 16..31 use high nibbles            with 5th bits qh[16..31].
+// One CUDA block per q5_0 block, 32 threads (one output element each).
+template<typename dst_t>
+static __global__ void dequantize_block_q5_0(const void * __restrict__ vx, dst_t * __restrict__ yy) {
+    const block_q5_0 * x = (const block_q5_0 *) vx;
+
+    const int64_t i  = blockIdx.x;
+    const int     tid = threadIdx.x;         // 0 .. 31 -> output element
+
+    const float d = __half2float(x[i].d);
+
+    uint32_t qh;
+    memcpy(&qh, x[i].qh, sizeof(qh));
+
+    const int     j       = tid & 15;        // qs byte 0 .. 15
+    const uint8_t qs_byte = x[i].qs[j];
+
+    int val;
+    if (tid < 16) {
+        const uint8_t xh = (uint8_t)(((qh >> (j + 0)) << 4) & 0x10);
+        val = ((qs_byte & 0x0f) | xh) - 16;
+    } else {
+        const uint8_t xh = (uint8_t)((qh >> (j + 12)) & 0x10);
+        val = ((qs_byte >> 4) | xh) - 16;
+    }
+
+    yy[i * QK5_0 + tid] = DequantizeCast<dst_t>::cast(d * (float)val);
+}
+
+template<typename dst_t>
+static void dequantize_row_q5_0_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int64_t nb = k / QK5_0;
+    dequantize_block_q5_0<<<nb, QK5_0, 0, stream>>>(vx, y);
+}
 
 template<typename T>
 using to_t_cuda_t = void (*)(const void * __restrict__ x, T * __restrict__ y, int64_t nrows, int64_t n_per_row, cudaStream_t stream);
@@ -2122,6 +2206,18 @@ static bool FastllmGGUFIsR4Type(ggml_type type) {
     return type == GGML_TYPE_Q2_K_R4 || type == GGML_TYPE_Q4_K_R4 ||
            type == GGML_TYPE_Q5_K_R4 || type == GGML_TYPE_Q6_K_R4;
 }
+// Environment switch to disable the new IQ4_XS / Q5_0 CUDA dequantizers so
+// callers fall back to the original chunked-MMVQ path for A/B comparison.
+// Env: FASTLLM_DISABLE_GGUF_DEQUANT_IQ4XS_Q5_0=1|on|true|yes
+static bool FastllmGGUFDequantIq4xsQ50Disabled() {
+    static const bool disabled = []{
+        const char *env = std::getenv("FASTLLM_DISABLE_GGUF_DEQUANT_IQ4XS_Q5_0");
+        if (env == nullptr || env[0] == '\0') return false;
+        const char c = (char)std::tolower((unsigned char)env[0]);
+        return c == '1' || c == 't' || c == 'y' || c == 'o';
+    }();
+    return disabled;
+}
 
 static size_t FastllmGGUFAlignBytes(size_t bytes) {
     const size_t align = 256;
@@ -2214,6 +2310,10 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return dequantize_row_q6_K_cuda;
         case GGML_TYPE_Q6_K_R4:
             return dequantize_row_q6_K_r4_cuda;
+        case GGML_TYPE_IQ4_XS:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_iq4_xs_cuda<float>;
+        case GGML_TYPE_Q5_0:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_q5_0_cuda<float>;
         default: {
             static std::set<ggml_type> warned_types;
             if (warned_types.find(type) == warned_types.end()) {
@@ -2261,6 +2361,10 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
         case GGML_TYPE_Q6_K_R4:
             return dequantize_row_q6_K_r4_cuda;
         // case GGML_TYPE_IQ2_XXS:
+        case GGML_TYPE_IQ4_XS:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_iq4_xs_cuda<half>;
+        case GGML_TYPE_Q5_0:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_q5_0_cuda<half>;
         //    return dequantize_row_iq2_xxs_cuda;
         // case GGML_TYPE_IQ1_KT:
         //    return dequantize_row_iq1_kt_cuda;
@@ -2349,6 +2453,10 @@ to_bf16_cuda_t ggml_get_to_bf16_cuda(ggml_type type) {
             return dequantize_row_q6_K_cuda;
         case GGML_TYPE_Q6_K_R4:
             return dequantize_row_q6_K_r4_cuda;
+        case GGML_TYPE_IQ4_XS:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_iq4_xs_cuda<__nv_bfloat16>;
+        case GGML_TYPE_Q5_0:
+            return FastllmGGUFDequantIq4xsQ50Disabled() ? nullptr : dequantize_row_q5_0_cuda<__nv_bfloat16>;
         default: {
             static std::set<ggml_type> warned_types;
             if (warned_types.find(type) == warned_types.end()) {
@@ -2394,7 +2502,16 @@ bool FastllmCudaMatMulFloatGGUF(const fastllm::Data &input, fastllm::Data &weigh
     cudaStream_t stream = cudaStreamPerThread;
     // dequant = nullptr; /// TODO: dequant目前似乎有bug，待查
 
-    if ((n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequantFp32 != nullptr) {
+    // SM70 IQ4_XS DP4A MMQ trial path. Only attempted for IQ4_XS on SM70;
+    // on any failure the existing dequant+cuBLAS / MMVQ fallback runs.
+    bool sm70Iq4XsDone = false;
+    if (ggufType == GGML_TYPE_IQ4_XS) {
+        sm70Iq4XsDone = FastllmCudaTrySm70Iq4XsMmq(
+            weight.cudaData, cudaInput, cudaOutput,
+            fastllm::DataType::FLOAT32, n, m, k, (void *)stream);
+    }
+
+    if (!sm70Iq4XsDone && (n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequantFp32 != nullptr) {
         auto fastllmCublasHandle = getFastllmCublasHandle();
 
         size_t wsBytes = 0;
@@ -2428,7 +2545,7 @@ bool FastllmCudaMatMulFloatGGUF(const fastllm::Data &input, fastllm::Data &weigh
                 exit(0);
             }
         }
-    } else if ((n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequantFp16 != nullptr) {
+    } else if (!sm70Iq4XsDone && (n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequantFp16 != nullptr) {
         auto fastllmCublasHandle = getFastllmCublasHandle();
 
         size_t wsBytes = 0;
@@ -2471,7 +2588,7 @@ bool FastllmCudaMatMulFloatGGUF(const fastllm::Data &input, fastllm::Data &weigh
                 exit(0);
             }
         }
-    } else {
+    } else if (!sm70Iq4XsDone) {
         q8Input = (block_q8_1*)FastllmCudaMalloc(n * m * sizeof(half));
         quantize_row_q8_1_cuda (
             cudaInput, q8Input, m, n, 1, m, GGML_TYPE_Q8_1, stream
@@ -2551,12 +2668,66 @@ bool FastllmCudaHalfMatMulGGUF(const fastllm::Data &input, fastllm::Data &weight
 
     ggml_backend_cuda_context ctx;
 
-    auto dequant = ggml_get_to_fp16_cuda((ggml_type)weight.ggmlType);
-    auto has_vec_dot = get_has_vec_dot_q_cuda((ggml_type)weight.ggmlType);
+    ggml_type ggufType = (ggml_type)weight.ggmlType;
+    auto dequantFp32 = FastllmGGUFUseFp32Dequant(weight, ggufType) ? ggml_get_to_fp32_cuda(ggufType) : nullptr;
+    auto dequant = ggml_get_to_fp16_cuda(ggufType);
+    auto has_vec_dot = get_has_vec_dot_q_cuda(ggufType);
     cudaStream_t stream = cudaStreamPerThread;
-    // dequant = nullptr; /// TODO: dequant目前似乎有bug，待查
 
-    if ((n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequant != nullptr) {
+
+    // SM70 IQ4_XS DP4A MMQ trial path.
+    bool sm70Iq4XsDone = false;
+    if (ggufType == GGML_TYPE_IQ4_XS) {
+        sm70Iq4XsDone = FastllmCudaTrySm70Iq4XsMmq(
+            weight.cudaData, cudaInput, cudaOutput,
+            fastllm::DataType::FLOAT16, n, m, k, (void *)stream);
+    }
+
+    if (!sm70Iq4XsDone && (n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequantFp32 != nullptr) {
+        auto fastllmCublasHandle = getFastllmCublasHandle();
+
+        size_t fp32WeightBytes = FastllmGGUFAlignBytes((size_t)k * m * sizeof(float));
+        size_t fp32InputBytes = FastllmGGUFAlignBytes((size_t)n * m * sizeof(float));
+        size_t needBytes = fp32WeightBytes + fp32InputBytes + (size_t)n * k * sizeof(float);
+        size_t wsBytes = 0;
+        float *workspace = (float *) FastllmGGUFGetDequantWorkspace(&wsBytes, weight, "half-input FP32 SGEMM");
+        bool ownScratch = false;
+        if (wsBytes < needBytes) {
+            workspace = (float *) FastllmCudaMalloc(needBytes);
+            ownScratch = true;
+        }
+
+        float *cudaFp32Weight = workspace;
+        float *cudaFp32Input = (float *)((uint8_t *)workspace + FastllmGGUFAlignBytes((size_t)k * m * sizeof(float)));
+        float *cudaFp32Output = (float *)((uint8_t *)cudaFp32Input + FastllmGGUFAlignBytes((size_t)n * m * sizeof(float)));
+
+        dequantFp32((const char *)weight.cudaData, cudaFp32Weight, k, m, stream);
+        int inputLen = n * m;
+        int outputLen = n * k;
+        int threadPerBlock = std::min(256, std::max(inputLen, outputLen));
+        FastllmCudaHalf2FloatKernel <<< (inputLen - 1) / threadPerBlock + 1, threadPerBlock, 0, stream >>>(cudaInput, cudaFp32Input, inputLen);
+
+        float h_alpha = 1.0f, h_beta = 0.0f;
+        bool pedanticSgemm = FastllmGGUFUsePedanticSgemm(weight, ggufType);
+        cublasStatus_t status = FastllmGGUFSgemmFloat(
+                fastllmCublasHandle,
+                CUBLAS_OP_T, CUBLAS_OP_N,
+                k, n, m,
+                &h_alpha, cudaFp32Weight,
+                m, cudaFp32Input,
+                m, &h_beta,
+                cudaFp32Output,
+                k, pedanticSgemm);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            printf("Error: cublas error.\n");
+            throw("cublas error");
+            exit(0);
+        }
+        FastllmCudaFloat2HalfKernel <<< (outputLen - 1) / threadPerBlock + 1, threadPerBlock, 0, stream >>>(cudaFp32Output, cudaOutput, outputLen);
+        if (ownScratch) {
+            FastllmCudaFree(workspace);
+        }
+    } else if (!sm70Iq4XsDone && (n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequant != nullptr) {
         auto fastllmCublasHandle = getFastllmCublasHandle();
 
         size_t needBytes = (size_t)k * m * sizeof(half);
@@ -2572,8 +2743,6 @@ bool FastllmCudaHalfMatMulGGUF(const fastllm::Data &input, fastllm::Data &weight
         cudaDataType_t AType = CUDA_R_16F, BType = CUDA_R_16F, CType = CUDA_R_16F, ComputeType = CUDA_R_16F;
         cublasStatus_t status;
 
-        int len = k * m;
-        int threadPerBlock = std::min(256, len);
         dequant((const char *)weight.cudaData, cudaFp16Weight, k, m, stream);
 
         status = cublasGemmEx(fastllmCublasHandle,
@@ -2591,7 +2760,7 @@ bool FastllmCudaHalfMatMulGGUF(const fastllm::Data &input, fastllm::Data &weight
         }
 
         FastllmReleaseDequantScratch(cudaFp16Weight, ownScratch);
-    } else {
+    } else if (!sm70Iq4XsDone) {
         q8Input = (block_q8_1*)FastllmCudaMalloc(n * m * sizeof(half));
         quantize_row_q8_1_cuda (
             cudaInput, q8Input, m, n, 1, m, GGML_TYPE_Q8_1, stream
@@ -2675,7 +2844,21 @@ bool FastllmCudaBFloat16MatMulGGUF(const fastllm::Data &input, fastllm::Data &we
     auto has_vec_dot = get_has_vec_dot_q_cuda((ggml_type)weight.ggmlType);
     cudaStream_t stream = cudaStreamPerThread;
 
-    if ((n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequant != nullptr) {
+    // SM70 IQ4_XS DP4A MMQ trial path.
+    bool sm70Iq4XsDone = false;
+    if ((ggml_type)weight.ggmlType == GGML_TYPE_IQ4_XS) {
+        sm70Iq4XsDone = FastllmCudaTrySm70Iq4XsMmq(
+            weight.cudaData, cudaInput, cudaOutput,
+            fastllm::DataType::BFLOAT16, n, m, k, (void *)stream);
+    }
+
+    int device = 0, major = 0;
+    bool bf16GemmSupported =
+        cudaGetDevice(&device) == cudaSuccess &&
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device) == cudaSuccess &&
+        major >= 8;
+    if (!sm70Iq4XsDone && bf16GemmSupported &&
+        (n > MMVQ_MAX_BATCH_SIZE || !has_vec_dot) && dequant != nullptr) {
         auto fastllmCublasHandle = getFastllmCublasHandle();
 
         size_t needBytes = (size_t)k * m * sizeof(__nv_bfloat16);
@@ -2707,7 +2890,7 @@ bool FastllmCudaBFloat16MatMulGGUF(const fastllm::Data &input, fastllm::Data &we
         }
 
         FastllmReleaseDequantScratch(cudaBf16Weight, ownScratch);
-    } else {
+    } else if (!sm70Iq4XsDone) {
         q8Input = (block_q8_1 *)FastllmCudaMalloc(n * m * sizeof(__nv_bfloat16));
         quantize_row_q8_1_cuda(
             cudaInput, q8Input, m, n, 1, m, GGML_TYPE_Q8_1, stream

--- a/src/devices/cuda/fastllm-iq4xs-sm70.cu
+++ b/src/devices/cuda/fastllm-iq4xs-sm70.cu
@@ -1,0 +1,749 @@
+//
+// SM70 (Tesla V100) IQ4_XS matrix-multiply-quantized (MMQ) kernel.
+//
+// This is a focused, self-contained DP4A-tiled matmul for GGML_TYPE_IQ4_XS
+// weights. It is NOT the generic llama.cpp MMQ subsystem: only the IQ4_XS
+// DP4A closure was extracted and simplified for a single compute capability
+// (SM70), where the Marlin SM75 m16n8/ldmatrix path is unavailable but the
+// INT8 dot-product (DP4A, `__dp4a`) is available (sm_61+).
+//
+// Provenance — derived from llama.cpp "turboquant" (MIT):
+//   llama.cpp-turboquant/ggml/src/ggml-cuda/mmq.cuh
+//       -> load_tiles_iq4_xs<mmq_y, need_check>  (DP4A branch, ~lines 3121-3184)
+//       -> vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y>  (~lines 1126-1156)
+//       -> mul_mat_q_process_tile                 (DP4A branch, ~lines 3446-3525)
+//       -> block_q8_1_mmq, MMQ_TILE_NE_K, MMQ_TILE_Y_K, MMQ_ITER_K, MMQ_NWARPS
+//   llama.cpp-turboquant/ggml/src/ggml-cuda/vecdotq.cuh
+//       -> vec_dot_q8_0_q8_1_impl                 (~lines 243-255)
+//       -> get_int_from_table_16                  (CUDA branch, ~lines 57-80)
+//       -> kvalues_iq4nl codebook                 (ggml-common.h ~lines 1200-1202)
+//   llama.cpp-turboquant/ggml/src/ggml-cuda/quantize.cu
+//       -> quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D4> (D4 branch, ~lines 280-373)
+//
+// The six-bit group scale and nibble→codebook mapping are cross-checked
+// against FastLLM's own validated dequantize_block_iq4_xs in
+// fastllm-ggml-cuda.cu (~lines 1978-2000), the ground truth for this repo's
+// IQ4_XS layout.
+//
+// Safety contract:
+//   * Eligibility: SM70 only, IQ4_XS caller, n in [8,64], m%256==0,
+//     k>=128, non-null pointers, supported dtype, shared memory fits.
+//     Smaller output projections are materially faster on the legacy path.
+//   * Trial path: on any failure returns false WITHOUT writing output,
+//     leaving the caller's dequant+cuBLAS / MMVQ fallback intact.
+//   * Failed CUDA launch clears the sticky error before returning false.
+//   * No persistent expanded-weight copy; nibbles are expanded on-the-fly
+//     into shared memory each tile via the codebook LUT.
+//   * Only DP4A + __byte_perm. No SM75 instructions (ldmatrix, mma.m16n8).
+//
+
+#include "fastllm-cuda.cuh"
+#include "fastllm.h"
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#define GGML_COMMON_DECL_CUDA
+#define GGML_COMMON_IMPL_CUDA
+#include "gguf.h"
+
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <tuple>
+
+// ---------------------------------------------------------------------------
+// Constants — mirror llama.cpp MMQ DP4A tile geometry for IQ4_XS.
+//
+// IQ4_XS reuses the Q8_0 DP4A tile sizes (mmq_get_dp4a_tile_x_sizes maps
+// GGML_TYPE_IQ4_XS → MMQ_DP4A_TXS_Q8_0).  The block_q8_1_mmq activation uses
+// the D4 scale layout (one float scale per 32 values, 4 per 128-value block).
+//
+//   QK8_1 = 32   block_q8_1 values per scale group
+//   QR8_1 = 1    quantization ratio
+//   QI8_1 = 8    QK8_1 / (4*QR8_1) = 32/(4*1) = 8.  This is the number of
+//               32-bit ints containing QK8_1=32 quantized values, divided by
+//               4 (QR8_1): one int32 holds 4 int8 values, so QK8_1/4 = 8
+//               int32 per 32-value scale group.
+//   QI8_0 = 8    same formula for q8_0 weights.
+//   QK_K  = 256  values per iq4_xs block (8 sub-blocks of 32).
+//   QR4_XS = 2   iq4_xs quantization ratio.
+// ---------------------------------------------------------------------------
+#define S70_TILE_NE_K  32
+#define S70_ITER_K     256
+#define S70_NWARPS     8
+#define S70_TILE_Y_K   36    // NE_K + NE_K/QI8_1 = 32 + 32/8 = 36
+#define S70_Y          128   // weight rows per CTA
+#define S70_VDR        8     // VDR_Q8_0_Q8_1_MMQ after IQ4_XS LUT expansion
+#define S70_QK_K       256
+#define S70_QK8_1      32
+#define S70_QI8_0      8     // QK8_0/(4*QR8_0) = 32/4
+#define S70_QI8_1      8     // QK8_1/(4*QR8_1) = 32/4
+// iq4_xs qs nibble array: QK_K/2 bytes = QK_K/8 int32 per block.
+#define S70_QI4_XS     (S70_QK_K / 8)  // = 32
+
+// Weight tile (DP4A Q8_0-equivalent) row strides:
+//   qs row stride = 2*NE_K + 1 = 65 int32
+//   df row stride = 2*NE_K/QI8_0 = 2*32/8 = 8 float, with +i/4 pad column
+#define S70_X_QS_STRIDE  (2 * S70_TILE_NE_K + 1)  // 65
+#define S70_X_DF_STRIDE  (2 * S70_TILE_NE_K / S70_QI8_0)  // 8
+
+// ---------------------------------------------------------------------------
+// Exact IQ4_NL codebook (shared by IQ4_XS and IQ4_NL).
+// ggml-common.h: kvalues_iq4nl = {-127,-104,-83,-65,-49,-35,-22,-10,
+//                                  1, 13, 25, 38, 53, 69, 89, 113}
+// ---------------------------------------------------------------------------
+static __constant__ int8_t s70_iq4nl_table[16] = {
+    -127, -104, -83, -65, -49, -35, -22, -10,
+    1, 13, 25, 38, 53, 69, 89, 113
+};
+
+// __byte_perm-based 16-entry table lookup (CUDA branch of
+// get_int_from_table_16).  Returns two int32: first holds the 4 codebook bytes
+// at even nibble indices of q4, second holds odd nibble indices.
+static __device__ __forceinline__ int2
+s70_get_int_from_table_16(const int q4, const int8_t * table) {
+    const uint32_t * t32 = (const uint32_t *) table;
+    const uint32_t sel = (0x32103210u | ((uint32_t)q4 & 0x88888888u) >> 1);
+    uint32_t tmp[2];
+    #pragma unroll
+    for (uint32_t i = 0; i < 2; ++i) {
+        const uint32_t sh = 16u * i;
+        const uint32_t lo = __byte_perm(t32[0], t32[1], (uint32_t)q4 >> sh);
+        const uint32_t hi = __byte_perm(t32[2], t32[3], (uint32_t)q4 >> sh);
+        tmp[i] = __byte_perm(lo, hi, sel >> sh);
+    }
+    return make_int2(__byte_perm(tmp[0], tmp[1], 0x6420),
+                     __byte_perm(tmp[0], tmp[1], 0x7531));
+}
+
+static __device__ __forceinline__ int
+s70_get_int_b4(const void * x, const int i32) {
+    return ((const int *) x)[i32]; // 4-byte aligned
+}
+
+// INT8 four-way dot product (DP4A). SM61+ supports __dp4a.
+    static __device__ __forceinline__ int
+    s70_dp4a(const int a, const int b, int c) {
+    #if defined(USE_ROCM)
+        const int8_t * a8 = (const int8_t *) &a;
+        const int8_t * b8 = (const int8_t *) &b;
+        return c + a8[0]*b8[0] + a8[1]*b8[1] + a8[2]*b8[2] + a8[3]*b8[3];
+    #elif __CUDA_ARCH__ >= 610
+        return __dp4a(a, b, c);
+    #else
+        const int8_t * a8 = (const int8_t *) &a;
+        const int8_t * b8 = (const int8_t *) &b;
+        return c + a8[0]*b8[0] + a8[1]*b8[1] + a8[2]*b8[2] + a8[3]*b8[3];
+    #endif
+    }
+
+// ---------------------------------------------------------------------------
+// block_q8_1_mmq — D4 layout activation quantization block.
+//
+// Matches llama.cpp block_q8_1_mmq (MMQ_Q8_1_DS_LAYOUT_D4): 4 float scales
+// (one per 32 values) + 128 int8 quantized values.
+// sizeof = 4*4 + 128 = 144 bytes = 36 int32.
+// ---------------------------------------------------------------------------
+struct s70_block_q8_1_mmq {
+    float  d4[4];                      // 1 float scale per 32 values
+    int8_t qs[4 * S70_QK8_1];          // 128 int8 values
+};
+
+// ---------------------------------------------------------------------------
+// Activation quantization kernel: src_t → block_q8_1_mmq (D4), TRANSPOSED.
+//
+// Ported from quantize.cu quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D4>.  The
+// output is laid out as qy[k_block][token] (token is the fast/inner index)
+// so that the matmul kernel can copy mmq_x contiguous token blocks with a
+// single contiguous shared-memory load (matching mul_mat_q_process_tile).
+//
+// One CTA quantizes 4*QK8_1 = 128 values of one token.  32 threads, each
+// loads 4 values, computes amax across the 8 threads sharing a 32-value
+// scale group (warp shuffle), writes d4[group] and the int8 qs.
+//
+// Zero-amax handling: d_inv = 0 → d = 0, q = 0 (avoids Inf/NaN from 127/0).
+// ---------------------------------------------------------------------------
+template <typename src_t>
+static __global__ void
+s70_quantize_mmq_q8_1(const src_t * __restrict__ x,
+                      s70_block_q8_1_mmq * __restrict__ qy,
+                      const int64_t ne0,   // contraction dim (= m)
+                      const int     ne1,   // actual token count (= n)
+                      const int     ne1_pad) { // padded token stride (= n_padded)
+    const int i1   = blockIdx.x;   // token
+    const int kb   = blockIdx.y;   // k-block index along contraction dim
+    const int tid  = threadIdx.x;   // 0..31
+
+    if (i1 >= ne1) return;  // padding tokens are pre-zeroed by the host
+
+    const int64_t i0 = (int64_t)kb * (4 * S70_QK8_1) + (int64_t)tid * 4;
+    const int iqs = tid * 4;  // 0..124, index within this 128-value block
+
+    // Transposed layout: qy[kb * ne1_pad + i1].
+    s70_block_q8_1_mmq * y = qy + (int64_t)kb * ne1_pad + i1;
+
+    float4 xi;
+    {
+        const src_t * px = x + (int64_t)i1 * ne0 + i0;
+        xi = make_float4((float)px[0], (float)px[1], (float)px[2], (float)px[3]);
+    }
+
+    float amax = fmaxf(fmaxf(fabsf(xi.x), fabsf(xi.y)),
+                       fmaxf(fabsf(xi.z), fabsf(xi.w)));
+
+    // Reduce amax across 8 threads (one 32-value scale group = 8 threads × 4 vals).
+    #pragma unroll
+    for (int offset = 4; offset > 0; offset >>= 1)
+        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFu, amax, offset));
+
+    // d_inv = 127/amax; guard amax==0 → d=0, q=0.
+    const float d_inv = amax > 0.0f ? (127.0f / amax) : 0.0f;
+
+    char4 q;
+    q.x = (char)roundf(xi.x * d_inv);
+    q.y = (char)roundf(xi.y * d_inv);
+    q.z = (char)roundf(xi.z * d_inv);
+    q.w = (char)roundf(xi.w * d_inv);
+
+    ((char4 *) y->qs)[iqs / 4] = q;
+
+    // Scale groups at iqs == 0, 32, 64, 96.
+    if (iqs % 32 == 0) {
+        const float d = d_inv > 0.0f ? (1.0f / d_inv) : 0.0f;
+        y->d4[iqs / 32] = d;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Weight tile loader — DP4A branch of load_tiles_iq4_xs.
+//
+// Expands one iq4_xs block (QK_K=256 values = 8 sub-blocks of 32) per weight
+// row into shared memory using the Q8_0 DP4A tile layout:
+//   x_qs[i * S70_X_QS_STRIDE + k0 + {0,4}] : two int32 of codebook-expanded int8
+//   x_df[i * S70_X_DF_STRIDE + i/4 + g]    : per-32-value scale d*(ls-32)
+//
+// x_tile points at this CTA's weight tile in shared memory.  `i` ranges over
+// the S70_Y=128 weight rows; need_check clamps i to i_max for tail rows.
+// ---------------------------------------------------------------------------
+template <int mmq_y, bool need_check>
+static __device__ __forceinline__ void
+s70_load_tiles_iq4_xs(const char * __restrict__ x, int * __restrict__ x_tile,
+                      const int kbx0, const int i_max, const int stride) {
+    constexpr int nwarps = S70_NWARPS;
+    constexpr int warp_size = 32;
+    constexpr int NE_K = S70_TILE_NE_K;
+
+    int   * x_qs = (int *)   x_tile;
+    float * x_df = (float *) (x_qs + mmq_y * S70_X_QS_STRIDE);
+
+    // threads_per_row = ITER_K / (4 * QR4_XS) = 256 / 8 = 32.
+    constexpr int threads_per_row = S70_ITER_K / (4 * 2 /*QR4_XS*/);
+    constexpr int nrows = warp_size / threads_per_row;  // 1
+    const int kqsx = threadIdx.x % threads_per_row;
+
+    // --- Expand nibbles into codebook values via LUT ---
+    #pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += nrows * nwarps) {
+        int i = i0 + (nrows == 1 ? threadIdx.y
+                                 : threadIdx.y * nrows + threadIdx.x / threads_per_row);
+        if (need_check) i = min(i, i_max);
+
+        const block_iq4_xs * bxi =
+            (const block_iq4_xs *) x + kbx0 + i * stride;
+
+        const int aux_q4 = s70_get_int_b4(bxi->qs, kqsx);
+        const int2 v = s70_get_int_from_table_16(aux_q4, s70_iq4nl_table);
+        const int k0 = 8 * (kqsx / 4) + kqsx % 4;
+
+        x_qs[i * S70_X_QS_STRIDE + k0 + 0] = v.x;
+        x_qs[i * S70_X_QS_STRIDE + k0 + 4] = v.y;
+    }
+
+    // --- Load six-bit scales ---
+    // rows_per_warp = warp_size / 8 = 4; 8 warps × 4 rows = 32 rows per pass.
+    constexpr int rows_per_warp = warp_size / 8;
+    #pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * rows_per_warp) {
+        int i = i0 + threadIdx.y * rows_per_warp + threadIdx.x / (NE_K / 4);
+        if (need_check) i = min(i, i_max);
+
+        const block_iq4_xs * bxi =
+            (const block_iq4_xs *) x + kbx0 + i * stride;
+
+        const float d = __half2float(bxi->d);
+        const int g = threadIdx.x % 8;  // sub-block index 0..7
+        const int ls = ((bxi->scales_l[g / 2] >> (4 * (g & 1))) & 0x0F)
+                     | (((bxi->scales_h >> (2 * g)) & 0x03) << 4);
+
+        x_df[i * S70_X_DF_STRIDE + i / 4 + g] = d * (float)(ls - 32);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DP4A vector dot — vec_dot_q8_0_q8_1_dp4a, specialized for the IQ4_XS tile.
+//
+// Accumulates FP32 into sum[].  Each thread owns a (j,i) sub-tile of the
+// (mmq_x tokens) × (mmq_y weight rows) output.
+// ---------------------------------------------------------------------------
+template <int mmq_x, int mmq_y>
+static __device__ __forceinline__ void
+s70_vec_dot_q8_0_q8_1_dp4a(const int * __restrict__ x, const int * __restrict__ y,
+                           float * __restrict__ sum, const int k00) {
+    constexpr int nwarps = S70_NWARPS;
+    constexpr int warp_size = 32;
+    constexpr int NE_K = S70_TILE_NE_K;
+
+    const int   * x_qs = (const int *)   x;
+    const float * x_df = (const float *) x + mmq_y * S70_X_QS_STRIDE;
+    // block_q8_1_mmq (D4): first 4 int32 are d4 scales, then 32 int32 of qs.
+    const int   * y_qs = (const int *)   y + 4;
+    const float * y_df = (const float *) y;
+
+    #pragma unroll
+    for (int k01 = 0; k01 < NE_K; k01 += S70_VDR) {
+        const int k0 = k00 + k01;
+
+        #pragma unroll
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
+
+            #pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
+                const int i = i0 + threadIdx.x;
+
+                // vec_dot_q8_0_q8_1_impl<float, VDR>: dp4a over VDR int32 pairs.
+                int sumi = 0;
+                const int * xv = &x_qs[i * S70_X_QS_STRIDE + k0];
+                const int * yv = &y_qs[j * S70_TILE_Y_K + k0 % NE_K];
+                #pragma unroll
+                for (int v = 0; v < S70_VDR; ++v)
+                    sumi = s70_dp4a(xv[v], yv[v], sumi);
+
+                const float xdf =
+                    x_df[i * S70_X_DF_STRIDE + i / (S70_QI8_0 / 2) + k0 / S70_QI8_0];
+                const float ydf =
+                    y_df[j * S70_TILE_Y_K + (k0 / S70_QI8_1) % (NE_K / S70_QI8_1)];
+
+                sum[j0 / nwarps * mmq_y / warp_size + i0 / warp_size]
+                    += xdf * ydf * (float)sumi;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Output write-back — mmq_write_back_dp4a.  Converts FP32 accumulators to the
+// destination type and stores into dst[token, output_row].
+// ---------------------------------------------------------------------------
+template <typename dst_t, int mmq_x, int mmq_y, bool need_check>
+static __device__ __forceinline__ void
+s70_write_back_dp4a(const float * __restrict__ sum, dst_t * __restrict__ dst,
+                    const int stride, const int i_max, const int j_max,
+                    const int row_offset, const int token_offset) {
+    constexpr int nwarps = S70_NWARPS;
+    constexpr int warp_size = 32;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+        const int j = j0 + threadIdx.y;
+        if (j > j_max) return;
+
+        #pragma unroll
+        for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
+            const int i = i0 + threadIdx.x;
+            if (need_check && i > i_max) continue;
+
+            const float v =
+                sum[j0 / nwarps * mmq_y / warp_size + i0 / warp_size];
+            dst[(token_offset + j) * stride + row_offset + i] = (dst_t)v;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The MMQ kernel for IQ4_XS on SM70.
+//
+// Grid: (ceil(k / mmq_y), 1).  Each CTA computes one mmq_x (tokens) × mmq_y
+// (output rows) tile.  (FastLLM convention: weight [k×m], input [n×m],
+// output [n×k].)  Since n ≤ 64 ≤ mmq_x_max, there is exactly one token tile.
+//
+// The K dimension is walked in ITER_K=256 steps; each step loads one full
+// iq4_xs block per weight row into shared mem (via LUT expansion), and two
+// halves of the quantized activation tile (each covering NE_K=32 of the
+// 64 K-values per q8_1_mmq block — one iq4_xs block spans two q8_1_mmq blocks).
+//
+//   weight       : block_iq4_xs[k][m/QK_K] (row-major, stride = m/QK_K)
+//   qy           : s70_block_q8_1_mmq[m/128][n_padded] (transposed: k-block outer)
+//   dst          : dst_t[n][k] (stride = k)
+// ---------------------------------------------------------------------------
+template <typename dst_t, int mmq_x, int mmq_y, bool need_check>
+__launch_bounds__(S70_NWARPS * 32, 1)
+static __global__ void
+s70_mul_mat_q(const char * __restrict__ weight,
+              const s70_block_q8_1_mmq * __restrict__ qy,
+              dst_t * __restrict__ dst,
+              const int k, const int m, const int n,
+              const int weight_stride,   // = m / QK_K
+              const int n_pad_stride) {  // = n_padded (token stride in qy)
+    constexpr int NE_K = S70_TILE_NE_K;
+    constexpr int sz = sizeof(s70_block_q8_1_mmq) / sizeof(int);  // 36
+
+    extern __shared__ int s70_smem[];
+    int * tile_y = s70_smem;
+    int * tile_x = tile_y + mmq_x * S70_TILE_Y_K;
+
+    // CTA tile origin.
+    const int it = blockIdx.x;                // output-row tile index
+
+    const int tile_x_max_i = k - it * mmq_y - 1;
+    const int tile_y_max_j = min(n - 1, mmq_x - 1);
+
+    const int kb_blocks_x = m / S70_QK_K;      // iq4_xs blocks per weight row
+
+    constexpr int blocks_per_iter = S70_ITER_K / S70_QK_K;  // 1
+
+    float sum[mmq_x * mmq_y / (S70_NWARPS * 32)] = {0.0f};
+
+    for (int kb0 = 0; kb0 < kb_blocks_x; kb0 += blocks_per_iter) {
+        // Load weight tile: expand iq4_xs nibbles + scales into shared mem.
+        s70_load_tiles_iq4_xs<mmq_y, need_check>(
+            weight, tile_x, it * mmq_y * weight_stride + kb0,
+            tile_x_max_i, weight_stride);
+
+        // --- Load first half of activation tile (K-offset 0 within block) ---
+        // qy layout [kb_y][token]: contiguous token blocks at
+        //   qy + kb_y * n_pad_stride (token tile origin is always 0).
+        // First q8_1_mmq sub-block for iq4_xs block kb0 is kb_y = 2*kb0.
+        {
+            const int kb_y = 2 * kb0;
+            const int * by0 = (const int *) qy
+                + ((int64_t)kb_y * n_pad_stride) * sz;
+            constexpr int tile_y_ints = mmq_x * S70_TILE_Y_K;
+            #pragma unroll
+            for (int l0 = 0; l0 < tile_y_ints;
+                 l0 += S70_NWARPS * 32) {
+                const int l = l0 + threadIdx.y * 32 + threadIdx.x;
+                if (l < tile_y_ints) tile_y[l] = by0[l];
+            }
+        }
+        __syncthreads();
+        s70_vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y>(tile_x, tile_y, sum, 0);
+        __syncthreads();
+
+        // --- Load second half (K-offset NE_K=32 within block) ---
+        {
+            const int kb_y = 2 * kb0 + 1;
+            const int * by0 = (const int *) qy
+                + ((int64_t)kb_y * n_pad_stride) * sz;
+            constexpr int tile_y_ints = mmq_x * S70_TILE_Y_K;
+            #pragma unroll
+            for (int l0 = 0; l0 < tile_y_ints;
+                 l0 += S70_NWARPS * 32) {
+                const int l = l0 + threadIdx.y * 32 + threadIdx.x;
+                if (l < tile_y_ints) tile_y[l] = by0[l];
+            }
+        }
+        __syncthreads();
+        s70_vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y>(tile_x, tile_y, sum, NE_K);
+        __syncthreads();
+    }
+    s70_write_back_dp4a<dst_t, mmq_x, mmq_y, need_check>(
+        sum, dst, k, tile_x_max_i, tile_y_max_j, it * mmq_y, 0);
+}
+
+// ===========================================================================
+// Host-side eligibility + launch wrapper.
+// ===========================================================================
+
+namespace {
+
+bool s70_env_flag(const char *name, bool defaultValue) {
+    const char *env = std::getenv(name);
+    if (env == nullptr || env[0] == '\0') return defaultValue;
+    std::string value(env);
+    for (char &ch : value) {
+        ch = (char)std::tolower((unsigned char)ch);
+    }
+    if (value == "0" || value == "off" || value == "false" ||
+        value == "no" || value == "disable") return false;
+    if (value == "1" || value == "on" || value == "true" ||
+        value == "yes" || value == "enable") return true;
+    return defaultValue;
+}
+
+bool s70_enabled() {
+    static const bool enabled =
+        s70_env_flag("FASTLLM_CUDA_SM70_IQ4XS_MMQ", true);
+    return enabled;
+}
+
+bool s70_detailed_log() {
+    static const bool enabled =
+        s70_env_flag("FASTLLM_CUDA_SM70_IQ4XS_MMQ_LOG", false);
+    return enabled;
+}
+
+bool s70_current_device(int &device, int &sm) {
+    cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        return false;
+    }
+    cudaDeviceProp prop;
+    err = cudaGetDeviceProperties(&prop, device);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        return false;
+    }
+    sm = prop.major * 10 + prop.minor;
+    return true;
+}
+
+// Smallest tile multiple of 8 in {8,16,32,64} that is >= n.
+int s70_pick_mmq_x(int n) {
+    if (n <= 8)  return 8;
+    if (n <= 16) return 16;
+    if (n <= 32) return 32;
+    return 64;
+}
+
+bool s70_mmq_x_ok(int x) {
+    return x == 8 || x == 16 || x == 32 || x == 64;
+}
+
+// One default route summary per device; shape-level diagnostics are opt-in.
+using LogKey = std::tuple<int, int, int, int, int>;
+std::mutex &s70_logmtx() { static std::mutex mutex; return mutex; }
+std::set<int> &s70_seen_device() { static std::set<int> seen; return seen; }
+std::set<LogKey> &s70_seen_sel() { static std::set<LogKey> seen; return seen; }
+std::set<LogKey> &s70_seen_rej() { static std::set<LogKey> seen; return seen; }
+std::set<LogKey> &s70_seen_fb() { static std::set<LogKey> seen; return seen; }
+
+void s70_log_sel(int device, int sm, int type, int n, int m, int k) {
+    std::lock_guard<std::mutex> lock(s70_logmtx());
+    if (s70_detailed_log()) {
+        if (s70_seen_sel().insert({sm, type, n, m, k}).second) {
+            fprintf(stderr,
+                    "[FastLLM][sm70-iq4xs-mmq] selected: type=%d n=%d m=%d k=%d sm=%d device=%d\n",
+                    type, n, m, k, sm, device);
+        }
+    } else if (s70_seen_device().insert(device).second) {
+        fprintf(stderr,
+                "[FastLLM] SM70 IQ4_XS MMQ enabled on CUDA device %d.\n",
+                device);
+    }
+}
+
+void s70_log_rej(int sm, int type, int n, int m, int k, const char *why) {
+    if (!s70_detailed_log()) return;
+    std::lock_guard<std::mutex> lock(s70_logmtx());
+    if (s70_seen_rej().insert({sm, type, n, m, k}).second) {
+        fprintf(stderr,
+                "[FastLLM][sm70-iq4xs-mmq] rejected (%s): type=%d n=%d m=%d k=%d sm=%d\n",
+                why, type, n, m, k, sm);
+    }
+}
+
+void s70_log_fb(int sm, int type, int n, int m, int k, const char *why) {
+    if (!s70_detailed_log()) return;
+    std::lock_guard<std::mutex> lock(s70_logmtx());
+    if (s70_seen_fb().insert({sm, type, n, m, k}).second) {
+        fprintf(stderr,
+                "[FastLLM][sm70-iq4xs-mmq] fallback (%s): type=%d n=%d m=%d k=%d sm=%d\n",
+                why, type, n, m, k, sm);
+    }
+}
+
+struct S70Scratch {
+    s70_block_q8_1_mmq *qy = nullptr;
+    size_t capacity = 0;
+};
+
+s70_block_q8_1_mmq *s70_get_scratch(int device, cudaStream_t stream,
+                                    size_t required) {
+    using ScratchKey = std::pair<int, uintptr_t>;
+    static thread_local std::map<ScratchKey, S70Scratch> scratchByStream;
+    S70Scratch &scratch = scratchByStream[{device, (uintptr_t)stream}];
+    if (scratch.qy != nullptr && scratch.capacity >= required) {
+        return scratch.qy;
+    }
+    if (scratch.qy != nullptr) {
+        cudaError_t err = cudaStreamSynchronize(stream);
+        if (err != cudaSuccess) {
+            cudaGetLastError();
+            FastllmCudaSetThreadError();
+            return nullptr;
+        }
+        FastllmCudaFree(scratch.qy);
+        scratch.qy = nullptr;
+        scratch.capacity = 0;
+    }
+    scratch.qy = (s70_block_q8_1_mmq *)FastllmCudaMalloc(
+        required * sizeof(s70_block_q8_1_mmq));
+    if (scratch.qy != nullptr) scratch.capacity = required;
+    return scratch.qy;
+}
+
+} // namespace
+
+extern "C" {
+
+// Route-introspection helper for tests/diagnostics.
+bool FastllmCudaSm70Iq4XsMmqSupported() {
+    int device = 0, sm = 0;
+    return s70_enabled() && s70_current_device(device, sm) && sm == 70;
+}
+
+// See header for full contract.
+bool FastllmCudaTrySm70Iq4XsMmq(const void *weight, const void *input,
+                                void *output, fastllm::DataType dataType,
+                                int n, int m, int k, void *stream) {
+    int device = 0, sm = 0;
+    const int type = (int)dataType;
+    if (!s70_enabled())                 { s70_log_rej(sm,type,n,m,k,"env disabled"); return false; }
+    if (!s70_current_device(device,sm)) { s70_log_rej(sm,type,n,m,k,"device query"); return false; }
+    if (sm != 70)                       { s70_log_rej(sm,type,n,m,k,"sm!=70");       return false; }
+    if (!weight || !input || !output)   { s70_log_rej(sm,type,n,m,k,"null ptr");    return false; }
+    if (dataType != fastllm::DataType::FLOAT32 &&
+        dataType != fastllm::DataType::FLOAT16 &&
+        dataType != fastllm::DataType::BFLOAT16) {
+        s70_log_rej(sm,type,n,m,k,"dtype");
+        return false;
+    }
+    if (n < 8 || n > 64)                { s70_log_rej(sm,type,n,m,k,"n range");     return false; }
+    if (m <= 0 || (m % S70_QK_K) != 0)  { s70_log_rej(sm,type,n,m,k,"m%256");       return false; }
+    if (k < S70_Y)                      { s70_log_rej(sm,type,n,m,k,"k<128");       return false; }
+
+    const int mmq_x = s70_pick_mmq_x(n);
+    if (!s70_mmq_x_ok(mmq_x))           { s70_log_rej(sm,type,n,m,k,"tile-x");      return false; }
+
+    constexpr int mmq_y = S70_Y;
+    const bool need_check = (k % mmq_y) != 0 || (n != mmq_x);
+
+    const size_t tile_y_bytes = (size_t)mmq_x * S70_TILE_Y_K * sizeof(int);
+    const size_t x_qs_ints = (size_t)mmq_y * S70_X_QS_STRIDE;
+    const size_t x_df_ints = (size_t)mmq_y * S70_X_DF_STRIDE +
+                             (size_t)mmq_y / (S70_QI8_0 / 2);
+    const size_t smem_bytes =
+        tile_y_bytes + (x_qs_ints + x_df_ints) * sizeof(int);
+
+    cudaDeviceProp prop;
+    cudaError_t err = cudaGetDeviceProperties(&prop, device);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        s70_log_rej(sm,type,n,m,k,"getprop");
+        return false;
+    }
+    const size_t smem_limit = prop.sharedMemPerBlockOptin
+        ? (size_t)prop.sharedMemPerBlockOptin
+        : (size_t)prop.sharedMemPerBlock;
+    if (smem_bytes > smem_limit) {
+        s70_log_rej(sm,type,n,m,k,"shared mem");
+        return false;
+    }
+
+    cudaStream_t cuStream = stream ? (cudaStream_t)stream : cudaStreamPerThread;
+
+    const int n_padded = mmq_x;
+    const int kb_y_total = m / (4 * S70_QK8_1);
+    const size_t qy_count = (size_t)kb_y_total * n_padded;
+    s70_block_q8_1_mmq *qy =
+        s70_get_scratch(device, cuStream, qy_count);
+    if (qy == nullptr) {
+        s70_log_fb(sm, type, n, m, k, "q8 scratch");
+        return false;
+    }
+
+    err = cudaMemsetAsync(
+        qy, 0, qy_count * sizeof(s70_block_q8_1_mmq), cuStream);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        s70_log_fb(sm, type, n, m, k, "q8 memset");
+        return false;
+    }
+
+    const dim3 quantBlock(32, 1, 1);
+    const dim3 quantGrid((unsigned)n, (unsigned)kb_y_total, 1);
+    switch (dataType) {
+        case fastllm::DataType::FLOAT32:
+            s70_quantize_mmq_q8_1<float><<<quantGrid, quantBlock, 0, cuStream>>>(
+                (const float *)input, qy, m, n, n_padded);
+            break;
+        case fastllm::DataType::FLOAT16:
+            s70_quantize_mmq_q8_1<half><<<quantGrid, quantBlock, 0, cuStream>>>(
+                (const half *)input, qy, m, n, n_padded);
+            break;
+        case fastllm::DataType::BFLOAT16:
+            s70_quantize_mmq_q8_1<__nv_bfloat16><<<quantGrid, quantBlock, 0, cuStream>>>(
+                (const __nv_bfloat16 *)input, qy, m, n, n_padded);
+            break;
+        default:
+            s70_log_rej(sm, type, n, m, k, "dtype-q");
+            return false;
+    }
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        s70_log_fb(sm, type, n, m, k, "q8 launch");
+        return false;
+    }
+
+    const int weight_stride = m / S70_QK_K;
+    const dim3 blockDims(32, S70_NWARPS, 1);
+    const dim3 gridDims((unsigned)((k + mmq_y - 1) / mmq_y), 1, 1);
+
+    #define S70_LAUNCH(DT, X, NC)                                                \
+        s70_mul_mat_q<DT, X, mmq_y, NC><<<gridDims, blockDims, smem_bytes,       \
+                cuStream>>>((const char *)weight, qy, (DT *)output,               \
+                            k, m, n, weight_stride, n_padded)
+
+    #define S70_DISP_X(DT)                                                       \
+        do {                                                                     \
+            if (need_check) {                                                    \
+                switch (mmq_x) {                                                 \
+                    case 8:  S70_LAUNCH(DT, 8,  true); break;                    \
+                    case 16: S70_LAUNCH(DT, 16, true); break;                    \
+                    case 32: S70_LAUNCH(DT, 32, true); break;                    \
+                    case 64: S70_LAUNCH(DT, 64, true); break;                    \
+                    default: s70_log_rej(sm,type,n,m,k,"tile"); return false;   \
+                }                                                                \
+            } else {                                                             \
+                switch (mmq_x) {                                                 \
+                    case 8:  S70_LAUNCH(DT, 8,  false); break;                   \
+                    case 16: S70_LAUNCH(DT, 16, false); break;                   \
+                    case 32: S70_LAUNCH(DT, 32, false); break;                   \
+                    case 64: S70_LAUNCH(DT, 64, false); break;                   \
+                    default: s70_log_rej(sm,type,n,m,k,"tile"); return false;   \
+                }                                                                \
+            }                                                                    \
+        } while (0)
+
+    switch (dataType) {
+        case fastllm::DataType::FLOAT32:  S70_DISP_X(float);         break;
+        case fastllm::DataType::FLOAT16:  S70_DISP_X(half);          break;
+        case fastllm::DataType::BFLOAT16: S70_DISP_X(__nv_bfloat16); break;
+        default:
+            s70_log_rej(sm, type, n, m, k, "dtype-mm");
+            return false;
+    }
+
+    #undef S70_LAUNCH
+    #undef S70_DISP_X
+
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        s70_log_fb(sm, type, n, m, k, "launch error");
+        return false;
+    }
+
+    s70_log_sel(device, sm, type, n, m, k);
+    return true;
+}
+
+} // extern "C"

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -518,7 +518,9 @@ namespace fastllm {
         {DataType::INT8, {"int8"}}, {DataType::INT4, {"int4o"}}, {DataType::INT2, {"int2"}}, {DataType::BIT, {"bit"}}, 
         {DataType::FLOAT16, {"float16", "fp16", "half"}}, {DataType::INT4_NOZERO, {"int4"}}, {DataType::INT4_GROUP, {"int4g"}},
         {DataType::FP8_E4M3, {"float8", "fp8", "fp8_e4m3"}}, {DataType::INT2_GROUP, {"int2g"}}, {DataType::BASE3_GROUP, {"base3g"}},
-        {DataType::INT32, {"int32"}}, {DataType::NVFP4, {"nvfp4", "fp4_e2m1"}}, {DataType::INT32PARAM, {"int32param"}},
+        {DataType::INT32, {"int32"}}, {DataType::NVFP4, {"nvfp4", "fp4_e2m1"}},
+        {DataType::Q8_0_KV, {"q8_0_kv"}}, {DataType::TURBO3_KV, {"turbo3", "turbo3_kv"}},
+        {DataType::INT32PARAM, {"int32param"}},
         {DataType::FP8_E4M3_BLOCK_128, {"fp8_e4m3_block_128"}}, {DataType::AWQ_4BIT_128, {"awq_4bit_128"}},
         {DataType::INT4_PERCHANNEL, {"int4_perchannel"}}, {DataType::FP8_E4M3_PERCHANNEL, {"fp8_e4m3_perchannel"}},
         {DataType::INT4_GROUP128, {"int4_group128"}}, {DataType::INT8_PERCHANNEL, {"int8_perchannel"}},
@@ -588,9 +590,34 @@ namespace fastllm {
         return data.cpuData + weightBytes;
     }
 
+    bool IsPackedKVCacheDataType(DataType type) {
+        return type == DataType::Q8_0_KV || type == DataType::TURBO3_KV;
+    }
+
+    size_t GetKVCacheRowBytes(DataType type, size_t columns) {
+        if (columns == 0) {
+            return 0;
+        }
+        if (type == DataType::Q8_0_KV) {
+            constexpr size_t blockValues = 32;
+            constexpr size_t blockBytes = sizeof(uint16_t) + blockValues;
+            return ((columns + blockValues - 1) / blockValues) * blockBytes;
+        }
+        if (type == DataType::TURBO3_KV) {
+            constexpr size_t blockValues = 128;
+            constexpr size_t blockBytes = sizeof(uint16_t) + blockValues / 4 + blockValues / 8;
+            static_assert(blockBytes == 50, "Turbo3 KV block must be 50 bytes per 128 values");
+            return ((columns + blockValues - 1) / blockValues) * blockBytes;
+        }
+        return GetDataBytes(type, 1, columns);
+    }
+
     size_t GetDataBytes(DataType type, size_t rows, size_t columns) {
         if (rows == 0 || columns == 0) {
             return 0;
+        }
+        if (IsPackedKVCacheDataType(type)) {
+            return rows * GetKVCacheRowBytes(type, columns);
         }
         if (type == DataType::FLOAT32) {
             return rows * columns * sizeof(float);
@@ -1578,7 +1605,8 @@ namespace fastllm {
             this->unitSize = 2;
             this->unitSizeDiv = 1;
         } else if (this->dataType == DataType::INT8 || this->dataType == DataType::FP8_E4M3 ||
-                   this->dataType == DataType::FP8_E4M3_PERCHANNEL) {
+                   this->dataType == DataType::FP8_E4M3_PERCHANNEL ||
+                   IsPackedKVCacheDataType(this->dataType)) {
             this->unitSize = 1;
             this->unitSizeDiv = 1;
         } else if (this->dataType == DataType::NVFP4) {
@@ -1615,7 +1643,8 @@ namespace fastllm {
              this->dataType == DataType::FP8_E4M3_PERCHANNEL ||
              this->dataType == DataType::NVFP4_BLOCK_16 ||
              this->dataType == DataType::NVFP4_BLOCK_16_E8M0 ||
-             this->dataType == DataType::INT4_GROUP32) && this->dims.size() >= 2) {
+             this->dataType == DataType::INT4_GROUP32 ||
+             IsPackedKVCacheDataType(this->dataType)) && this->dims.size() >= 2) {
             size_t rows = 0, columns = 0;
             FastllmGetPackedRowsCols(this->dims, rows, columns);
             this->expansionBytes = GetDataBytes(this->dataType, rows, columns);
@@ -1839,7 +1868,8 @@ namespace fastllm {
              this->dataType == DataType::FP8_E4M3_PERCHANNEL ||
              this->dataType == DataType::NVFP4_BLOCK_16 ||
              this->dataType == DataType::NVFP4_BLOCK_16_E8M0 ||
-             this->dataType == DataType::INT4_GROUP32) && this->dims.size() >= 2) {
+             this->dataType == DataType::INT4_GROUP32 ||
+             IsPackedKVCacheDataType(this->dataType)) && this->dims.size() >= 2) {
             size_t rows = 0, columns = 0;
             FastllmGetPackedRowsCols(this->dims, rows, columns);
             return GetDataBytes(this->dataType, rows, columns);
@@ -1857,7 +1887,8 @@ namespace fastllm {
              this->dataType == DataType::FP8_E4M3_PERCHANNEL ||
              this->dataType == DataType::NVFP4_BLOCK_16 ||
              this->dataType == DataType::NVFP4_BLOCK_16_E8M0 ||
-             this->dataType == DataType::INT4_GROUP32) && this->dims.size() >= 2) {
+             this->dataType == DataType::INT4_GROUP32 ||
+             IsPackedKVCacheDataType(this->dataType)) && this->dims.size() >= 2) {
             size_t rows = 0, columns = 0;
             FastllmGetPackedRowsCols(this->dims, rows, columns);
             this->expansionBytes = GetDataBytes(this->dataType, rows, columns);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -17,6 +17,7 @@
 #if defined(__linux__) && defined(__GLIBC__)
 #include <malloc.h>
 #endif
+#include <exception>
 
 #include "chatglm.h"
 #include "moss.h"
@@ -287,6 +288,16 @@ namespace fastllm {
     static bool IsDisabledTpSpec(const std::string &spec) {
         return spec.empty() || spec == "false" || spec == "off" ||
                spec == "none" || spec == "disable";
+    }
+
+    static bool Qwen35GGUFVHeadsTiledEnabled() {
+        const char *env = std::getenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
+        if (env == nullptr || env[0] == '\0') {
+            return true;
+        }
+        const std::string value = TrimAndLower(env);
+        return value != "0" && value != "false" && value != "off" &&
+               value != "no" && value != "disable";
     }
 
     static int ParseRoutedExpertIndex(const std::string &weightName) {
@@ -2362,6 +2373,7 @@ namespace fastllm {
         static std::map <std::string, std::string> ggufTypeToFastllmTypeDict = {
             {"qwen2", "qwen2"}, // llama
             {"qwen3moe", "qwen3_moe"}, {"qwen3_moe", "qwen3_moe"}, // qwen3_moe
+            {"qwen35", "qwen3_5"}, {"qwen3_5", "qwen3_5"}, // qwen3_5 (Qwen3.6 GGUF reports as qwen35)
             {"glm4_moe", "glm4_moe"}, // glm4_moe
             {"glm-dsa", "glm_moe_dsa"}, {"glm_moe_dsa", "glm_moe_dsa"}, // glm_moe_dsa
             {"minimax_m2", "minimax_m2"}, // minimax_m2
@@ -2378,7 +2390,8 @@ namespace fastllm {
     static int GetGLMDSAGGUFMainLayerCount(const json11::Json &params,
                                            const std::string &arch,
                                            const basellm *model) {
-        if (model == nullptr || model->model_type != "glm_moe_dsa") {
+        if (model == nullptr ||
+            (model->model_type != "glm_moe_dsa" && model->model_type != "qwen3_5")) {
             return -1;
         }
 
@@ -2443,7 +2456,22 @@ namespace fastllm {
         json11::Json config;
         ReadGGUFMetaData(ggufFileNames[0], config);
         json11::Json params = config["params"];
-        std::string arch = params["general.architecture"].string_value();        
+        const std::string sourceArch = params["general.architecture"].string_value();
+        std::string arch = sourceArch;
+        const bool sourceQwen35GGUF = sourceArch == "qwen35" || sourceArch == "qwen3_5";
+        if (sourceArch == "qwen35moe" || sourceArch == "qwen3_5_moe") {
+            throw std::runtime_error("Unsupported Qwen3.5 MoE GGUF architecture: " + sourceArch + ".");
+        }
+        if (sourceQwen35GGUF) {
+            int nextnPredictLayers = params[sourceArch + ".nextn_predict_layers"].is_null() ?
+                                     0 : params[sourceArch + ".nextn_predict_layers"].int_value();
+            if (nextnPredictLayers > 1) {
+                throw std::runtime_error("Qwen3.5 GGUF supports at most one MTP layer, got " +
+                                         std::to_string(nextnPredictLayers) + ".");
+            }
+        }
+        const bool qwen35GGUFVHeadsTiled =
+            sourceQwen35GGUF && Qwen35GGUFVHeadsTiledEnabled();
 
         basellm *model = nullptr; 
         std::string path = originalPath;
@@ -2582,6 +2610,62 @@ namespace fastllm {
                     model->weight.AddDict("qk_nope_head_dim", std::to_string(qkMlaHeadDim - qkRopeHeadDim));
                 }
             }
+            if (sourceQwen35GGUF) {
+                int nextnPredictLayers = params[arch + ".nextn_predict_layers"].is_null() ?
+                                         0 : params[arch + ".nextn_predict_layers"].int_value();
+                if (nextnPredictLayers > 0 && model->block_cnt >= nextnPredictLayers) {
+                    model->block_cnt -= nextnPredictLayers;
+                    printf("Load qwen35 main block_cnt = %d (nextn = %d)\n",
+                           model->block_cnt, nextnPredictLayers);
+                }
+                model->weight.AddDict("model_type", "qwen3_5");
+                model->weight.AddDict("num_hidden_layers", std::to_string(model->block_cnt));
+                if (!params[arch + ".nextn_predict_layers"].is_null()) {
+                    model->weight.AddDict("mtp_num_hidden_layers",
+                                          std::to_string(params[arch + ".nextn_predict_layers"].int_value()));
+                }
+                auto q35Int = [&](const std::string &dictKey, const std::string &ggufKey) {
+                    if (!params[arch + "." + ggufKey].is_null()) {
+                        model->weight.AddDict(dictKey, std::to_string(params[arch + "." + ggufKey].int_value()));
+                    }
+                };
+                q35Int("hidden_size", "embedding_length");
+                q35Int("num_attention_heads", "attention.head_count");
+                q35Int("num_key_value_heads", "attention.head_count_kv");
+                q35Int("head_dim", "attention.key_length");
+                q35Int("max_position_embeddings", "context_length");
+                q35Int("intermediate_size", "feed_forward_length");
+                if (!params[arch + ".attention.layer_norm_rms_epsilon"].is_null()) {
+                    model->weight.AddDict("rms_norm_eps",
+                                          std::to_string(params[arch + ".attention.layer_norm_rms_epsilon"].number_value()));
+                }
+                // Qwen3.5 GDN linear-attention params: GGUF stores ssm.* which map
+                // to HF linear_attn dims as exposed by Qwen3_5Model::InitParams.
+                q35Int("linear_num_key_heads", "ssm.group_count");
+                // linear_num_value_heads = ssm.inner_size / ssm.state_size
+                // (time_step_rank happens to equal it for Qwen3.6 but is a
+                //  separate concept; derive from the value-head count instead).
+                if (!params[arch + ".ssm.inner_size"].is_null() &&
+                    !params[arch + ".ssm.state_size"].is_null() &&
+                    params[arch + ".ssm.state_size"].int_value() > 0) {
+                    int innerSize = params[arch + ".ssm.inner_size"].int_value();
+                    int stateSize = params[arch + ".ssm.state_size"].int_value();
+                    model->weight.AddDict("linear_num_value_heads",
+                                          std::to_string(innerSize / stateSize));
+                }
+                q35Int("linear_key_head_dim", "ssm.state_size");
+                q35Int("linear_value_head_dim", "ssm.state_size");
+                // Qwen3.5 GGUF converters pre-offset norms independently of
+                // their V-head layout. The layout can be overridden for old or
+                // nonstandard files without changing norm semantics.
+                model->weight.AddDict("ggufNormsPreOffset", "1");
+                model->weight.AddDict("ggufOutProjColumnsTiled",
+                                      qwen35GGUFVHeadsTiled ? "1" : "0");
+                if (!params[arch + ".rope.freq_base"].is_null()) {
+                    model->weight.AddDict("rope_theta",
+                                          std::to_string(params[arch + ".rope.freq_base"].number_value()));
+                }
+            }
 
             if (!params[arch + ".attention.head_count"].is_null()) {
                 model->num_attention_heads = params[arch + ".attention.head_count"].int_value();
@@ -2644,7 +2728,15 @@ namespace fastllm {
             // printf("config = %s\n", config.dump().c_str());
         }
 
-        arch = ConvertGGUFTypeToFastllmType(arch);
+        if (sourceQwen35GGUF) {
+            // Preserve GGUF properties when `originalPath` supplies the HF
+            // config/tokenizer (the branch above replaces `arch`).
+            model->weight.AddDict("ggufNormsPreOffset", "1");
+            model->weight.AddDict("ggufOutProjColumnsTiled",
+                                  qwen35GGUFVHeadsTiled ? "1" : "0");
+        }
+
+        arch = ConvertGGUFTypeToFastllmType(sourceArch);
         int ggufMainLayerCount = GetGLMDSAGGUFMainLayerCount(params, arch, model);
 
         // 3.0 更新模型信息
@@ -2658,6 +2750,58 @@ namespace fastllm {
         ReportModelLoadProgress("weights_prepare", 0, 1);
         for (auto &s : ggufFileNames) {
             AppendGGUFTasks(arch, s, readGGUFTasks);
+        }
+        // Qwen3.5 GGUF: the nextn-specific tensors (eh_proj/enorm/hnorm/...)
+        // are renamed to mtp.* by the GGUF rules. The MTP block's attention/FFN
+        // weights were renamed by the trunk rules into
+        // model.language_model.layers.{block_count}.*; reroute them into
+        // mtp.layers.0.* so Qwen3_5Model's MTP draft head picks them up.
+        if (arch == "qwen3_5") {
+            std::string layerPrefix = "model.language_model.layers." +
+                                       std::to_string(model->block_cnt) + ".";
+            std::string mtpLayer = "mtp.layers.0.";
+            for (auto &task : readGGUFTasks) {
+                std::string &name = task.name;
+                if (name.compare(0, layerPrefix.size(), layerPrefix) == 0) {
+                    name = mtpLayer + name.substr(layerPrefix.size());
+                }
+            }
+        }
+        // Normalize converter-tiled V rows before any merge. An explicit
+        // override keeps old/nonstandard GGUFs in their native grouped layout;
+        // A_log still needs the independent -exp inverse in that mode.
+        if (arch == "qwen3_5") {
+            auto dictGet = [&](const std::string &key, const std::string &def) -> std::string {
+                auto it = model->weight.dicts.find(key);
+                return it != model->weight.dicts.end() ? it->second : def;
+            };
+            int numKHeads = atoi(dictGet("linear_num_key_heads", "0").c_str());
+            int numVHeads = atoi(dictGet("linear_num_value_heads", "0").c_str());
+            int headKDim = atoi(dictGet("linear_key_head_dim", "0").c_str());
+            if (qwen35GGUFVHeadsTiled) {
+                AssertInFastLLM(numKHeads > 0 && numVHeads >= numKHeads &&
+                                numVHeads % numKHeads == 0 && headKDim > 0,
+                                "Qwen3.5 GGUF V-head untile metadata is invalid.\n");
+            }
+            for (auto &task : readGGUFTasks) {
+                if (task.replaceType != GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads) {
+                    continue;
+                }
+                if (!qwen35GGUFVHeadsTiled) {
+                    task.replaceType = task.untileComposeNegLog
+                        ? GGUFWeightReplaceRule::GGUFWeightReplaceNegLogFP32
+                        : GGUFWeightReplaceRule::GGUFWeightReplaceDirect;
+                    continue;
+                }
+                task.untileNumKHeads = numKHeads;
+                task.untileNumVHeads = numVHeads;
+                const bool hasQkPrefix =
+                    task.name.find("in_proj_qkv.") != std::string::npos ||
+                    task.name.find("linear_attn.conv1d.") != std::string::npos;
+                task.untileVRowStart = hasQkPrefix
+                    ? 2 * numKHeads * headKDim
+                    : 0;
+            }
         }
         uint64_t totalLoadBytes = 0;
         for (int i = 0; i < readGGUFTasks.size(); i++) {
@@ -2683,6 +2827,7 @@ namespace fastllm {
         std::vector <std::thread*> threads;
         int threadNum = std::min(16, std::max(4, (int)GetAlivePool()->threads.size()));
         std::mutex locker;
+        std::vector<std::exception_ptr> threadErrors(threadNum);
         int cnt = 0;
         uint64_t completedLoadBytes = 0;
         ReportModelLoadProgress("weights_load", 0, std::max<size_t>(1, tensors.size()),
@@ -2717,9 +2862,11 @@ namespace fastllm {
         // Load 
         for (int i = 0; i < threadNum; i++) {
             threads.push_back(
-                new std::thread([&](int st, int end) {
-                    for (int i = st; i < end; i++) {
-                        auto &weightName = tensors[i];
+                new std::thread([&, i](int st, int end) {
+                    std::unique_lock<std::mutex> workerLock(locker, std::defer_lock);
+                    try {
+                        for (int tensorIndex = st; tensorIndex < end; tensorIndex++) {
+                            auto &weightName = tensors[tensorIndex];
                         uint64_t tensorBytes = 0;
                         if (readGGUFTaskDict.find(weightName) != readGGUFTaskDict.end()) {
                             auto *task = readGGUFTaskDict[weightName];
@@ -2729,12 +2876,14 @@ namespace fastllm {
                                 SetDiskGGUFWeightMeta(*task->weight, task->tensor, task->fileName, task->offset);
                             } else {
                                 WeightImportGGUFTensor(task->weight, &task->tensor, task->fileName,
-                                                       task->offset, task->replaceType);
+                                                       task->offset, task->replaceType,
+                                                       task->untileNumKHeads, task->untileNumVHeads,
+                                                       task->untileVRowStart, task->untileComposeNegLog);
                             }
                         } 
                         {
                             // try merge                                
-                            locker.lock();
+                            workerLock.lock();
                             allFinishNames.insert(weightName);
                             // 检查是否需要合并权重
                             bool needMerge = false;
@@ -2784,7 +2933,7 @@ namespace fastllm {
                                     continue;
                                 }
 
-                                locker.unlock();
+                                workerLock.unlock();
                                 for (auto &it : rule.rules) {
                                     if (allWeightNames.find(it.inputs[0]) == allWeightNames.end()) {
                                         continue;
@@ -2862,12 +3011,13 @@ namespace fastllm {
 #ifdef USE_TFACC
                                         try {
                                             if (model->ShouldRegisterSpecialWeightForDeviceType(mergeName, "tfacc")) {
-                                                locker.lock();
+                                                workerLock.lock();
                                                 mergeData.weightSum.resize(1);
                                                 RegisterFastllmData(&mergeData, it.type);
-                                                locker.unlock();
+                                                workerLock.unlock();
                                             }
                                         } catch (...) {
+                                            if (workerLock.owns_lock()) workerLock.unlock();
                                         }
 #endif
 #if defined(USE_NUMAS)
@@ -2882,29 +3032,30 @@ namespace fastllm {
                                         model->MoveSpecialWeightToCudaIfNeeded(mergeName, mergeData);
                                     }
 
-                                    locker.lock();
+                                    workerLock.lock();
                                     allFinishNames.insert(mergedWeightName);
                                     model->OnWeightLoaded(mergedWeightName, allFinishNames);
-                                    locker.unlock();
+                                    workerLock.unlock();
                                     for (auto input : it.inputs) {
                                         model->weight.weight.erase(input);
                                     }
                                 }
-                                locker.lock();
+                                workerLock.lock();
                             }
-                            locker.unlock();
+                            workerLock.unlock();
 #ifdef USE_TFACC
                             try {
                                 if (!needMerge && model->ShouldRegisterSpecialWeightForDeviceType(weightName, "tfacc")) {
                                     auto weightIt = model->weight.weight.find(weightName);
                                     if (weightIt != model->weight.weight.end()) {
-                                        locker.lock();
+                                        workerLock.lock();
                                         weightIt->second.weightSum.resize(1);
                                         RegisterFastllmData(&weightIt->second, model->specialWeights[weightName]);
-                                        locker.unlock();
+                                        workerLock.unlock();
                                     }
                                 }
                             } catch (...) {
+                                if (workerLock.owns_lock()) workerLock.unlock();
                             }
 #endif
 #if defined(USE_NUMAS)
@@ -2928,13 +3079,13 @@ namespace fastllm {
                         }
 
                         if (tensors.size() != 0) {
-                            locker.lock();
+                            workerLock.lock();
                             int current = ++cnt;
                             completedLoadBytes += tensorBytes;
                             uint64_t currentBytes = completedLoadBytes;
                             printf("Loading %d \r", current * 100 / (int)tensors.size());
                             fflush(stdout);
-                            locker.unlock();
+                            workerLock.unlock();
                             if (current == (int)tensors.size() ||
                                 current * 100 / (int)tensors.size() !=
                                     (current - 1) * 100 / (int)tensors.size()) {
@@ -2942,6 +3093,9 @@ namespace fastllm {
                                                         currentBytes, totalLoadBytes);
                             }
                         }
+                        }
+                    } catch (...) {
+                        threadErrors[i] = std::current_exception();
                     }
                 }, parts[i].first, parts[i].second)
             );
@@ -2949,6 +3103,11 @@ namespace fastllm {
         for (int i = 0; i < threads.size(); i++) {
             threads[i]->join();
             delete threads[i];
+        }
+        for (auto &error : threadErrors) {
+            if (error) {
+                std::rethrow_exception(error);
+            }
         }
         model->OnModelWeightsLoaded();
 
@@ -2959,6 +3118,9 @@ namespace fastllm {
     }
 
     std::unique_ptr<fastllm::basellm> CreateLLMModelFromFile(const std::string &fileName) {
+        if (IsGGUFFile(fileName)) {
+            return CreateLLMModelFromGGUFFile(fileName, "");
+        }
         std::string modelType = GetModelTypeFromFile(fileName);
         basellm *model = CreateModelWithType(modelType);
         if(modelType == "bert"){

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -268,9 +268,6 @@ namespace fastllm {
                deviceName[deviceType.size()] == ':';
     }
 
-#ifdef USE_CUDA
-    static std::mutex multiCudaTpLoadSplitLock;
-
     static std::string TrimAndLower(const std::string &s) {
         int l = 0, r = (int)s.size();
         while (l < r && std::isspace((unsigned char)s[l])) {
@@ -285,11 +282,6 @@ namespace fastllm {
         return ret;
     }
 
-    static bool IsDisabledTpSpec(const std::string &spec) {
-        return spec.empty() || spec == "false" || spec == "off" ||
-               spec == "none" || spec == "disable";
-    }
-
     static bool Qwen35GGUFVHeadsTiledEnabled() {
         const char *env = std::getenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
         if (env == nullptr || env[0] == '\0') {
@@ -298,6 +290,14 @@ namespace fastllm {
         const std::string value = TrimAndLower(env);
         return value != "0" && value != "false" && value != "off" &&
                value != "no" && value != "disable";
+    }
+
+#ifdef USE_CUDA
+    static std::mutex multiCudaTpLoadSplitLock;
+
+    static bool IsDisabledTpSpec(const std::string &spec) {
+        return spec.empty() || spec == "false" || spec == "off" ||
+               spec == "none" || spec == "disable";
     }
 
     static int ParseRoutedExpertIndex(const std::string &weightName) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -2734,6 +2734,13 @@ namespace fastllm {
             model->weight.AddDict("ggufNormsPreOffset", "1");
             model->weight.AddDict("ggufOutProjColumnsTiled",
                                   qwen35GGUFVHeadsTiled ? "1" : "0");
+            for (const std::string &token : {std::string("<|endoftext|>"),
+                                             std::string("<|im_end|>")}) {
+                auto it = model->weight.tokenizer.stringToTokenDict.find(token);
+                if (it != model->weight.tokenizer.stringToTokenDict.end()) {
+                    model->eos_token_ids.insert(it->second);
+                }
+            }
         }
 
         arch = ConvertGGUFTypeToFastllmType(sourceArch);

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -450,6 +450,8 @@ namespace fastllm {
         }
         intParams.clear();
         toolCallConstraintGeneratedText.clear();
+        pendingStopTokens.clear();
+        pendingStopText.clear();
         currentTokens.clear();
         allTokens.clear();
         while (resultTokenQueue.size() > 0){

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -3118,6 +3118,33 @@ namespace fastllm {
         return this->GetChunkedPrefillSize();
     }
 
+    DataType ParseKVCacheDataType(const std::string &value) {
+        if (value.empty() || value == "auto") {
+            return DataType::DATA_AUTO_NONE;
+        }
+        if (value == "float" || value == "float32") {
+            return DataType::FLOAT32;
+        }
+        if (value == "half" || value == "float16") {
+            return DataType::FLOAT16;
+        }
+        if (value == "bf16" || value == "bfloat16") {
+            return DataType::BFLOAT16;
+        }
+        if (value == "fp8" || value == "float8" || value == "fp8_e4m3") {
+            return DataType::FP8_E4M3;
+        }
+        throw std::invalid_argument(
+            "KV cache dtype should be auto, float32, float16, bfloat16 or fp8_e4m3.");
+    }
+
+    void basellm::SetTokenLimit(int tokens) {
+        this->tokensLimit = tokens;
+        if (tokens > 0) {
+            fastllm::SetMaxTokens(tokens);
+        }
+    }
+
     void basellm::SetDataType(DataType dataType) {
         if (dataType == DataType::FLOAT32) {
 

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -432,19 +432,19 @@ namespace fastllm {
         }
     }
 
-    void ResponseContext::Init(int blocks, DataType, DataType kvCacheDataType) {
+    void ResponseContext::Init(basellm *model) {
+        AssertInFastLLM(model != nullptr, "ResponseContext::Init requires a model.\n");
         pastKeyValues.clear();
-        // A request owns two cache descriptors per transformer block.  Without
+        // A request owns two cache descriptors per transformer block. Without
         // reserving here, vector growth repeatedly copy-constructs every Data
-        // descriptor already inserted.  Qwen3.5 has enough blocks for that
-        // O(blocks^2) setup work to serialize a burst of HTTP requests and
-        // split one batch into multiple prefills before any GPU work starts.
-        pastKeyValues.reserve(blocks);
-        for (int i = 0; i < blocks; i++) {
+        // descriptor already inserted.
+        pastKeyValues.reserve(model->block_cnt);
+        for (int i = 0; i < model->block_cnt; i++) {
+            auto types = model->GetKVCacheDataTypes(i);
             pastKeyValues.emplace_back(
                 std::piecewise_construct,
-                std::forward_as_tuple(kvCacheDataType),
-                std::forward_as_tuple(kvCacheDataType));
+                std::forward_as_tuple(types.first),
+                std::forward_as_tuple(types.second));
             pastKeyValues.back().first.SetKVCache();
             pastKeyValues.back().second.SetKVCache();
         }
@@ -454,13 +454,14 @@ namespace fastllm {
         pendingStopText.clear();
         currentTokens.clear();
         allTokens.clear();
-        while (resultTokenQueue.size() > 0){
+        while (resultTokenQueue.size() > 0) {
             resultTokenQueue.pop();
         }
         isEnding = false;
-        preTokens = 0;
+        isAbort = false;
         longPrefill.Reset();
     }
+
 
     void ResponseContext::TryRecord(basellm *model) {
         model->TryRecordResponseContext(this);
@@ -2794,7 +2795,7 @@ namespace fastllm {
         dictLocker.lock();
         int handleId = responseContextDict.CreateHandle();
         ResponseContext *context = responseContextDict.GetHandle(handleId);
-        context->Init(this->block_cnt, this->dataType, this->kvCacheDataType);
+        context->Init(this);
         context->inputTokens = (int)inputTokens.size();
         context->currentTokens = inputTokens;
         context->allTokens = inputTokens;
@@ -3137,8 +3138,11 @@ namespace fastllm {
         if (value == "fp8" || value == "float8" || value == "fp8_e4m3") {
             return DataType::FP8_E4M3;
         }
+        if (value == "turbo3" || value == "turbo3_kv") {
+            return DataType::TURBO3_KV;
+        }
         throw std::invalid_argument(
-            "KV cache dtype should be auto, float32, float16, bfloat16 or fp8_e4m3.");
+            "KV cache dtype should be auto, float32, float16, bfloat16, fp8_e4m3 or turbo3.");
     }
 
     void basellm::SetTokenLimit(int tokens) {
@@ -3659,7 +3663,11 @@ namespace fastllm {
             std::vector <std::pair <Data, Data> > weightWarmupPastKeyValuesStorage;
             std::vector <std::pair <Data*, Data*> > weightWarmupPastKeyValues;
             for (int i = 0; i < block_cnt; i++) {
-                weightWarmupPastKeyValuesStorage.push_back(std::make_pair(Data(this->kvCacheDataType), Data(this->kvCacheDataType)));
+                auto types = this->GetKVCacheDataTypes(i);
+                weightWarmupPastKeyValuesStorage.emplace_back(
+                    std::piecewise_construct,
+                    std::forward_as_tuple(types.first),
+                    std::forward_as_tuple(types.second));
                 weightWarmupPastKeyValuesStorage.back().first.SetKVCache();
                 weightWarmupPastKeyValuesStorage.back().second.SetKVCache();
             }
@@ -3703,7 +3711,11 @@ namespace fastllm {
         std::vector <std::pair <Data, Data> > pastKeyValuesStorage;
         std::vector <std::pair <Data*, Data*> > pastKeyValues;
         for (int i = 0; i < block_cnt; i++) {
-            pastKeyValuesStorage.push_back(std::make_pair(Data(this->kvCacheDataType), Data(this->kvCacheDataType)));
+            auto types = this->GetKVCacheDataTypes(i);
+            pastKeyValuesStorage.emplace_back(
+                std::piecewise_construct,
+                std::forward_as_tuple(types.first),
+                std::forward_as_tuple(types.second));
             pastKeyValuesStorage.back().first.SetKVCache();
             pastKeyValuesStorage.back().second.SetKVCache();
         }
@@ -3725,7 +3737,7 @@ namespace fastllm {
         elementsInKVCachePerToken = 0;
         bool foundTokenGrowingCache = false;
         bool hasCudaTokenGrowingCache = false;
-        std::vector <long long> layerElementsPerToken(block_cnt, 0);
+        std::vector <long long> layerKeyElementsPerToken(block_cnt, 0), layerValueElementsPerToken(block_cnt, 0);
         int tokenGrowingLayerCount = 0, linearLayerCount = 0;
         int boundedLayerCount = 0;
         long long linearFixedBytes = 0;
@@ -3839,15 +3851,23 @@ namespace fastllm {
                 foundTokenGrowingCache = true;
             }
 
-            layerElementsPerToken[i] =
-                (long long)pastKey.dims[0] * pastKey.dims[2] +
+            layerKeyElementsPerToken[i] =
+                (long long)pastKey.dims[0] * pastKey.dims[2];
+            layerValueElementsPerToken[i] =
                 (long long)pastValue.dims[0] * pastValue.dims[2];
-            elementsInKVCachePerToken += layerElementsPerToken[i];
+            elementsInKVCachePerToken +=
+                layerKeyElementsPerToken[i] + layerValueElementsPerToken[i];
         }
 
         long long bytesPerToken = 0;
-        if (elementsInKVCachePerToken > 0) {
-            bytesPerToken = GetDataBytes(this->kvCacheDataType, 1, elementsInKVCachePerToken);
+        for (int i = 0; i < block_cnt; i++) {
+            if (layerKeyElementsPerToken[i] <= 0 || layerValueElementsPerToken[i] <= 0) {
+                continue;
+            }
+            bytesPerToken += GetDataBytes(pastKeyValuesStorage[i].first.dataType, 1,
+                                          layerKeyElementsPerToken[i]);
+            bytesPerToken += GetDataBytes(pastKeyValuesStorage[i].second.dataType, 1,
+                                          layerValueElementsPerToken[i]);
         }
         if (autoCalcPages) {
             printf("[Fastllm] AutoWarmup stats: tokenGrowingLayers=%d, boundedLayers=%d, linearLayers=%d, fixedCachePerRequest=%.2f MB, kvBytesPerToken=%.2f KB, firstKVLayer=%d.\n",
@@ -3893,7 +3913,11 @@ namespace fastllm {
             pastKeyValues.reserve((size_t)batch * block_cnt);
             for (int b = 0; b < batch; b++) {
                 for (int i = 0; i < block_cnt; i++) {
-                    pastKeyValuesStorage.push_back(std::make_pair(Data(this->kvCacheDataType), Data(this->kvCacheDataType)));
+                    auto types = this->GetKVCacheDataTypes(i);
+                    pastKeyValuesStorage.emplace_back(
+                        std::piecewise_construct,
+                        std::forward_as_tuple(types.first),
+                        std::forward_as_tuple(types.second));
                     pastKeyValuesStorage.back().first.SetKVCache();
                     pastKeyValuesStorage.back().second.SetKVCache();
                     pastKeyValues.push_back(std::make_pair(&pastKeyValuesStorage.back().first,
@@ -3990,25 +4014,29 @@ namespace fastllm {
             std::map <int, long long> deviceDelayedCacheBytesPerPage;
             std::map <int, int> deviceLayerCount;
             auto updateDelayedCacheReserve = [&](int id,
+                                                 DataType keyType,
                                                  long long keyElementsPerToken,
+                                                 DataType valueType,
                                                  long long valueElementsPerToken) {
                 if (id < 0 || keyElementsPerToken <= 0 || valueElementsPerToken <= 0) {
                     return;
                 }
-                long long keyBytesPerPage = GetDataBytes(this->kvCacheDataType, pageLen, keyElementsPerToken);
-                long long valueBytesPerPage = GetDataBytes(this->kvCacheDataType, pageLen, valueElementsPerToken);
+                long long keyBytesPerPage = GetDataBytes(keyType, pageLen, keyElementsPerToken);
+                long long valueBytesPerPage = GetDataBytes(valueType, pageLen, valueElementsPerToken);
                 long long layerPairBytesPerPage = keyBytesPerPage + valueBytesPerPage;
                 deviceDelayedCacheBytesPerPage[id] =
                     std::max(deviceDelayedCacheBytesPerPage[id], layerPairBytesPerPage);
             };
             for (int i = 0; i < block_cnt; i++) {
-                if (layerElementsPerToken[i] <= 0) {
+                if (layerKeyElementsPerToken[i] <= 0 || layerValueElementsPerToken[i] <= 0) {
                     continue;
                 }
                 auto &pastKey = pastKeyValuesStorage[i].first;
                 auto &pastValue = pastKeyValuesStorage[i].second;
                 bool accountedByLocalShard = false;
-                long long layerBytesPerPage = GetDataBytes(this->kvCacheDataType, pageLen, layerElementsPerToken[i]);
+                long long layerBytesPerPage =
+                    GetDataBytes(pastKey.dataType, pageLen, layerKeyElementsPerToken[i]) +
+                    GetDataBytes(pastValue.dataType, pageLen, layerValueElementsPerToken[i]);
 
                 if (pastKey.multiDeviceData && pastValue.multiDeviceData &&
                     !pastKey.multiDeviceDatas.empty() && !pastValue.multiDeviceDatas.empty()) {
@@ -4030,12 +4058,13 @@ namespace fastllm {
                             (long long)localKey->dims[0] * localKey->dims[2];
                         long long localValueElementsPerToken =
                             (long long)localValue->dims[0] * localValue->dims[2];
-                        long long localElementsPerToken =
-                            localKeyElementsPerToken + localValueElementsPerToken;
-                        long long localBytesPerPage = GetDataBytes(this->kvCacheDataType, pageLen, localElementsPerToken);
+                        long long localBytesPerPage =
+                            GetDataBytes(localKey->dataType, pageLen, localKeyElementsPerToken) +
+                            GetDataBytes(localValue->dataType, pageLen, localValueElementsPerToken);
                         deviceIds.insert(id);
                         deviceBytesPerPage[id] += localBytesPerPage;
-                        updateDelayedCacheReserve(id, localKeyElementsPerToken, localValueElementsPerToken);
+                        updateDelayedCacheReserve(id, localKey->dataType, localKeyElementsPerToken,
+                                                  localValue->dataType, localValueElementsPerToken);
                         deviceLayerCount[id]++;
                         accountedByLocalShard = true;
                     }
@@ -4053,7 +4082,8 @@ namespace fastllm {
                         deviceBytesPerPage[id] += layerBytesPerPage;
                         long long keyElementsPerToken = (long long)pastKey.dims[0] * pastKey.dims[2];
                         long long valueElementsPerToken = (long long)pastValue.dims[0] * pastValue.dims[2];
-                        updateDelayedCacheReserve(id, keyElementsPerToken, valueElementsPerToken);
+                        updateDelayedCacheReserve(id, pastKey.dataType, keyElementsPerToken,
+                                                  pastValue.dataType, valueElementsPerToken);
                         deviceLayerCount[id]++;
                     }
                 }

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -459,6 +459,7 @@ namespace fastllm {
         }
         isEnding = false;
         preTokens = 0;
+        longPrefill.Reset();
     }
 
     void ResponseContext::TryRecord(basellm *model) {

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -8,6 +8,8 @@
 #include "blocks/baseblock.h"
 #include "executor.h"
 #include "gguf.h"
+#include "utils/stop_token_matcher.h"
+#include "utils/stop_string_matcher.h"
 
 #include <algorithm>
 #include <atomic>
@@ -15357,8 +15359,16 @@ namespace fastllm {
                             acceptedTokenLists[i] : emptyAcceptedTokens;
                     for (int tokenIndex = 0; tokenIndex < (int)curAcceptedTokens.size(); tokenIndex++) {
                         int curRet = curAcceptedTokens[tokenIndex];
+                        auto flushPendingStopTokens = [&]() {
+                            FlushPendingStopTokensTo(
+                                ctx->pendingStopTokens,
+                                [&](int token) {
+                                    ctx->resultTokenQueue.push(token);
+                                });
+                        };
                         if (curRet == model->eos_token_id ||
                             model->eos_token_ids.find(curRet) != model->eos_token_ids.end()) {
+                            flushPendingStopTokens();
                             ctx->isEnding = true;
                             ctx->TryRecordPagedCache(model);
                             eraseMtpCache(ctx);
@@ -15366,26 +15376,59 @@ namespace fastllm {
                         }
                         auto itStopTk = ctx->generationConfig.stop_token_ids.find(curRet);
                         if (itStopTk != ctx->generationConfig.stop_token_ids.end()) {
+                            flushPendingStopTokens();
                             ctx->isEnding = true;
                             ctx->TryRecordPagedCache(model);
                             eraseMtpCache(ctx);
                             break;
                         }
+                        std::string decodedToken =
+                            model->weight.tokenizer.DecodeTokens({curRet});
+                        std::string safeStopText;
+                        bool matchedStopText = PushStopText(
+                            ctx->generationConfig.stop_strings,
+                            ctx->pendingStopText, decodedToken,
+                            safeStopText);
 
-                        ctx->resultTokenQueue.push(curRet);
-                        if (tokenIndex == 0) {
-                            queueGeneratedResultLogits(ctx, logits, i);
+                        std::vector<int> readyTokens;
+                        int matchedStopLength = PushStopToken(
+                            ctx->generationConfig.stop_token_sequences,
+                            ctx->pendingStopTokens, curRet, readyTokens);
+                        for (int readyIndex = 0;
+                             readyIndex < (int)readyTokens.size();
+                             readyIndex++) {
+                            int readyToken = readyTokens[readyIndex];
+                            ctx->resultTokenQueue.push(readyToken);
+                            if (tokenIndex == 0 && readyIndex == 0) {
+                                queueGeneratedResultLogits(ctx, logits, i);
+                            }
                         }
+
                         ctx->allTokens.push_back(curRet);
                         if (Qwen35NeedRepeatPenalty(ctx->generationConfig)) {
                             ctx->tokens.Push(curRet);
                         }
                         ctx->curTokens++;
-                        if (ctx->curTokens == ctx->generationConfig.output_token_limit) {
+
+                        if (matchedStopText || matchedStopLength > 0) {
+                            ctx->isEnding = true;
+                            ctx->TryRecordPagedCache(model);
+                            eraseMtpCache(ctx);
+                        } else if (ctx->curTokens == ctx->generationConfig.output_token_limit) {
+                            FlushPendingStopTokens(ctx->pendingStopTokens,
+                                                   readyTokens);
+                            for (int readyToken : readyTokens) {
+                                ctx->resultTokenQueue.push(readyToken);
+                            }
                             ctx->isEnding = true;
                             ctx->TryRecordPagedCache(model);
                             eraseMtpCache(ctx);
                         } else if (ctx->allTokens.size() >= model->max_positions) {
+                            FlushPendingStopTokens(ctx->pendingStopTokens,
+                                                   readyTokens);
+                            for (int readyToken : readyTokens) {
+                                ctx->resultTokenQueue.push(readyToken);
+                            }
                             ctx->isEnding = true;
                             ctx->TryRecordPagedCache(model);
                             eraseMtpCache(ctx);

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -7,6 +7,7 @@
 #include "qwen3_5.h"
 #include "blocks/baseblock.h"
 #include "executor.h"
+#include "gguf.h"
 
 #include <algorithm>
 #include <atomic>
@@ -37,6 +38,97 @@
 namespace fastllm {
 #ifdef USE_NUMAS
     extern void RegisterNumas(fastllm::Data *data, std::string weightType);
+#endif
+
+    Qwen35GdnProjectionLayout ResolveQwen35GdnProjectionLayout(
+            const WeightMap &weight,
+            const std::string &layerPrefix) {
+        auto has = [&](const char *suffix) {
+            return weight.weight.find(layerPrefix + suffix) != weight.weight.end();
+        };
+        if (has("linear_attn.in_proj_qkvzba.weight")) {
+            return Qwen35GdnProjectionLayout::Qkvzba;
+        }
+        if (has("linear_attn.in_proj_qkvz.weight") &&
+            has("linear_attn.in_proj_ba.weight")) {
+            return Qwen35GdnProjectionLayout::QkvzBa;
+        }
+        if (has("linear_attn.in_proj_qkv.weight") &&
+            has("linear_attn.in_proj_z.weight") &&
+            has("linear_attn.in_proj_ba.weight")) {
+            return Qwen35GdnProjectionLayout::QkvZBa;
+        }
+        return Qwen35GdnProjectionLayout::Missing;
+    }
+
+    Qwen35AttentionProjectionLayout ResolveQwen35AttentionProjectionLayout(
+            const WeightMap &weight,
+            const std::string &layerPrefix) {
+        auto has = [&](const char *suffix) {
+            return weight.weight.find(layerPrefix + suffix) != weight.weight.end();
+        };
+        if (has("self_attn.mergeqkv.weight")) {
+            return Qwen35AttentionProjectionLayout::MergedQkv;
+        }
+        if (has("self_attn.q_proj.weight") &&
+            has("self_attn.k_proj.weight") &&
+            has("self_attn.v_proj.weight")) {
+            return Qwen35AttentionProjectionLayout::SplitQkv;
+        }
+        return Qwen35AttentionProjectionLayout::Missing;
+    }
+
+#ifdef USE_CUDA
+    Qwen35DivisionScheme BuildQwen35LinearOutProjScheme(
+            const Qwen35DivisionScheme &keyHeadScheme,
+            int numKHeads,
+            int numVHeads,
+            int headVDim,
+            int quantBlock,
+            bool tiledColumns) {
+        if (!(numKHeads > 0 && numVHeads >= numKHeads &&
+              numVHeads % numKHeads == 0 && headVDim > 0)) {
+            throw std::runtime_error(
+                "Qwen3.5 out_proj TP split got invalid head metadata.");
+        }
+        quantBlock = std::max(1, quantBlock);
+        const int valueHeadsPerKey = numVHeads / numKHeads;
+        Qwen35DivisionScheme ret;
+        for (auto &it : keyHeadScheme) {
+            ret[it.first];
+            if (it.second.size() > 1) {
+                throw std::runtime_error(
+                    "Qwen3.5 out_proj TP split requires one contiguous key-head range per device.");
+            }
+            for (auto &range : it.second) {
+                if (!(range.first >= 0 && range.second > range.first &&
+                      range.second <= numKHeads)) {
+                    throw std::runtime_error(
+                        "Qwen3.5 out_proj TP split got an invalid key-head range.");
+                }
+                if (tiledColumns) {
+                    for (int r = 0; r < valueHeadsPerKey; r++) {
+                        const int start = (r * numKHeads + range.first) * headVDim;
+                        const int end = (r * numKHeads + range.second) * headVDim;
+                        if (!(start % quantBlock == 0 && end % quantBlock == 0)) {
+                            throw std::runtime_error(
+                                "Qwen3.5 tiled out_proj TP split is not quant-block aligned.");
+                        }
+                        ret[it.first].push_back({start, end});
+                    }
+                } else {
+                    const int start = range.first * valueHeadsPerKey * headVDim;
+                    const int end = range.second * valueHeadsPerKey * headVDim;
+                    if (!(start % quantBlock == 0 && end % quantBlock == 0)) {
+                        throw std::runtime_error(
+                            "Qwen3.5 grouped out_proj TP split is not quant-block aligned.");
+                    }
+                    ret[it.first].push_back({start, end});
+                }
+            }
+        }
+        return ret;
+    }
 #endif
 
     static std::string Qwen35MoeExpertPrefix(int layer, int expert) {
@@ -124,8 +216,8 @@ namespace fastllm {
     }
 
     static constexpr int QWEN35_MTP_LOG_INTERVAL = 64;
-    static constexpr int QWEN35_MTP_MAX_DRAFTS = 8;
-    static constexpr int QWEN35_MTP_FAST_SEQ_MAX = 6;
+    static constexpr int QWEN35_MTP_MAX_DRAFTS = 9;
+    static constexpr int QWEN35_MTP_FAST_SEQ_MAX = QWEN35_MTP_MAX_DRAFTS + 1;
     static constexpr float QWEN35_MTP_TYPICAL_POSTERIOR_THRESHOLD = 0.09f;
     static constexpr float QWEN35_MTP_TYPICAL_POSTERIOR_ALPHA = 0.3f;
     static constexpr int QWEN35_MTP_PREFIX_SNAPSHOT_MAX =
@@ -155,6 +247,87 @@ namespace fastllm {
         explicit Qwen35MtpBatchFastPathUnavailable(const std::string &message)
             : std::runtime_error(message) {}
     };
+    struct Qwen35GdnDryRunResult {
+        bool eligible = false;
+        std::string reason;
+    };
+
+    static void Qwen35LogGdnDecisionOnce(const std::string &key,
+                                         const std::string &message) {
+        static std::mutex logMutex;
+        static std::set<std::string> logged;
+        std::lock_guard<std::mutex> guard(logMutex);
+        if (logged.insert(key).second) {
+            printf("[Fastllm] Qwen3.5 GDN %s\n", message.c_str());
+            fflush(stdout);
+        }
+    }
+
+    static Qwen35GdnDryRunResult Qwen35DryRunSingleDecodeRecurrent(
+            const Data &q, const Data &k, const Data &v,
+            const Data &gateA, const Data &gateB,
+            const Data &normWeight, const Data *aLog, const Data *dtBias,
+            const Data &lastRecurrentState, bool tiledQKHeadOrder) {
+        auto reject = [](const std::string &reason) {
+            return Qwen35GdnDryRunResult{false, reason};
+        };
+        if (q.dataDevice != DataDevice::CUDA ||
+            k.dataDevice != DataDevice::CUDA ||
+            v.dataDevice != DataDevice::CUDA ||
+            gateA.dataDevice != DataDevice::CUDA ||
+            gateB.dataDevice != DataDevice::CUDA) {
+            return reject("input_not_cuda");
+        }
+        if (q.dataType != DataType::FLOAT16 ||
+            k.dataType != DataType::FLOAT16 ||
+            v.dataType != DataType::FLOAT16 ||
+            gateA.dataType != DataType::FLOAT16 ||
+            gateB.dataType != DataType::FLOAT16) {
+            return reject("input_dtype_requires_fp16");
+        }
+        if (q.dims.size() != 4 || k.dims.size() != 4 ||
+            v.dims.size() != 4 || gateA.dims.size() != 3 ||
+            gateB.dims.size() != 3) {
+            return reject("input_rank_mismatch");
+        }
+        if (q.dims[0] != 1 || k.dims[0] != 1 || v.dims[0] != 1 ||
+            q.dims[1] != 1 || k.dims[1] != 1 || v.dims[1] != 1 ||
+            gateA.dims[0] != 1 || gateB.dims[0] != 1 ||
+            gateA.dims[1] != 1 || gateB.dims[1] != 1) {
+            return reject("single_token_shape_required");
+        }
+        if (q.dims[3] != 128 || k.dims[3] != 128 ||
+            q.dims[2] <= 0 || q.dims[2] != k.dims[2]) {
+            return reject("qk_head_shape_mismatch");
+        }
+        if (v.dims[2] <= 0 || gateA.dims[2] != v.dims[2] ||
+            gateB.dims[2] != v.dims[2] || v.dims[2] % q.dims[2] != 0) {
+            return reject("value_head_shape_mismatch");
+        }
+        if (normWeight.dataType != DataType::FLOAT32 ||
+            normWeight.dims.size() != 1 || normWeight.dims[0] != q.dims[3]) {
+            return reject("norm_weight_contract_mismatch");
+        }
+        if (aLog != nullptr || dtBias != nullptr) {
+            if (aLog == nullptr || dtBias == nullptr ||
+                aLog->dataType != DataType::FLOAT32 ||
+                dtBias->dataType != DataType::FLOAT32 ||
+                aLog->dims != std::vector<int>({v.dims[2]}) ||
+                dtBias->dims != std::vector<int>({v.dims[2]})) {
+                return reject("decay_weight_contract_mismatch");
+            }
+        }
+        if (lastRecurrentState.dataDevice != DataDevice::CUDA ||
+            lastRecurrentState.dataType != DataType::FLOAT16 ||
+            lastRecurrentState.dims !=
+                std::vector<int>({1, v.dims[2], q.dims[3], v.dims[3]})) {
+            return reject("recurrent_state_contract_mismatch");
+        }
+        if (tiledQKHeadOrder && v.dims[2] <= q.dims[2]) {
+            return reject("tiled_qk_order_requires_more_value_heads");
+        }
+        return {true, "eligible"};
+    }
 
     enum Qwen35MtpProfilePath {
         QWEN35_MTP_PROFILE_SEED = 0,
@@ -1778,6 +1951,19 @@ namespace fastllm {
             return ret;
         }
 
+        static DivisionScheme ExtractQwen35RangeScheme(
+                const DivisionScheme &scheme, int rangeIndex, int base) {
+            DivisionScheme ret;
+            for (auto &it : scheme) {
+                ret[it.first];
+                if (rangeIndex < (int)it.second.size()) {
+                    ret[it.first].push_back({it.second[rangeIndex].first - base,
+                                            it.second[rangeIndex].second - base});
+                }
+            }
+            return ret;
+        }
+
         static DivisionScheme BuildQwen35LinearKeyHeadScheme(
                 std::vector<int> devices,
                 std::map<int, int> ratios,
@@ -1870,6 +2056,44 @@ namespace fastllm {
             return ret;
         }
 
+        static DivisionScheme BuildQwen35LinearQkvScheme(
+                const DivisionScheme &keyHeadScheme,
+                int numKHeads,
+                int numVHeads,
+                int headKDim,
+                int headVDim) {
+            DivisionScheme ret;
+            int valueHeadsPerKey = numVHeads / numKHeads;
+            int kd = numKHeads * headKDim;
+            int vd = numVHeads * headVDim;
+            for (auto &it : keyHeadScheme) {
+                ret[it.first];
+                for (auto &kr : it.second) {
+                    int vs = kr.first * valueHeadsPerKey;
+                    int ve = kr.second * valueHeadsPerKey;
+                    ret[it.first].push_back({kr.first * headKDim, kr.second * headKDim});
+                    ret[it.first].push_back({kd + kr.first * headKDim, kd + kr.second * headKDim});
+                    ret[it.first].push_back({kd * 2 + vs * headVDim,
+                                            kd * 2 + ve * headVDim});
+                }
+            }
+            return ret;
+        }
+
+        static DivisionScheme BuildQwen35LinearZScheme(
+                const DivisionScheme &valueHeadScheme,
+                int headVDim) {
+            DivisionScheme ret;
+            for (auto &it : valueHeadScheme) {
+                ret[it.first];
+                for (auto &range : it.second) {
+                    ret[it.first].push_back({range.first * headVDim,
+                                            range.second * headVDim});
+                }
+            }
+            return ret;
+        }
+
         static DivisionScheme BuildQwen35LinearBaScheme(
                 const DivisionScheme &valueHeadScheme,
                 int numVHeads) {
@@ -1908,18 +2132,6 @@ namespace fastllm {
             return ret;
         }
 
-        static DivisionScheme BuildQwen35LinearOutProjScheme(
-                const DivisionScheme &valueHeadScheme,
-                int headVDim) {
-            DivisionScheme ret;
-            for (auto &it : valueHeadScheme) {
-                ret[it.first];
-                for (auto &range : it.second) {
-                    ret[it.first].push_back({range.first * headVDim, range.second * headVDim});
-                }
-            }
-            return ret;
-        }
 
         static int Qwen35RangeTotal(const DivisionScheme &scheme, int device) {
             int total = 0;
@@ -3711,6 +3923,9 @@ namespace fastllm {
                 Qwen3CudaDirectRunner &runner,
                 Data *attenInput,
                 Data *mergeQkvWeight, Data *mergeQkvBias,
+                Data *qWeight, Data *qBias,
+                Data *kWeight, Data *kBias,
+                Data *vWeight, Data *vBias,
                 Data *qNormWeight, Data *kNormWeight,
                 Data *oWeight, Data *oBias,
                 Data *allPositionIds,
@@ -3741,7 +3956,10 @@ namespace fastllm {
                 int flashInferCudaGraph = -1) {
             using namespace qwen3cuda;
             AssertInFastLLM(attenInput != nullptr && mergeQkvWeight != nullptr &&
-                            mergeQkvBias != nullptr && qNormWeight != nullptr &&
+                            mergeQkvBias != nullptr && qWeight != nullptr && qBias != nullptr &&
+                            kWeight != nullptr && kBias != nullptr &&
+                            vWeight != nullptr && vBias != nullptr &&
+                            qNormWeight != nullptr &&
                             kNormWeight != nullptr && allPositionIds != nullptr &&
                             pastKeyValues != nullptr && batchPastKeys != nullptr &&
                             batchPastValues != nullptr && merged != nullptr &&
@@ -3756,8 +3974,16 @@ namespace fastllm {
             AssertInFastLLM(numAttentionHeads > 0 && numKeyValueHeads > 0 &&
                             headDim > 0 && numAttentionHeads % numKeyValueHeads == 0,
                             "Qwen3.5 gated paged attention block got invalid head metadata.\n");
-
-            Qwen3CudaLinear(runner, *attenInput, *mergeQkvWeight, *mergeQkvBias, *merged);
+            if (!mergeQkvWeight->dims.empty()) {
+                Qwen3CudaLinear(runner, *attenInput, *mergeQkvWeight, *mergeQkvBias, *merged);
+            } else {
+                Data qResult, kResult, vResult, qkResult;
+                Qwen3CudaLinear(runner, *attenInput, *qWeight, *qBias, qResult);
+                Qwen3CudaLinear(runner, *attenInput, *kWeight, *kBias, kResult);
+                Qwen3CudaLinear(runner, *attenInput, *vWeight, *vBias, vResult);
+                Qwen3CudaCat(runner, qResult, kResult, -1, qkResult);
+                Qwen3CudaCat(runner, qkResult, vResult, -1, *merged);
+            }
 
             int bsz = attenInput->dims[0];
             int seqlen = attenInput->dims[1];
@@ -4403,6 +4629,45 @@ namespace fastllm {
         }
     }
 
+    // Materialize grouped V-head activations in the GGUF tiled column order
+    // immediately before quantized out_proj.
+    static void Qwen35ReorderGroupedToTiled(Data &act, int localKeyHeads,
+                                             int localValueHeads, int headVDim) {
+        if (!(localKeyHeads > 0 && localValueHeads >= localKeyHeads &&
+              localValueHeads % localKeyHeads == 0 && headVDim > 0 &&
+              !act.dims.empty() &&
+              act.dims.back() == localValueHeads * headVDim)) {
+            throw std::runtime_error(
+                "Qwen3.5 grouped-to-tiled activation reorder got invalid dimensions.");
+        }
+        if (localValueHeads == localKeyHeads) return;
+        const int Rloc = localValueHeads / localKeyHeads;
+        std::vector<int> origShape = act.dims;
+        act.Reshape({-1, localKeyHeads, Rloc, headVDim});
+        PermuteSelf(act, {0, 2, 1, 3});
+        act.Reshape(origShape);
+    }
+
+#ifdef USE_CUDA
+    static void Qwen35CudaReorderGroupedToTiled(
+            Qwen3CudaDirectRunner &runner, Data &act,
+            int localKeyHeads, int localValueHeads, int headVDim) {
+        if (!(localKeyHeads > 0 && localValueHeads >= localKeyHeads &&
+              localValueHeads % localKeyHeads == 0 && headVDim > 0 &&
+              !act.dims.empty() &&
+              act.dims.back() == localValueHeads * headVDim)) {
+            throw std::runtime_error(
+                "Qwen3.5 CUDA grouped-to-tiled reorder got invalid dimensions.");
+        }
+        if (localValueHeads == localKeyHeads) return;
+        const int Rloc = localValueHeads / localKeyHeads;
+        std::vector<int> origShape = act.dims;
+        act.Reshape({-1, localKeyHeads, Rloc, headVDim});
+        qwen3cuda::Qwen3CudaPermuteSelf(runner, act, {0, 2, 1, 3});
+        act.Reshape(origShape);
+    }
+#endif
+
     static void Add1(Data &input) {
         if (input.dims.size() == 0) {
             return;
@@ -4618,7 +4883,29 @@ namespace fastllm {
 
     static bool Qwen35TryCudaLinearAttnSingleDecodeNormRecurrent(
             Data &q, Data &k, Data &v, Data &g, Data &b,
-            Data &normWeight, float eps, Data &lastRecurrentState, Data &coreAttnOut) {
+            Data &normWeight, float eps, Data &lastRecurrentState, Data &coreAttnOut,
+            bool tiledQKHeadOrder = false) {
+        Qwen35GdnDryRunResult dryRun = Qwen35DryRunSingleDecodeRecurrent(
+            q, k, v, g, b, normWeight, nullptr, nullptr,
+            lastRecurrentState, tiledQKHeadOrder);
+        std::string dryRunKey = std::string("single_norm_") +
+            (tiledQKHeadOrder ? "gguf_tiled" : "grouped");
+        if (!dryRun.eligible) {
+            Qwen35LogGdnDecisionOnce(
+                dryRunKey + "_reject_" + dryRun.reason,
+                "single-norm dry-run=reject reason=" + dryRun.reason +
+                (tiledQKHeadOrder ? " action=fail-fast" :
+                                    " fallback=generic-recurrent"));
+            AssertInFastLLM(!tiledQKHeadOrder,
+                            "Qwen3.5 GGUF tiled single-norm GDN dry-run rejected: " +
+                            dryRun.reason + "\n");
+            return false;
+        }
+        Qwen35LogGdnDecisionOnce(
+            dryRunKey + "_eligible",
+            "single-norm dry-run=eligible selected=cuda-transposed-recurrent head-map=" +
+            std::string(tiledQKHeadOrder ? "modulo" : "grouped"));
+
         if (q.dataDevice != DataDevice::CUDA ||
             k.dataDevice != DataDevice::CUDA ||
             v.dataDevice != DataDevice::CUDA ||
@@ -4673,12 +4960,21 @@ namespace fastllm {
         bool stateLayoutReady = Qwen35EnsureCudaLinearAttnStateTransposed(lastRecurrentState);
         bool fused = stateLayoutReady &&
             FastllmRecurrentGatedDeltaRuleNormTransposedFloat16(
-                q, k, v, g, b, normWeight, lastRecurrentState, coreAttnOut, eps, recurrentQScale
+                q, k, v, g, b, normWeight, lastRecurrentState, coreAttnOut,
+                eps, recurrentQScale, tiledQKHeadOrder
             );
         if (fused) {
             SwapSingleTokenSeqHeadByReshape(coreAttnOut);
             return true;
         }
+        Qwen35LogGdnDecisionOnce(
+            dryRunKey + "_runtime_reject",
+            "single-norm runtime-reject selected=cuda-transposed-recurrent" +
+            std::string(tiledQKHeadOrder ? " action=fail-fast" :
+                                            " fallback=generic-recurrent"));
+        AssertInFastLLM(!tiledQKHeadOrder,
+                        "Qwen3.5 GGUF tiled single-norm GDN runtime rejection.\n");
+
         if (stateLayoutReady) {
             Qwen35EnsureCudaLinearAttnStateKVLayout(lastRecurrentState);
         }
@@ -4694,7 +4990,29 @@ namespace fastllm {
     static bool Qwen35TryCudaLinearAttnSingleDecodeNormBaRecurrent(
             Data &q, Data &k, Data &v, Data &a, Data &b,
             Data &normWeight, Data &aLog, Data &dtBias,
-            float eps, Data &lastRecurrentState, Data &coreAttnOut) {
+            float eps, Data &lastRecurrentState, Data &coreAttnOut,
+            bool tiledQKHeadOrder = false) {
+        Qwen35GdnDryRunResult dryRun = Qwen35DryRunSingleDecodeRecurrent(
+            q, k, v, a, b, normWeight, &aLog, &dtBias,
+            lastRecurrentState, tiledQKHeadOrder);
+        std::string dryRunKey = std::string("single_norm_ba_") +
+            (tiledQKHeadOrder ? "gguf_tiled" : "grouped");
+        if (!dryRun.eligible) {
+            Qwen35LogGdnDecisionOnce(
+                dryRunKey + "_reject_" + dryRun.reason,
+                "single-norm-ba dry-run=reject reason=" + dryRun.reason +
+                (tiledQKHeadOrder ? " action=fail-fast" :
+                                    " fallback=single-norm"));
+            AssertInFastLLM(!tiledQKHeadOrder,
+                            "Qwen3.5 GGUF tiled single-norm-ba GDN dry-run rejected: " +
+                            dryRun.reason + "\n");
+            return false;
+        }
+        Qwen35LogGdnDecisionOnce(
+            dryRunKey + "_eligible",
+            "single-norm-ba dry-run=eligible selected=cuda-transposed-recurrent head-map=" +
+            std::string(tiledQKHeadOrder ? "modulo" : "grouped"));
+
         if (q.dataDevice != DataDevice::CUDA ||
             k.dataDevice != DataDevice::CUDA ||
             v.dataDevice != DataDevice::CUDA ||
@@ -4763,12 +5081,19 @@ namespace fastllm {
         bool fused = stateLayoutReady &&
             FastllmRecurrentGatedDeltaRuleNormBaTransposedFloat16(
                 q, k, v, a, b, normWeight, aLog, dtBias, lastRecurrentState,
-                coreAttnOut, eps, recurrentQScale
+                coreAttnOut, eps, recurrentQScale, tiledQKHeadOrder
             );
         if (fused) {
             SwapSingleTokenSeqHeadByReshape(coreAttnOut);
             return true;
         }
+        Qwen35LogGdnDecisionOnce(
+            dryRunKey + "_runtime_reject",
+            "single-norm-ba runtime-reject selected=cuda-transposed-recurrent" +
+            std::string(tiledQKHeadOrder ? " action=fail-fast" :
+                                            " fallback=single-norm"));
+        AssertInFastLLM(!tiledQKHeadOrder,
+                        "Qwen3.5 GGUF tiled single-norm-ba GDN runtime rejection.\n");
         if (stateLayoutReady) {
             Qwen35EnsureCudaLinearAttnStateKVLayout(lastRecurrentState);
         }
@@ -5275,6 +5600,8 @@ namespace fastllm {
                     this->weight.weight.find(prefix + "linear_attn.in_proj_qkvz.weight") !=
                         this->weight.weight.end() ||
                     this->weight.weight.find(prefix + "linear_attn.in_proj_qkvzba.weight") !=
+                        this->weight.weight.end() ||
+                    this->weight.weight.find(prefix + "linear_attn.in_proj_qkv.weight") !=
                         this->weight.weight.end();
                 if (!isLinearAttentionLayer) {
                     continue;
@@ -5288,11 +5615,15 @@ namespace fastllm {
                         prefix + "linear_attn.in_proj_qkvz.weight";
                     std::string qkvzbaWeightName =
                         prefix + "linear_attn.in_proj_qkvzba.weight";
+                    std::string qkvWeightName =
+                        prefix + "linear_attn.in_proj_qkv.weight";
+                    std::string balanceWeightName =
+                        this->weight.weight.find(qkvzbaWeightName) != this->weight.weight.end() ?
+                            qkvzbaWeightName :
+                            (this->weight.weight.find(qkvzWeightName) != this->weight.weight.end() ?
+                                 qkvzWeightName : qkvWeightName);
                     BalanceMultiCudaDivisionSchemeByLayer(
-                        this->weight.weight.find(qkvzbaWeightName) !=
-                                this->weight.weight.end() ?
-                            qkvzbaWeightName : qkvzWeightName,
-                        devices, keyScheme);
+                        balanceWeightName, devices, keyScheme);
                     DivisionScheme valueScheme = BuildQwen35LinearValueHeadScheme(
                         keyScheme, num_v_heads / num_k_heads);
                     localKeyHeads = Qwen35LocalHeads(keyScheme, deviceId);
@@ -5763,8 +6094,16 @@ namespace fastllm {
                 if (tensorParallel) {
                     DivisionScheme keyScheme = BuildQwen35LinearKeyHeadScheme(
                         devices, ratios, num_k_heads);
+                    std::string qkvzWeightName = prefix + "linear_attn.in_proj_qkvz.weight";
+                    std::string qkvzbaWeightName = prefix + "linear_attn.in_proj_qkvzba.weight";
+                    std::string qkvWeightName = prefix + "linear_attn.in_proj_qkv.weight";
+                    std::string balanceWeightName =
+                        weight.weight.find(qkvzbaWeightName) != weight.weight.end() ?
+                            qkvzbaWeightName :
+                            (weight.weight.find(qkvzWeightName) != weight.weight.end() ?
+                                 qkvzWeightName : qkvWeightName);
                     BalanceMultiCudaDivisionSchemeByLayer(
-                        prefix + "linear_attn.in_proj_qkvz.weight", devices, keyScheme);
+                        balanceWeightName, devices, keyScheme);
                     DivisionScheme valueScheme = BuildQwen35LinearValueHeadScheme(
                         keyScheme, num_v_heads / num_k_heads);
                     localKeyHeads = Qwen35LocalHeads(keyScheme, gpuId);
@@ -6536,6 +6875,36 @@ namespace fastllm {
                     std::string qNormName = prefix + "self_attn.q_norm.weight";
                     std::string kNormName = prefix + "self_attn.k_norm.weight";
                     std::string oWeightName = prefix + "self_attn.o_proj.weight";
+                    std::string qWeightName = prefix + "self_attn.q_proj.weight";
+                    std::string qBiasName = prefix + "self_attn.q_proj.bias";
+                    std::string kWeightName = prefix + "self_attn.k_proj.weight";
+                    std::string kBiasName = prefix + "self_attn.k_proj.bias";
+                    std::string vWeightName = prefix + "self_attn.v_proj.weight";
+                    std::string vBiasName = prefix + "self_attn.v_proj.bias";
+                    Qwen35AttentionProjectionLayout attentionLayout =
+                        ResolveQwen35AttentionProjectionLayout(weight, prefix);
+                    AssertInFastLLM(attentionLayout != Qwen35AttentionProjectionLayout::Missing,
+                                    "Qwen3.5 CUDA graph requires complete attention projection weights.\n");
+                    Data *localMergeWeight = GetEmptyData();
+                    Data *localMergeBias = GetEmptyData();
+                    Data *localQWeight = GetEmptyData();
+                    Data *localQBias = GetEmptyData();
+                    Data *localKWeight = GetEmptyData();
+                    Data *localKBias = GetEmptyData();
+                    Data *localVWeight = GetEmptyData();
+                    Data *localVBias = GetEmptyData();
+                    if (attentionLayout == Qwen35AttentionProjectionLayout::MergedQkv) {
+                        localMergeWeight = requireLocal(weight[mergeQkvWeightName], mergeQkvWeightName);
+                        localMergeBias = requireLocal(GetThreadTensorParallelBias(mergeQkvBiasName),
+                                                      mergeQkvBiasName);
+                    } else {
+                        localQWeight = requireLocal(weight[qWeightName], qWeightName);
+                        localQBias = requireLocal(GetThreadTensorParallelBias(qBiasName), qBiasName);
+                        localKWeight = requireLocal(weight[kWeightName], kWeightName);
+                        localKBias = requireLocal(GetThreadTensorParallelBias(kBiasName), kBiasName);
+                        localVWeight = requireLocal(weight[vWeightName], vWeightName);
+                        localVBias = requireLocal(GetThreadTensorParallelBias(vBiasName), vBiasName);
+                    }
                     std::string oBiasName = prefix + "self_attn.o_proj.bias";
 
                     int localKVHeads = num_key_value_heads;
@@ -6550,8 +6919,10 @@ namespace fastllm {
                         Qwen35CudaAttentionPagedBlock(
                             cudaRunner,
                             &buf.attenInput,
-                            requireLocal(weight[mergeQkvWeightName], mergeQkvWeightName),
-                            requireLocal(GetThreadTensorParallelBias(mergeQkvBiasName), mergeQkvBiasName),
+                            localMergeWeight, localMergeBias,
+                            localQWeight, localQBias,
+                            localKWeight, localKBias,
+                            localVWeight, localVBias,
                             requireLocal(weight[qNormName], qNormName),
                             requireLocal(weight[kNormName], kNormName),
                             requireLocal(weight[oWeightName], oWeightName),
@@ -6590,6 +6961,8 @@ namespace fastllm {
                     std::string qkvzWeightName = prefix + "linear_attn.in_proj_qkvz.weight";
                     std::string baWeightName = prefix + "linear_attn.in_proj_ba.weight";
                     std::string qkvzbaWeightName = prefix + "linear_attn.in_proj_qkvzba.weight";
+                    std::string qkvWeightName = prefix + "linear_attn.in_proj_qkv.weight";
+                    std::string zWeightName = prefix + "linear_attn.in_proj_z.weight";
                     std::string conv1dWeightName = prefix + "linear_attn.conv1d.weight";
                     std::string conv1dBiasName = prefix + "linear_attn.conv1d.bias";
                     std::string aLogName = prefix + "linear_attn.A_log";
@@ -6613,27 +6986,42 @@ namespace fastllm {
                     int localVd = localValueHeads * head_v_dim;
                     int localQkvDim = localKd * 2 + localVd;
 
+                    Qwen35GdnProjectionLayout gdnLayout =
+                        ResolveQwen35GdnProjectionLayout(weight, prefix);
                     bool hasMergedGdnInLinear =
-                        weight.weight.find(qkvzbaWeightName) != weight.weight.end();
+                        gdnLayout == Qwen35GdnProjectionLayout::Qkvzba;
+                    AssertInFastLLM(gdnLayout != Qwen35GdnProjectionLayout::Missing,
+                                    "Qwen3.5 CUDA graph requires complete linear attention projection weights.\n");
                     if (hasMergedGdnInLinear) {
                         Qwen3CudaLinear(cudaRunner, buf.attenInput,
                                         *requireLocal(weight[qkvzbaWeightName], qkvzbaWeightName),
                                         *requireLocal(GetThreadTensorParallelBias(qkvzbaWeightName + ".tp_bias"),
                                                       qkvzbaWeightName + ".tp_bias"),
                                         buf.gdnMerged);
-                    } else {
-                        AssertInFastLLM(weight.weight.find(qkvzWeightName) != weight.weight.end() &&
-                                        weight.weight.find(baWeightName) != weight.weight.end(),
-                                        "Qwen3.5 CUDA graph requires linear attention qkvz/ba weights.\n");
+                        Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, 0, localQkvDim, buf.qkvConvInput);
+                        Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, localQkvDim,
+                                       localQkvDim + localVd, buf.z);
+                    } else if (gdnLayout == Qwen35GdnProjectionLayout::QkvzBa) {
                         Qwen3CudaLinear(cudaRunner, buf.attenInput,
                                         *requireLocal(weight[qkvzWeightName], qkvzWeightName),
                                         *requireLocal(GetThreadTensorParallelBias(qkvzWeightName + ".tp_bias"),
                                                       qkvzWeightName + ".tp_bias"),
                                         buf.gdnMerged);
+                        Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, 0, localQkvDim, buf.qkvConvInput);
+                        Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, localQkvDim,
+                                       localQkvDim + localVd, buf.z);
+                    } else {
+                        Qwen3CudaLinear(cudaRunner, buf.attenInput,
+                                        *requireLocal(weight[qkvWeightName], qkvWeightName),
+                                        *requireLocal(GetThreadTensorParallelBias(qkvWeightName + ".tp_bias"),
+                                                      qkvWeightName + ".tp_bias"),
+                                        buf.qkvConvInput);
+                        Qwen3CudaLinear(cudaRunner, buf.attenInput,
+                                        *requireLocal(weight[zWeightName], zWeightName),
+                                        *requireLocal(GetThreadTensorParallelBias(zWeightName + ".tp_bias"),
+                                                      zWeightName + ".tp_bias"),
+                                        buf.z);
                     }
-                    Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, 0, localQkvDim, buf.qkvConvInput);
-                    Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, localQkvDim,
-                                   localQkvDim + localVd, buf.z);
                     if (hasMergedGdnInLinear) {
                         Qwen3CudaSplit(cudaRunner, buf.gdnMerged, -1, localQkvDim + localVd,
                                        localQkvDim + localVd + localValueHeads * 2, buf.ba);
@@ -6730,7 +7118,7 @@ namespace fastllm {
                                 linearStatePool->cudaData, state.linearSlotIds.cudaData, batch,
                                 buf.coreAttnOut,
                                 localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                rms_norm_eps, recurrentQScale);
+                                rms_norm_eps, recurrentQScale, false);
                     }
                     if (fusedBatchRecurrentFromConvBa) {
                         for (int rb = 0; rb < batch; rb++) {
@@ -6802,6 +7190,10 @@ namespace fastllm {
                         Qwen35CudaMulTo(cudaRunner, buf.coreAttnOut, buf.z);
                     }
                     buf.coreAttnOut.Reshape({zShape[0], zShape[1], localVd});
+                    if (ggufOutProjColumnsTiled) {
+                        Qwen35CudaReorderGroupedToTiled(cudaRunner, buf.coreAttnOut,
+                                                         localKeyHeads, localValueHeads, head_v_dim);
+                    }
                     Qwen3CudaLinearResidualReduce(
                         cudaRunner, buf.coreAttnOut,
                         *requireLocal(weight[outProjWeightName], outProjWeightName),
@@ -7357,6 +7749,36 @@ namespace fastllm {
                 std::string kNormName = prefix + "self_attn.k_norm.weight";
                 std::string oWeightName = prefix + "self_attn.o_proj.weight";
                 std::string oBiasName = prefix + "self_attn.o_proj.bias";
+                std::string qWeightName = prefix + "self_attn.q_proj.weight";
+                std::string qBiasName = prefix + "self_attn.q_proj.bias";
+                std::string kWeightName = prefix + "self_attn.k_proj.weight";
+                std::string kBiasName = prefix + "self_attn.k_proj.bias";
+                std::string vWeightName = prefix + "self_attn.v_proj.weight";
+                std::string vBiasName = prefix + "self_attn.v_proj.bias";
+                Qwen35AttentionProjectionLayout attentionLayout =
+                    ResolveQwen35AttentionProjectionLayout(weight, prefix);
+                AssertInFastLLM(attentionLayout != Qwen35AttentionProjectionLayout::Missing,
+                                "Qwen3.5 ForwardSingleGPU requires complete attention projection weights.\n");
+                Data *localMergeWeight = GetEmptyData();
+                Data *localMergeBias = GetEmptyData();
+                Data *localQWeight = GetEmptyData();
+                Data *localQBias = GetEmptyData();
+                Data *localKWeight = GetEmptyData();
+                Data *localKBias = GetEmptyData();
+                Data *localVWeight = GetEmptyData();
+                Data *localVBias = GetEmptyData();
+                if (attentionLayout == Qwen35AttentionProjectionLayout::MergedQkv) {
+                    localMergeWeight = requireLocal(weight[mergeQkvWeightName], mergeQkvWeightName);
+                    localMergeBias = requireLocal(GetThreadTensorParallelBias(mergeQkvBiasName),
+                                                  mergeQkvBiasName);
+                } else {
+                    localQWeight = requireLocal(weight[qWeightName], qWeightName);
+                    localQBias = requireLocal(GetThreadTensorParallelBias(qBiasName), qBiasName);
+                    localKWeight = requireLocal(weight[kWeightName], kWeightName);
+                    localKBias = requireLocal(GetThreadTensorParallelBias(kBiasName), kBiasName);
+                    localVWeight = requireLocal(weight[vWeightName], vWeightName);
+                    localVBias = requireLocal(GetThreadTensorParallelBias(vBiasName), vBiasName);
+                }
 
                 int localKVHeads = num_key_value_heads;
                 if (tensorParallel) {
@@ -7370,8 +7792,10 @@ namespace fastllm {
                     Qwen35CudaAttentionPagedBlock(
                         cudaRunner,
                         &attenInput,
-                        requireLocal(weight[mergeQkvWeightName], mergeQkvWeightName),
-                        requireLocal(GetThreadTensorParallelBias(mergeQkvBiasName), mergeQkvBiasName),
+                        localMergeWeight, localMergeBias,
+                        localQWeight, localQBias,
+                        localKWeight, localKBias,
+                        localVWeight, localVBias,
                         requireLocal(weight[qNormName], qNormName),
                         requireLocal(weight[kNormName], kNormName),
                         requireLocal(weight[oWeightName], oWeightName),
@@ -7409,6 +7833,8 @@ namespace fastllm {
                 std::string qkvzWeightName = prefix + "linear_attn.in_proj_qkvz.weight";
                 std::string baWeightName = prefix + "linear_attn.in_proj_ba.weight";
                 std::string qkvzbaWeightName = prefix + "linear_attn.in_proj_qkvzba.weight";
+                std::string qkvWeightName = prefix + "linear_attn.in_proj_qkv.weight";
+                std::string zWeightName = prefix + "linear_attn.in_proj_z.weight";
                 std::string conv1dWeightName = prefix + "linear_attn.conv1d.weight";
                 std::string conv1dBiasName = prefix + "linear_attn.conv1d.bias";
                 std::string aLogName = prefix + "linear_attn.A_log";
@@ -7431,26 +7857,40 @@ namespace fastllm {
                 int localKd = localKeyHeads * head_k_dim;
                 int localVd = localValueHeads * head_v_dim;
                 int localQkvDim = localKd * 2 + localVd;
+                Qwen35GdnProjectionLayout gdnLayout =
+                    ResolveQwen35GdnProjectionLayout(weight, prefix);
                 bool hasMergedGdnInLinear =
-                    weight.weight.find(qkvzbaWeightName) != weight.weight.end();
+                    gdnLayout == Qwen35GdnProjectionLayout::Qkvzba;
+                AssertInFastLLM(gdnLayout != Qwen35GdnProjectionLayout::Missing,
+                                "Qwen3.5 ForwardSingleGPU requires complete linear attention projection weights.\n");
                 if (hasMergedGdnInLinear) {
                     Qwen3CudaLinear(cudaRunner, attenInput,
                                     *requireLocal(weight[qkvzbaWeightName], qkvzbaWeightName),
                                     *requireLocal(GetThreadTensorParallelBias(qkvzbaWeightName + ".tp_bias"),
                                                   qkvzbaWeightName + ".tp_bias"),
                                     gdnMerged);
-                } else {
-                    AssertInFastLLM(weight.weight.find(qkvzWeightName) != weight.weight.end() &&
-                                    weight.weight.find(baWeightName) != weight.weight.end(),
-                                    "Qwen3.5 ForwardSingleGPU requires linear attention qkvz/ba weights.\n");
+                    Qwen3CudaSplit(cudaRunner, gdnMerged, -1, 0, localQkvDim, qkvConvInput);
+                    Qwen3CudaSplit(cudaRunner, gdnMerged, -1, localQkvDim, localQkvDim + localVd, z);
+                } else if (gdnLayout == Qwen35GdnProjectionLayout::QkvzBa) {
                     Qwen3CudaLinear(cudaRunner, attenInput,
                                     *requireLocal(weight[qkvzWeightName], qkvzWeightName),
                                     *requireLocal(GetThreadTensorParallelBias(qkvzWeightName + ".tp_bias"),
                                                   qkvzWeightName + ".tp_bias"),
                                     gdnMerged);
+                    Qwen3CudaSplit(cudaRunner, gdnMerged, -1, 0, localQkvDim, qkvConvInput);
+                    Qwen3CudaSplit(cudaRunner, gdnMerged, -1, localQkvDim, localQkvDim + localVd, z);
+                } else {
+                    Qwen3CudaLinear(cudaRunner, attenInput,
+                                    *requireLocal(weight[qkvWeightName], qkvWeightName),
+                                    *requireLocal(GetThreadTensorParallelBias(qkvWeightName + ".tp_bias"),
+                                                  qkvWeightName + ".tp_bias"),
+                                    qkvConvInput);
+                    Qwen3CudaLinear(cudaRunner, attenInput,
+                                    *requireLocal(weight[zWeightName], zWeightName),
+                                    *requireLocal(GetThreadTensorParallelBias(zWeightName + ".tp_bias"),
+                                                  zWeightName + ".tp_bias"),
+                                    z);
                 }
-                Qwen3CudaSplit(cudaRunner, gdnMerged, -1, 0, localQkvDim, qkvConvInput);
-                Qwen3CudaSplit(cudaRunner, gdnMerged, -1, localQkvDim, localQkvDim + localVd, z);
                 bool captureLinearState =
                     speculativeCaptureFirstTokenLinearState;
                 int linearStateCaptureSlots =
@@ -7902,7 +8342,7 @@ namespace fastllm {
                             tokenValueStates, captureTokens,
                             localKeyHeads, localValueHeads,
                             head_k_dim, head_v_dim, rms_norm_eps,
-                            1.0f / std::sqrt((float)head_k_dim));
+                            1.0f / std::sqrt((float)head_k_dim), false);
                     if (!fused) {
                         throw Qwen35MtpBatchFastPathUnavailable(
                             "Qwen3.5 batched MTP recurrent fast path is unavailable.");
@@ -7999,13 +8439,13 @@ namespace fastllm {
                                 *convOutputForRecurrent, baMerged, *linearNormWeight, *aLog, *dtBias,
                                 fusedRecurrentStates, coreAttnOut,
                                 localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                rms_norm_eps, recurrentQScale);
+                                rms_norm_eps, recurrentQScale, false);
                         } else {
                             FastllmRecurrentGatedDeltaRuleBatchFromConvBa(
                                 *convOutputForRecurrent, baMerged, *linearNormWeight, *aLog, *dtBias,
                                 fusedRecurrentStates, coreAttnOut,
                                 localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                rms_norm_eps, recurrentQScale);
+                                rms_norm_eps, recurrentQScale, false);
                         }
                         fusedBatchRecurrentFromConvBa = true;
                         for (int rb = 0; rb < batch; rb++) {
@@ -8125,14 +8565,18 @@ namespace fastllm {
                         if (num_v_heads / num_k_heads > 1) {
                             Qwen35CudaMul(cudaRunner, q, 1.0f, qRepeat);
                             Qwen35CudaMul(cudaRunner, k, 1.0f, kRepeat);
-                            qRepeat.Resize({q.dims[0], q.dims[1], q.dims[2],
-                                            1, q.dims[3]});
-                            kRepeat.Resize({k.dims[0], k.dims[1], k.dims[2],
-                                            1, k.dims[3]});
-                            Qwen35CudaRepeat(cudaRunner, qRepeat, 3,
-                                            num_v_heads / num_k_heads, q);
-                            Qwen35CudaRepeat(cudaRunner, kRepeat, 3,
-                                            num_v_heads / num_k_heads, k);
+                            // All V-heads are now grouped (load-time untile).
+                            // Repeat each K head in place along axis 3.
+                            {
+                                qRepeat.Resize({q.dims[0], q.dims[1], q.dims[2],
+                                                1, q.dims[3]});
+                                kRepeat.Resize({k.dims[0], k.dims[1], k.dims[2],
+                                                1, k.dims[3]});
+                                Qwen35CudaRepeat(cudaRunner, qRepeat, 3,
+                                                num_v_heads / num_k_heads, q);
+                                Qwen35CudaRepeat(cudaRunner, kRepeat, 3,
+                                                num_v_heads / num_k_heads, k);
+                            }
                             q.Reshape({q.dims[0], q.dims[1], -1,
                                        q.dims.back()});
                             k.Reshape({k.dims[0], k.dims[1], -1,
@@ -8264,7 +8708,7 @@ namespace fastllm {
                         *requireLocal(inv_scale_data, "linear_attn.inv_scale"),
                         *requireLocal(weight[aLogName], aLogName),
                         *requireLocal(weight[dtBiasName], dtBiasName),
-                        rms_norm_eps, pastValue, coreAttnOut
+                        rms_norm_eps, pastValue, coreAttnOut, false
                     );
                     if (!fusedSingleDecode) {
                         Qwen35CudaSigmoidMambaSoftplus(cudaRunner, b, a,
@@ -8274,7 +8718,7 @@ namespace fastllm {
                         fusedSingleDecode = Qwen35TryCudaLinearAttnSingleDecodeNormRecurrent(
                             q, k, v, g, b,
                             *requireLocal(inv_scale_data, "linear_attn.inv_scale"),
-                            rms_norm_eps, pastValue, coreAttnOut
+                            rms_norm_eps, pastValue, coreAttnOut, false
                         );
                     }
                     if (!fusedSingleDecode) {
@@ -8315,7 +8759,8 @@ namespace fastllm {
                                         *requireLocal(weight[dtBiasName], dtBiasName),
                                         pastValue, coreAttnOut,
                                         localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim));
+                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim),
+                                        false);
                             } else {
                                 // 融合序列 kernel 内部在处理完第 t 个 token 后直接把递归状态
                                 // 写入快照 slot, 替代逐行前向 + 全量 CopyFrom 的慢速路径。
@@ -8335,7 +8780,8 @@ namespace fastllm {
                                         pastValue, coreAttnOut,
                                         tokenValueStates, valueCaptureTokens,
                                         localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim));
+                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim),
+                                        false);
                                 if (fusedSmallDecode) {
                                     for (int tokenIndex = 0; tokenIndex < valueCaptureTokens; tokenIndex++) {
                                         if (tokenValueStates[tokenIndex] != nullptr) {
@@ -8363,7 +8809,8 @@ namespace fastllm {
                                         *requireLocal(weight[dtBiasName], dtBiasName),
                                         pastValue, rowOut,
                                         localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim));
+                                        rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim),
+                                        false);
                                 if (!rowOk) {
                                     if (row == 0) {
                                         fusedSmallDecode = false;
@@ -8418,7 +8865,8 @@ namespace fastllm {
                                 *requireLocal(weight[dtBiasName], dtBiasName),
                                 pastValue, coreAttnOut0,
                                 localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim));
+                                rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim),
+                                false);
                         if (fusedFirstToken) {
                             Data *firstTokenValueState =
                                 getFirstTokenLinearCaptureSlot(false);
@@ -8438,7 +8886,8 @@ namespace fastllm {
                                     *requireLocal(weight[dtBiasName], dtBiasName),
                                     pastValue, coreAttnOut1,
                                     localKeyHeads, localValueHeads, head_k_dim, head_v_dim,
-                                    rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim));
+                                    rms_norm_eps, 1.0f / std::sqrt((float)head_k_dim),
+                                    false);
                             AssertInFastLLM(fusedSecondToken,
                                             "Qwen3.5 two-token conv+ba linear decode fused first token but failed second token.\n");
                             SwapSingleTokenSeqHeadByReshape(coreAttnOut1);
@@ -8460,7 +8909,7 @@ namespace fastllm {
                             *requireLocal(inv_scale_data, "linear_attn.inv_scale"),
                             *requireLocal(weight[aLogName], aLogName),
                             *requireLocal(weight[dtBiasName], dtBiasName),
-                            rms_norm_eps, pastValue, coreAttnOut0
+                            rms_norm_eps, pastValue, coreAttnOut0, false
                         );
                     }
                     if (fusedTwoTokenDecode && !fusedConvBaTwoTokenDecode) {
@@ -8480,7 +8929,7 @@ namespace fastllm {
                             *requireLocal(inv_scale_data, "linear_attn.inv_scale"),
                             *requireLocal(weight[aLogName], aLogName),
                             *requireLocal(weight[dtBiasName], dtBiasName),
-                            rms_norm_eps, pastValue, coreAttnOut1
+                            rms_norm_eps, pastValue, coreAttnOut1, false
                         );
                         AssertInFastLLM(fusedSecondToken,
                                         "Qwen3.5 two-token linear decode fused first token but failed second token.\n");
@@ -8541,6 +8990,10 @@ namespace fastllm {
                     Qwen35CudaMulTo(cudaRunner, coreAttnOut, z);
                 }
                 coreAttnOut.Reshape({zShape[0], zShape[1], localVd});
+                if (ggufOutProjColumnsTiled) {
+                    Qwen35CudaReorderGroupedToTiled(cudaRunner, coreAttnOut,
+                                                     localKeyHeads, localValueHeads, head_v_dim);
+                }
                 Qwen3CudaLinearResidualReduce(
                     cudaRunner, coreAttnOut,
                     *requireLocal(weight[outProjWeightName], outProjWeightName),
@@ -9129,14 +9582,16 @@ namespace fastllm {
             if (initialized_add1) {
                 return;
             }
-            for (int i = 0; i < block_cnt; i++) {
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+            if (!ggufNormsPreOffset) {
+                for (int i = 0; i < block_cnt; i++) {
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+                }
+                Add1(this->weight[language_prefix + "norm.weight"]);
+                AddMtpRmsNormOffset();
             }
-            Add1(this->weight[language_prefix + "norm.weight"]);
-            AddMtpRmsNormOffset();
             initialized_add1 = true;
         };
 
@@ -9199,19 +9654,51 @@ namespace fastllm {
                             std::string kNormName = prefix + "self_attn.k_norm.weight";
                             std::string oWeightName = prefix + "self_attn.o_proj.weight";
                             std::string oBiasName = prefix + "self_attn.o_proj.bias";
-                            AssertInFastLLM(weight.weight.find(mergeQkvWeightName) != weight.weight.end(),
-                                            "Qwen3.5 ForwardGPU requires merged qgate/k/v weight.\n");
+                            std::string qWeightName = prefix + "self_attn.q_proj.weight";
+                            std::string qBiasName = prefix + "self_attn.q_proj.bias";
+                            std::string kWeightName = prefix + "self_attn.k_proj.weight";
+                            std::string kBiasName = prefix + "self_attn.k_proj.bias";
+                            std::string vWeightName = prefix + "self_attn.v_proj.weight";
+                            std::string vBiasName = prefix + "self_attn.v_proj.bias";
+                            Qwen35AttentionProjectionLayout attentionLayout =
+                                ResolveQwen35AttentionProjectionLayout(weight, prefix);
+                            AssertInFastLLM(attentionLayout != Qwen35AttentionProjectionLayout::Missing,
+                                            "Qwen3.5 ForwardGPU requires complete attention projection weights.\n");
                             prepareReplicated(qNormName);
                             prepareReplicated(kNormName);
 
-                            Data &mergeW = weight[mergeQkvWeightName];
-                            Data &mergeB = GetThreadTensorParallelBias(mergeQkvBiasName);
-                            mergeW.tpPackType = TP_PACK_NONE;
                             DivisionScheme qkvScheme = BuildQwen35GatedAttentionQkvScheme(
                                 devices, ratios, num_attention_heads, num_key_value_heads, head_dim);
                             std::vector<int> devCopy = devices;
-                            AssertInFastLLM(SplitMultiCudaWeight(mergeW, mergeB, devCopy, qkvScheme, 0),
-                                            "Qwen3.5 ForwardGPU failed to split " + mergeQkvWeightName + ".\n");
+                            if (attentionLayout == Qwen35AttentionProjectionLayout::MergedQkv) {
+                                Data &mergeW = weight[mergeQkvWeightName];
+                                Data &mergeB = GetThreadTensorParallelBias(mergeQkvBiasName);
+                                mergeW.tpPackType = TP_PACK_NONE;
+                                AssertInFastLLM(SplitMultiCudaWeight(mergeW, mergeB, devCopy,
+                                                                     qkvScheme, 0),
+                                                "Qwen3.5 ForwardGPU failed to split " + mergeQkvWeightName + ".\n");
+                            } else {
+                                int qGateWidth = num_attention_heads * head_dim * 2;
+                                int kvWidth = num_key_value_heads * head_dim;
+                                DivisionScheme qScheme = ExtractQwen35RangeScheme(qkvScheme, 0, 0);
+                                DivisionScheme kScheme = ExtractQwen35RangeScheme(qkvScheme, 1, qGateWidth);
+                                DivisionScheme vScheme = ExtractQwen35RangeScheme(qkvScheme, 2,
+                                                                                  qGateWidth + kvWidth);
+                                Data &qBias = GetThreadTensorParallelBias(qBiasName);
+                                Data &kBias = GetThreadTensorParallelBias(kBiasName);
+                                Data &vBias = GetThreadTensorParallelBias(vBiasName);
+                                AssertInFastLLM(SplitMultiCudaWeight(weight[qWeightName], qBias,
+                                                                     devCopy, qScheme, 0),
+                                                "Qwen3.5 ForwardGPU failed to split " + qWeightName + ".\n");
+                                devCopy = devices;
+                                AssertInFastLLM(SplitMultiCudaWeight(weight[kWeightName], kBias,
+                                                                     devCopy, kScheme, 0),
+                                                "Qwen3.5 ForwardGPU failed to split " + kWeightName + ".\n");
+                                devCopy = devices;
+                                AssertInFastLLM(SplitMultiCudaWeight(weight[vWeightName], vBias,
+                                                                     devCopy, vScheme, 0),
+                                                "Qwen3.5 ForwardGPU failed to split " + vWeightName + ".\n");
+                            }
                             int qGateWidth = num_attention_heads * head_dim * 2;
                             threadTpAttentionKVHeadSchemes[i] =
                                 ExtractQwen35AttentionKVHeadScheme(qkvScheme, qGateWidth, head_dim);
@@ -9224,25 +9711,30 @@ namespace fastllm {
                             std::string qkvzWeightName = prefix + "linear_attn.in_proj_qkvz.weight";
                             std::string baWeightName = prefix + "linear_attn.in_proj_ba.weight";
                             std::string qkvzbaWeightName = prefix + "linear_attn.in_proj_qkvzba.weight";
+                            std::string qkvWeightName = prefix + "linear_attn.in_proj_qkv.weight";
+                            std::string zWeightName = prefix + "linear_attn.in_proj_z.weight";
                             std::string conv1dWeightName = prefix + "linear_attn.conv1d.weight";
                             std::string conv1dBiasName = prefix + "linear_attn.conv1d.bias";
                             std::string aLogName = prefix + "linear_attn.A_log";
                             std::string dtBiasName = prefix + "linear_attn.dt_bias";
                             std::string outNormWeightName = prefix + "linear_attn.norm.weight";
                             std::string outProjWeightName = prefix + "linear_attn.out_proj.weight";
+                            Qwen35GdnProjectionLayout gdnLayout =
+                                ResolveQwen35GdnProjectionLayout(weight, prefix);
                             bool hasMergedGdnInLinear =
-                                weight.weight.find(qkvzbaWeightName) != weight.weight.end();
-                            AssertInFastLLM(hasMergedGdnInLinear ||
-                                            (weight.weight.find(qkvzWeightName) != weight.weight.end() &&
-                                             weight.weight.find(baWeightName) != weight.weight.end()),
-                                            "Qwen3.5 ForwardGPU requires linear attention qkvzba or qkvz/ba weights.\n");
+                                gdnLayout == Qwen35GdnProjectionLayout::Qkvzba;
+                            AssertInFastLLM(gdnLayout != Qwen35GdnProjectionLayout::Missing,
+                                            "Qwen3.5 ForwardGPU requires complete linear attention projection weights.\n");
                             prepareReplicated(outNormWeightName);
 
                             DivisionScheme keyScheme = BuildQwen35LinearKeyHeadScheme(
                                 devices, ratios, num_k_heads);
+                            std::string balanceWeightName = hasMergedGdnInLinear ?
+                                qkvzbaWeightName :
+                                (gdnLayout == Qwen35GdnProjectionLayout::QkvzBa ?
+                                     qkvzWeightName : qkvWeightName);
                             BalanceMultiCudaDivisionSchemeByLayer(
-                                hasMergedGdnInLinear ? qkvzbaWeightName : qkvzWeightName,
-                                devices, keyScheme);
+                                balanceWeightName, devices, keyScheme);
                             DivisionScheme valueScheme = BuildQwen35LinearValueHeadScheme(
                                 keyScheme, num_v_heads / num_k_heads);
                             threadTpLinearKeyHeadSchemes[i] = keyScheme;
@@ -9256,13 +9748,29 @@ namespace fastllm {
                                 AssertInFastLLM(SplitMultiCudaWeight(weight[qkvzbaWeightName], qkvzbaBias,
                                                                      devCopy, qkvzbaScheme, 0, true),
                                                 "Qwen3.5 ForwardGPU failed to split " + qkvzbaWeightName + ".\n");
-                            } else {
+                            } else if (gdnLayout == Qwen35GdnProjectionLayout::QkvzBa) {
                                 DivisionScheme qkvzScheme = BuildQwen35LinearQkvzScheme(
                                     keyScheme, num_k_heads, num_v_heads, head_k_dim, head_v_dim);
                                 Data &qkvzBias = GetThreadTensorParallelBias(qkvzWeightName + ".tp_bias");
                                 AssertInFastLLM(SplitMultiCudaWeight(weight[qkvzWeightName], qkvzBias,
                                                                      devCopy, qkvzScheme, 0, true),
                                                 "Qwen3.5 ForwardGPU failed to split " + qkvzWeightName + ".\n");
+                            } else {
+                                DivisionScheme qkvScheme = BuildQwen35LinearQkvScheme(
+                                    keyScheme, num_k_heads, num_v_heads, head_k_dim, head_v_dim);
+                                DivisionScheme zScheme = BuildQwen35LinearZScheme(
+                                    valueScheme, head_v_dim);
+                                Data &qkvBias = GetThreadTensorParallelBias(qkvWeightName + ".tp_bias");
+                                Data &zBias = GetThreadTensorParallelBias(zWeightName + ".tp_bias");
+                                AssertInFastLLM(SplitMultiCudaWeight(weight[qkvWeightName], qkvBias,
+                                                                     devCopy, qkvScheme, 0, true),
+                                                "Qwen3.5 ForwardGPU failed to split " + qkvWeightName + ".\n");
+                                devCopy = devices;
+                                AssertInFastLLM(SplitMultiCudaWeight(weight[zWeightName], zBias,
+                                                                     devCopy, zScheme, 0, true),
+                                                "Qwen3.5 ForwardGPU failed to split " + zWeightName + ".\n");
+                            }
+                            if (!hasMergedGdnInLinear) {
                                 DivisionScheme baScheme = BuildQwen35LinearBaScheme(
                                     valueScheme, num_v_heads);
                                 Data &baBias = GetThreadTensorParallelBias(baWeightName + ".tp_bias");
@@ -9285,7 +9793,13 @@ namespace fastllm {
                             AssertInFastLLM(SplitQwen35VectorWeight(weight[dtBiasName], devices, valueScheme),
                                             "Qwen3.5 ForwardGPU failed to split " + dtBiasName + ".\n");
 
-                            DivisionScheme outScheme = BuildQwen35LinearOutProjScheme(valueScheme, head_v_dim);
+                            const int outProjQuantBlock =
+                                weight[outProjWeightName].dataType == DataType::DATA_GGUF_FORMAT
+                                    ? (int)ggml_blck_size((ggml_type)weight[outProjWeightName].ggmlType)
+                                    : 1;
+                            DivisionScheme outScheme = BuildQwen35LinearOutProjScheme(
+                                keyScheme, num_k_heads, num_v_heads, head_v_dim,
+                                outProjQuantBlock, ggufOutProjColumnsTiled);
                             Data &outBias = GetThreadTensorParallelBias(outProjWeightName + ".tp_bias");
                             devCopy = devices;
                             AssertInFastLLM(SplitMultiCudaWeight(weight[outProjWeightName], outBias,
@@ -14910,22 +15424,19 @@ namespace fastllm {
             }
         }
         basellm::InitParams();
-        num_key_value_heads = num_attention_heads;
         if (this->weight.dicts.find("num_key_value_heads") != this->weight.dicts.end()) {
             num_key_value_heads = atoi(this->weight.dicts["num_key_value_heads"].c_str());
         }
-        if (this->weight.dicts.find("linear_num_key_heads") != this->weight.dicts.end()) {
-            num_k_heads = atoi(this->weight.dicts["linear_num_key_heads"].c_str());
-        }
-        if (this->weight.dicts.find("linear_num_value_heads") != this->weight.dicts.end()) {
-            num_v_heads = atoi(this->weight.dicts["linear_num_value_heads"].c_str());
-        }
-        if (this->weight.dicts.find("linear_key_head_dim") != this->weight.dicts.end()) {
-            head_k_dim = atoi(this->weight.dicts["linear_key_head_dim"].c_str());
-        }
-        if (this->weight.dicts.find("linear_value_head_dim") != this->weight.dicts.end()) {
-            head_v_dim = atoi(this->weight.dicts["linear_value_head_dim"].c_str());
-        }
+        ggufNormsPreOffset = getDictValue("ggufNormsPreOffset", "0") == "1";
+        ggufOutProjColumnsTiled = getDictValue("ggufOutProjColumnsTiled", "0") == "1";
+        num_k_heads = atoi(getDictValue("linear_num_key_heads", "0").c_str());
+        num_v_heads = atoi(getDictValue("linear_num_value_heads", "0").c_str());
+        head_k_dim = atoi(getDictValue("linear_key_head_dim", "0").c_str());
+        head_v_dim = atoi(getDictValue("linear_value_head_dim", "0").c_str());
+        AssertInFastLLM(num_k_heads > 0 && num_v_heads > 0 &&
+                        head_k_dim > 0 && head_v_dim > 0 &&
+                        num_v_heads % num_k_heads == 0,
+                        "Qwen3.5 requires valid linear attention head metadata.\n");
         head_dim = embed_dim / num_attention_heads;
         if (this->weight.dicts.find("head_dim") != this->weight.dicts.end()) {
             head_dim = atoi(this->weight.dicts["head_dim"].c_str());
@@ -15896,6 +16407,17 @@ namespace fastllm {
     }
 
     void Qwen3_5Model::OnModelWeightsLoaded() {
+        for (int i = 0; i < block_cnt; i++) {
+            std::string convWeightName = language_prefix + "layers." +
+                                         std::to_string(i) +
+                                         ".linear_attn.conv1d.weight";
+            auto convIt = weight.weight.find(convWeightName);
+            if (convIt != weight.weight.end() && convIt->second.dims.size() == 2) {
+                const int channels = convIt->second.dims[0];
+                const int kernel = convIt->second.dims[1];
+                convIt->second.Reshape({channels, 1, kernel});
+            }
+        }
         if (!loadFusedMoePlanned || moeFusedWeightsPrepared) {
             return;
         }
@@ -17853,14 +18375,16 @@ namespace fastllm {
         PrepareGdnWeights();
 
         if (!initialized_add1) {
-            for (int i = 0; i < block_cnt; i++) {
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+            if (!ggufNormsPreOffset) {
+                for (int i = 0; i < block_cnt; i++) {
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+                }
+                Add1(this->weight[language_prefix + "norm.weight"]);
+                AddMtpRmsNormOffset();
             }
-            Add1(this->weight[language_prefix + "norm.weight"]);
-            AddMtpRmsNormOffset();
             initialized_add1 = true;
         }
 
@@ -17958,6 +18482,8 @@ namespace fastllm {
                 std::string qkvzWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkvz.weight";
                 std::string baWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_ba.weight";
                 std::string qkvzbaWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkvzba.weight";
+                std::string qkvWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkv.weight";
+                std::string zWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_z.weight";
                 std::string conv1dWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.conv1d.weight";
                 std::string conv1dBiasName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.conv1d.bias";
                 std::string aLogName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.A_log";
@@ -17967,9 +18493,17 @@ namespace fastllm {
                 Qwen35PrepareLinearAttentionCache(pastValue, linearCacheType);
 
                 int kd = num_k_heads * head_k_dim, vd = num_v_heads * head_v_dim;
-                int mixedQkvzDim = this->weight[qkvzWeightName].dims[0];
-                int baMergedDim = this->weight[baWeightName].dims[0];
-                bool hasMergedGdnInLinear = this->weight.weight.find(qkvzbaWeightName) != this->weight.weight.end();
+                int mixedQkvzDim = kd * 2 + vd * 2;
+                int baMergedDim = num_v_heads * 2;
+                std::string layerPrefix = language_prefix + "layers." + std::to_string(i) + ".";
+                Qwen35GdnProjectionLayout gdnLayout =
+                    ResolveQwen35GdnProjectionLayout(weight, layerPrefix);
+                AssertInFastLLM(gdnLayout != Qwen35GdnProjectionLayout::Missing,
+                                "Qwen3.5 generic forward requires complete linear attention projection weights.\n");
+                bool hasMergedGdnInLinear =
+                    gdnLayout == Qwen35GdnProjectionLayout::Qkvzba;
+                bool hasSplitQkvZ =
+                    gdnLayout == Qwen35GdnProjectionLayout::QkvZBa;
                 if (hasMergedGdnInLinear && !isSingleTokenDecode &&
                     attenInput.dataDevice == DataDevice::CUDA &&
                     this->weight[qkvzbaWeightName].dataDevice != DataDevice::CUDA) {
@@ -17991,18 +18525,24 @@ namespace fastllm {
                         Split(gdn_in_merged, -1, 0, mixedQkvzDim, mixed_qkvz);
                         Split(gdn_in_merged, -1, mixedQkvzDim, mixedQkvzDim + baMergedDim, ba_merged);
                     }
+                } else if (hasSplitQkvZ) {
+                    Linear(attenInput, weight[qkvWeightName], Data(), qkvConvInput);
+                    Linear(attenInput, weight[zWeightName], Data(), z);
+                    Linear(attenInput, weight[baWeightName], Data(), ba_merged);
                 } else {
                     Linear(attenInput, weight[qkvzWeightName], Data(), mixed_qkvz);
                     Linear(attenInput, weight[baWeightName], Data(), ba_merged);
                 }
 
                 int qkvzDim = kd * 2 + vd;
-                if (isSingleTokenDecode && CanUseSingleRowLastDimView(mixed_qkvz)) {
-                    MakeSingleRowLastDimView(mixed_qkvz, 0, qkvzDim, qkvConvInput);
-                    MakeSingleRowLastDimView(mixed_qkvz, qkvzDim, qkvzDim + vd, z);
-                } else {
-                    Split(mixed_qkvz, -1, 0, qkvzDim, qkvConvInput);
-                    Split(mixed_qkvz, -1, qkvzDim, qkvzDim + vd, z);
+                if (!hasSplitQkvZ) {
+                    if (isSingleTokenDecode && CanUseSingleRowLastDimView(mixed_qkvz)) {
+                        MakeSingleRowLastDimView(mixed_qkvz, 0, qkvzDim, qkvConvInput);
+                        MakeSingleRowLastDimView(mixed_qkvz, qkvzDim, qkvzDim + vd, z);
+                    } else {
+                        Split(mixed_qkvz, -1, 0, qkvzDim, qkvConvInput);
+                        Split(mixed_qkvz, -1, qkvzDim, qkvzDim + vd, z);
+                    }
                 }
 
                 if (isSingleTokenDecode && CanUseSingleRowLastDimView(ba_merged)) {
@@ -18156,7 +18696,8 @@ namespace fastllm {
                     bool fusedSingleDecode = false;
 #ifdef USE_CUDA
                     fusedSingleDecode = Qwen35TryCudaLinearAttnSingleDecodeNormRecurrent(
-                        q, k, v, g, b, inv_scale_data, rms_norm_eps, last_recurrent_state, core_attn_out
+                        q, k, v, g, b, inv_scale_data, rms_norm_eps,
+                        last_recurrent_state, core_attn_out, false
                     );
 #endif
                     if (!fusedSingleDecode) {
@@ -18185,13 +18726,11 @@ namespace fastllm {
                         Data qrepeat, krepeat;
                         Mul(q, 1.0f, qrepeat);
                         Mul(k, 1.0f, krepeat);
-
+                        // All V-heads are now grouped (load-time untile).
                         qrepeat.Resize({q.dims[0], q.dims[1], q.dims[2], 1, q.dims[3]});
                         krepeat.Resize({k.dims[0], k.dims[1], k.dims[2], 1, k.dims[3]});
-
                         Repeat(qrepeat, 3, num_v_heads / num_k_heads, q);
                         Repeat(krepeat, 3, num_v_heads / num_k_heads, k);
-
                         q.Reshape({q.dims[0], q.dims[1], -1, q.dims.back()});
                         k.Reshape({k.dims[0], k.dims[1], -1, k.dims.back()});
                     }
@@ -18412,6 +18951,10 @@ namespace fastllm {
                 }
 
                 core_attn_out.Reshape({zShape[0], zShape[1], -1});
+                if (ggufOutProjColumnsTiled) {
+                    Qwen35ReorderGroupedToTiled(core_attn_out,
+                                                 num_k_heads, num_v_heads, head_v_dim);
+                }
                 if (isSingleTokenDecode &&
                     core_attn_out.dataDevice == DataDevice::CUDA &&
                     core_attn_out.dataType == DataType::FLOAT16 &&
@@ -18971,14 +19514,16 @@ namespace fastllm {
         PrepareGdnWeights();
 
         if (!initialized_add1) {
-            for (int i = 0; i < block_cnt; i++) {
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
-                Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+            if (!ggufNormsPreOffset) {
+                for (int i = 0; i < block_cnt; i++) {
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".input_layernorm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.q_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".self_attn.k_norm.weight"]);
+                    Add1(this->weight[language_prefix + "layers." + std::to_string(i) + ".post_attention_layernorm.weight"]);
+                }
+                Add1(this->weight[language_prefix + "norm.weight"]);
+                AddMtpRmsNormOffset();
             }
-            Add1(this->weight[language_prefix + "norm.weight"]);
-            AddMtpRmsNormOffset();
             initialized_add1 = true;
         }
 
@@ -19140,15 +19685,25 @@ namespace fastllm {
                 std::string qkvzWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkvz.weight";
                 std::string baWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_ba.weight";
                 std::string qkvzbaWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkvzba.weight";
+                std::string qkvWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_qkv.weight";
+                std::string zWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.in_proj_z.weight";
                 std::string conv1dWeightName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.conv1d.weight";
                 std::string conv1dBiasName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.conv1d.bias";
                 std::string aLogName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.A_log";
                 std::string dtBiasName = language_prefix + "layers." + std::to_string(i) + ".linear_attn.dt_bias";
 
                 int kd = num_k_heads * head_k_dim, vd = num_v_heads * head_v_dim;
-                int mixedQkvzDim = this->weight[qkvzWeightName].dims[0];
-                int baMergedDim = this->weight[baWeightName].dims[0];
-                bool hasMergedGdnInLinear = this->weight.weight.find(qkvzbaWeightName) != this->weight.weight.end();
+                int mixedQkvzDim = kd * 2 + vd * 2;
+                int baMergedDim = num_v_heads * 2;
+                std::string layerPrefix = language_prefix + "layers." + std::to_string(i) + ".";
+                Qwen35GdnProjectionLayout gdnLayout =
+                    ResolveQwen35GdnProjectionLayout(weight, layerPrefix);
+                AssertInFastLLM(gdnLayout != Qwen35GdnProjectionLayout::Missing,
+                                "Qwen3.5 ForwardV2 requires complete linear attention projection weights.\n");
+                bool hasMergedGdnInLinear =
+                    gdnLayout == Qwen35GdnProjectionLayout::Qkvzba;
+                bool hasSplitQkvZ =
+                    gdnLayout == Qwen35GdnProjectionLayout::QkvZBa;
                 if (hasMergedGdnInLinear && !isSingleTokenDecode &&
                     attenInput.dataDevice == DataDevice::CUDA &&
                     this->weight[qkvzbaWeightName].dataDevice != DataDevice::CUDA) {
@@ -19170,19 +19725,25 @@ namespace fastllm {
                         Split(gdn_in_merged, -1, 0, mixedQkvzDim, mixed_qkvz);
                         Split(gdn_in_merged, -1, mixedQkvzDim, mixedQkvzDim + baMergedDim, ba_merged);
                     }
+                } else if (hasSplitQkvZ) {
+                    Linear(attenInput, weight[qkvWeightName], Data(), qkvConvInput);
+                    Linear(attenInput, weight[zWeightName], Data(), z);
+                    Linear(attenInput, weight[baWeightName], Data(), ba_merged);
                 } else {
                     Linear(attenInput, weight[qkvzWeightName], Data(), mixed_qkvz);
                     Linear(attenInput, weight[baWeightName], Data(), ba_merged);
                 }
 
-                // Split qkvz -> mixed_qkv + z
+                // Split qkvz -> mixed_qkv + z when qkvz was loaded as one tensor.
                 int qkvzDim = kd * 2 + vd;
-                if (isSingleTokenDecode && CanUseSingleRowLastDimView(mixed_qkvz)) {
-                    MakeSingleRowLastDimView(mixed_qkvz, 0, qkvzDim, qkvConvInput);
-                    MakeSingleRowLastDimView(mixed_qkvz, qkvzDim, qkvzDim + vd, z);
-                } else {
-                    Split(mixed_qkvz, -1, 0, qkvzDim, qkvConvInput);
-                    Split(mixed_qkvz, -1, qkvzDim, qkvzDim + vd, z);
+                if (!hasSplitQkvZ) {
+                    if (isSingleTokenDecode && CanUseSingleRowLastDimView(mixed_qkvz)) {
+                        MakeSingleRowLastDimView(mixed_qkvz, 0, qkvzDim, qkvConvInput);
+                        MakeSingleRowLastDimView(mixed_qkvz, qkvzDim, qkvzDim + vd, z);
+                    } else {
+                        Split(mixed_qkvz, -1, 0, qkvzDim, qkvConvInput);
+                        Split(mixed_qkvz, -1, qkvzDim, qkvzDim + vd, z);
+                    }
                 }
 
                 // Split ba -> b + a (note: b and a have dim num_v_heads, not vd).
@@ -19360,7 +19921,7 @@ namespace fastllm {
                             convOutput, ba_merged, inv_scale_data, weight[aLogName], weight[dtBiasName],
                             recurrentStates, core_attn_out,
                             num_k_heads, num_v_heads, head_k_dim, head_v_dim,
-                            rms_norm_eps, recurrentQScale
+                            rms_norm_eps, recurrentQScale, false
                         );
                         for (int rb = 0; rb < batch; rb++) {
                             Qwen35PrepareLinearAttentionCache(*recurrentStates[rb], linearCacheType);
@@ -19415,7 +19976,8 @@ namespace fastllm {
                     bool fusedSingleDecode = false;
 #ifdef USE_CUDA
                     fusedSingleDecode = Qwen35TryCudaLinearAttnSingleDecodeNormRecurrent(
-                        q, k, v, g, b, inv_scale_data, rms_norm_eps, last_recurrent_state, core_attn_out
+                        q, k, v, g, b, inv_scale_data, rms_norm_eps,
+                        last_recurrent_state, core_attn_out, false
                     );
 #endif
                     if (!fusedSingleDecode) {
@@ -19500,13 +20062,11 @@ namespace fastllm {
                         Data qrepeat, krepeat;
                         Mul(q, 1.0f, qrepeat);
                         Mul(k, 1.0f, krepeat);
-
+                        // All V-heads are now grouped (load-time untile).
                         qrepeat.Resize({q.dims[0], q.dims[1], q.dims[2], 1, q.dims[3]});
                         krepeat.Resize({k.dims[0], k.dims[1], k.dims[2], 1, k.dims[3]});
-
                         Repeat(qrepeat, 3, num_v_heads / num_k_heads, q);
                         Repeat(krepeat, 3, num_v_heads / num_k_heads, k);
-
                         q.Reshape({q.dims[0], q.dims[1], -1, q.dims.back()});
                         k.Reshape({k.dims[0], k.dims[1], -1, k.dims.back()});
                     }
@@ -19729,6 +20289,10 @@ namespace fastllm {
                     }
 
                     core_attn_out.Reshape({zShape[0], zShape[1], -1});
+                    if (ggufOutProjColumnsTiled) {
+                        Qwen35ReorderGroupedToTiled(core_attn_out,
+                                                     num_k_heads, num_v_heads, head_v_dim);
+                    }
                     if (isSingleTokenDecode &&
                         core_attn_out.dataDevice == DataDevice::CUDA &&
                         core_attn_out.dataType == DataType::FLOAT16 &&

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -78,6 +78,25 @@ namespace fastllm {
         return Qwen35AttentionProjectionLayout::Missing;
     }
 
+    int SelectQwen35DecodeTokensForPageBudget(
+            int requestedTokens,
+            const std::vector<std::pair<int, int> > &requestedNeedsAndFree,
+            const std::vector<std::pair<int, int> > &singleNeedsAndFree) {
+        auto fits = [](const std::vector<std::pair<int, int> > &needsAndFree) {
+            for (const auto &item : needsAndFree) {
+                if (item.first > item.second) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        requestedTokens = std::max(1, requestedTokens);
+        if (fits(requestedNeedsAndFree)) {
+            return requestedTokens;
+        }
+        return fits(singleNeedsAndFree) ? 1 : 0;
+    }
+
 #ifdef USE_CUDA
     Qwen35DivisionScheme BuildQwen35LinearOutProjScheme(
             const Qwen35DivisionScheme &keyHeadScheme,
@@ -14305,10 +14324,9 @@ namespace fastllm {
             return true;
         };
 
-        auto collectDecodePageNeeds = [&](ResponseContext *ctx) -> std::map<PagedCacheManager*, int> {
+        auto collectDecodePageNeeds = [&](ResponseContext *ctx, int decodeTokens) -> std::map<PagedCacheManager*, int> {
             std::map<PagedCacheManager*, int> needs;
-            int decodeTokens = ctx == nullptr ? 1 :
-                std::max(1, scheduledDecodeTokens(ctx));
+            decodeTokens = std::max(1, decodeTokens);
             // Multi-token MTP validation runs against a paged-cache view. A
             // partial last page is cloned before appending so rejected draft
             // tokens cannot overwrite the real cache.
@@ -14383,6 +14401,19 @@ namespace fastllm {
                 }
             }
             return false;
+        };
+        auto pageNeedsAndFree = [](const std::map<PagedCacheManager*, int> &needs) {
+            std::vector<std::pair<int, int> > ret;
+            ret.reserve(needs.size());
+            for (const auto &it : needs) {
+                PagedCacheManager *manager = it.first;
+                if (manager == nullptr || it.second <= 0) {
+                    continue;
+                }
+                std::lock_guard<std::mutex> guard(manager->pageIndexLocker);
+                ret.push_back({it.second, manager->FreePageCount()});
+            }
+            return ret;
         };
         auto accumulatePagedManagerNeeds = [](
                 std::map<PagedCacheManager*, int> &total,
@@ -14809,10 +14840,18 @@ namespace fastllm {
                     }
 
                     if (!isPrompt) {
-                        auto pageNeeds = collectDecodePageNeeds(ctx);
+                        auto pageNeeds = collectDecodePageNeeds(ctx, scheduledTokens);
                         if (!pageNeeds.empty() && hasPagedManagerShortage(pageNeeds)) {
-                            releaseAndReinitRequest(ctx);
-                            continue;
+                            auto singlePageNeeds = collectDecodePageNeeds(ctx, 1);
+                            int budgetedTokens = SelectQwen35DecodeTokensForPageBudget(
+                                scheduledTokens, pageNeedsAndFree(pageNeeds),
+                                pageNeedsAndFree(singlePageNeeds));
+                            if (budgetedTokens == 0) {
+                                releaseAndReinitRequest(ctx);
+                                continue;
+                            }
+                            scheduledTokens = budgetedTokens;
+                            pageNeeds.swap(singlePageNeeds);
                         }
                         if (!pageNeeds.empty()) {
                             auto combinedPageNeeds = selectedDecodePageNeeds;
@@ -14838,7 +14877,7 @@ namespace fastllm {
                     selectedMultimodal = isMultimodal;
 
                     if (!isPrompt && !selectedMultimodal && !ctx->currentTokens.empty()) {
-                        int seqLen = scheduledDecodeTokens(ctx);
+                        int seqLen = scheduledTokens;
                         if (seqLen == 1) {
                             ids.push_back((float)ctx->currentTokens[0]);
                             seqLens.push_back(1);

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -99,6 +99,149 @@ namespace fastllm {
         return fits(singleNeedsAndFree) ? 1 : 0;
     }
 
+    bool Qwen35InterleaveLongPrefillEnabled() {
+        const char *env = std::getenv("FASTLLM_QWEN35_INTERLEAVE_LONG_PREFILL");
+        if (env == nullptr || env[0] == 0) {
+            return false;
+        }
+        std::string lowered(env);
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                       [](unsigned char c) { return (char)std::tolower(c); });
+        return lowered == "true" || lowered == "1" ||
+               lowered == "yes" || lowered == "on";
+    }
+    bool Qwen35BatchedMtpEnabled() {
+        const char *env = std::getenv("FASTLLM_QWEN35_BATCHED_MTP");
+        if (env == nullptr || env[0] == 0) {
+            return true;
+        }
+        std::string lowered(env);
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                       [](unsigned char c) { return (char)std::tolower(c); });
+        return lowered != "false" && lowered != "0" &&
+               lowered != "no" && lowered != "off";
+    }
+
+    Qwen35RequestPhase ClassifyQwen35RequestPhase(const ResponseContext &context) {
+        if (context.longPrefill.inProgress &&
+            context.longPrefill.cursor < context.longPrefill.total) {
+            return Qwen35RequestPhase::ContinuedPrefill;
+        }
+        return context.preTokens == 0 ?
+            Qwen35RequestPhase::NewPrefill : Qwen35RequestPhase::Decode;
+    }
+
+    bool BeginQwen35LongPrefill(
+            ResponseContext &context,
+            int total,
+            uint64_t ticket,
+            const std::map<PagedCacheManager*, int> &reservedPages) {
+        if (context.longPrefill.inProgress || context.preTokens != 0 ||
+            total <= 0 || total != (int)context.currentTokens.size()) {
+            return false;
+        }
+        for (const auto &item : reservedPages) {
+            if (item.first == nullptr || item.second < 0) {
+                return false;
+            }
+        }
+        context.longPrefill.inProgress = true;
+        context.longPrefill.total = total;
+        context.longPrefill.cursor = 0;
+        context.longPrefill.mtpViable = true;
+        context.longPrefill.ticket = ticket;
+        context.longPrefill.reservedPages = reservedPages;
+        return true;
+    }
+
+    Qwen35LongPrefillQuantum PlanQwen35LongPrefillQuantum(
+            const ResponseContext &context,
+            int chunkSize) {
+        Qwen35LongPrefillQuantum quantum;
+        const Qwen35LongPrefillProgress &progress = context.longPrefill;
+        if (!progress.inProgress || chunkSize <= 0 || progress.total <= 0 ||
+            progress.cursor < 0 || progress.cursor >= progress.total ||
+            context.preTokens != progress.cursor) {
+            return quantum;
+        }
+        quantum.cursor = progress.cursor;
+        quantum.length = std::min(chunkSize, progress.total - progress.cursor);
+        quantum.baseTokens = context.cacheLen + progress.cursor;
+        quantum.isLast = progress.cursor + quantum.length == progress.total;
+        quantum.producesOutput = quantum.isLast;
+        return quantum;
+    }
+
+    bool CommitQwen35LongPrefillQuantum(
+            ResponseContext &context,
+            const Qwen35LongPrefillQuantum &quantum,
+            bool mtpViable) {
+        Qwen35LongPrefillProgress &progress = context.longPrefill;
+        if (!progress.inProgress || quantum.length <= 0 ||
+            quantum.cursor != progress.cursor ||
+            context.preTokens != progress.cursor ||
+            quantum.baseTokens != context.cacheLen + progress.cursor ||
+            quantum.cursor + quantum.length > progress.total) {
+            return false;
+        }
+        bool isLast = quantum.cursor + quantum.length == progress.total;
+        if (quantum.isLast != isLast || quantum.producesOutput != isLast) {
+            return false;
+        }
+        progress.cursor += quantum.length;
+        context.preTokens += quantum.length;
+        progress.mtpViable = progress.mtpViable && mtpViable;
+        if (isLast) {
+            progress.inProgress = false;
+            progress.reservedPages.clear();
+        }
+        return true;
+    }
+
+    int SelectQwen35LongPrefillHandle(
+            const std::vector<std::tuple<int, uint64_t> > &candidates,
+            uint64_t lastTicket) {
+        int afterHandle = -1;
+        uint64_t afterTicket = UINT64_MAX;
+        int firstHandle = -1;
+        uint64_t firstTicket = UINT64_MAX;
+        for (const auto &candidate : candidates) {
+            int handle = std::get<0>(candidate);
+            uint64_t ticket = std::get<1>(candidate);
+            if (handle < 0) {
+                continue;
+            }
+            if (ticket < firstTicket ||
+                (ticket == firstTicket && (firstHandle < 0 || handle < firstHandle))) {
+                firstTicket = ticket;
+                firstHandle = handle;
+            }
+            if (ticket > lastTicket &&
+                (ticket < afterTicket ||
+                 (ticket == afterTicket && (afterHandle < 0 || handle < afterHandle)))) {
+                afterTicket = ticket;
+                afterHandle = handle;
+            }
+        }
+        return afterHandle >= 0 ? afterHandle : firstHandle;
+    }
+
+    bool CanAdmitQwen35LongPrefill(int residentRequests, int schedulerLanes) {
+        return residentRequests >= 0 && schedulerLanes > 0 &&
+               residentRequests < schedulerLanes;
+    }
+
+    bool CanReserveQwen35LongPrefillPages(
+            const std::vector<Qwen35PageReservationBudget> &budgets) {
+        for (const auto &budget : budgets) {
+            if (budget.reserved < 0 || budget.needed < 0 || budget.free < 0 ||
+                (long long)budget.reserved + budget.needed > budget.free) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 #ifdef USE_CUDA
     Qwen35DivisionScheme BuildQwen35LinearOutProjScheme(
             const Qwen35DivisionScheme &keyHeadScheme,
@@ -3147,7 +3290,7 @@ namespace fastllm {
         }
 
         static int Qwen35LinearPrefixSnapshotIntervalTokens() {
-            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 16);
+            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 64);
             pages = std::max(1, pages);
             return pages * fastllm::GetPageLen();
         }
@@ -14086,6 +14229,15 @@ namespace fastllm {
         const int mtpBatchDecodeTokens = std::min(
             mtpDraftsPerStep + 1, QWEN35_MTP_FAST_SEQ_MAX);
         int prefillChunkSize = model->GetChunkedPrefillSize();
+        const bool interleaveLongPrefill = Qwen35InterleaveLongPrefillEnabled();
+        const int longPrefillResidentLanes = interleaveLongPrefill ?
+            std::max(mtpSchedulerLanes,
+                     std::min(configuredMtpSchedulerLanes,
+                              QWEN35_MTP_PREFIX_SNAPSHOT_BATCH_MAX)) :
+            mtpSchedulerLanes;
+        uint64_t nextLongPrefillTicket = 0;
+        uint64_t lastLongPrefillTicket = 0;
+        bool lastQuantumWasLongPrefill = false;
 
         auto releasePagedCachePages = [](Data &cache, bool clearDims = false) {
             std::set<std::pair<PagedCacheManager*, int> > releasedPages;
@@ -14144,6 +14296,7 @@ namespace fastllm {
             ctx->preTokens = 0;
             ctx->cacheLen = 0;
             ctx->intParams.clear();
+            ctx->longPrefill.Reset();
         };
 
         auto scheduledDecodeTokens = [&](const ResponseContext *ctx) {
@@ -14385,6 +14538,105 @@ namespace fastllm {
                 }
             }
             return needs;
+        };
+
+        struct Qwen35PrefillPageNeed {
+            std::map<PagedCacheManager*, int> needs;
+            bool impossible = false;
+        };
+        auto collectPrefillPageNeeds = [&](ResponseContext *ctx, int appendTokens) {
+            Qwen35PrefillPageNeed state;
+            if (ctx == nullptr || appendTokens <= 0) {
+                return state;
+            }
+            auto addManagerNeed = [&](PagedCacheManager *manager,
+                                      int currentTokens,
+                                      int currentPages) {
+                if (manager == nullptr || manager->pageLen <= 0 ||
+                    manager->type != PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE) {
+                    return;
+                }
+                long long totalTokens = (long long)std::max(0, currentTokens) + appendTokens;
+                long long totalManagerPages =
+                    (totalTokens + manager->pageLen - 1) / manager->pageLen;
+                if (totalManagerPages > manager->maxPages) {
+                    state.impossible = true;
+                    return;
+                }
+                int newPages = (int)totalManagerPages - std::max(0, currentPages);
+                if (newPages > 0) {
+                    int &need = state.needs[manager];
+                    need = need >= INT_MAX - newPages ? INT_MAX : need + newPages;
+                }
+            };
+            std::function<bool(Data&)> addExistingCache = [&](Data &cache) {
+                if (cache.multiDeviceData && !cache.multiDeviceDatas.empty()) {
+                    bool usedLocal = false;
+                    for (auto &item : cache.multiDeviceDatas) {
+                        if (item.second != nullptr) {
+                            usedLocal = addExistingCache(*item.second) || usedLocal;
+                        }
+                    }
+                    if (usedLocal) {
+                        return true;
+                    }
+                }
+                if (!cache.isPagedKVCache || cache.pagedKVCacheData == nullptr) {
+                    return false;
+                }
+                int currentPages = (int)cache.pageIndex.size();
+                int cachePageLen = cache.pageLen > 0 ?
+                    cache.pageLen : cache.pagedKVCacheData->pageLen;
+                int currentTokens = currentPages > 0 ?
+                    (currentPages - 1) * cachePageLen + cache.lastPageLen : 0;
+                addManagerNeed(cache.pagedKVCacheData, currentTokens, currentPages);
+                return true;
+            };
+            for (int layer = 0;
+                 layer < model->block_cnt && layer < (int)ctx->pastKeyValues.size();
+                 layer++) {
+                for (int keyFlag = 0; keyFlag < 2; keyFlag++) {
+                    bool isKey = keyFlag == 0;
+                    Data &cache = isKey ? ctx->pastKeyValues[layer].first :
+                                          ctx->pastKeyValues[layer].second;
+                    if (addExistingCache(cache)) {
+                        continue;
+                    }
+                    for (auto &ref : model->GetPagedKVCacheManagers(layer, isKey)) {
+                        addManagerNeed(ref.second, 0, 0);
+                    }
+                }
+            }
+            return state;
+        };
+
+        auto pageNeedsFitWithReservations = [](
+                const std::map<PagedCacheManager*, int> &needs,
+                const std::map<PagedCacheManager*, int> &reserved) {
+            std::set<PagedCacheManager*> managers;
+            for (const auto &item : needs) managers.insert(item.first);
+            for (const auto &item : reserved) managers.insert(item.first);
+            for (PagedCacheManager *manager : managers) {
+                if (manager == nullptr) {
+                    continue;
+                }
+                int need = 0;
+                int reservation = 0;
+                auto needIt = needs.find(manager);
+                if (needIt != needs.end()) need = needIt->second;
+                auto reservationIt = reserved.find(manager);
+                if (reservationIt != reserved.end()) reservation = reservationIt->second;
+                int freePages = 0;
+                {
+                    std::lock_guard<std::mutex> guard(manager->pageIndexLocker);
+                    freePages = manager->FreePageCount();
+                }
+                if (need < 0 || reservation < 0 ||
+                    (long long)need + reservation > freePages) {
+                    return false;
+                }
+            }
+            return true;
         };
 
         auto hasPagedManagerShortage = [](const std::map<PagedCacheManager*, int> &needs) -> bool {
@@ -14675,6 +14927,11 @@ namespace fastllm {
         } else if (model->verbose) {
             printf("Fastllm Scheduler: Qwen3.5 MTP (lane=%d).\n", mtpSchedulerLanes);
         }
+        if (interleaveLongPrefill) {
+            printf("[Qwen3.5 MTP] interleaved long prefill enabled: chunk=%d, decode_lanes=%d, resident_lanes=%d.\n",
+                   prefillChunkSize, mtpSchedulerLanes, longPrefillResidentLanes);
+            fflush(stdout);
+        }
         if (model->verbose && useMtpBatchScheduling &&
             mtpDraftsPerStep + 1 > QWEN35_MTP_FAST_SEQ_MAX) {
             printf("[Qwen3.5 MTP] batched validation uses %d of %d configured drafts per step.\n",
@@ -14708,6 +14965,8 @@ namespace fastllm {
             bool selectedIsPrompt = false;
             bool selectedMultimodal = false;
             std::map<PagedCacheManager*, int> selectedDecodePageNeeds;
+            bool selectedLongPrefill = false;
+            Qwen35LongPrefillQuantum selectedLongPrefillQuantum;
 
             attentionMasks.reserve(mtpSchedulerLanes);
             positionIds.reserve(mtpSchedulerLanes);
@@ -14730,6 +14989,10 @@ namespace fastllm {
             int busyPages = 0;
             int currentActivate = 0;
             bool hasPrefill = false;
+            bool hasDecode = false;
+            bool hasContinuedPrefill = false;
+            std::vector<std::tuple<int, uint64_t> > continuedPrefillCandidates;
+            std::map<PagedCacheManager*, int> outstandingPrefillReservations;
             struct DecodeOrder {
                 int sortKey;
                 int handle;
@@ -14756,11 +15019,30 @@ namespace fastllm {
                     eraseMtpCache(ctx);
                     continue;
                 }
-                if (ctx->preTokens > 0) {
-                    currentActivate++;
-                }
-                if (ctx->preTokens == 0) {
-                    hasPrefill = true;
+                if (interleaveLongPrefill) {
+                    Qwen35RequestPhase phase = ClassifyQwen35RequestPhase(*ctx);
+                    if (phase == Qwen35RequestPhase::ContinuedPrefill) {
+                        currentActivate++;
+                        hasPrefill = true;
+                        hasContinuedPrefill = true;
+                        continuedPrefillCandidates.push_back(
+                            {it.first, ctx->longPrefill.ticket});
+                        accumulatePagedManagerNeeds(
+                            outstandingPrefillReservations,
+                            ctx->longPrefill.reservedPages);
+                    } else if (phase == Qwen35RequestPhase::NewPrefill) {
+                        hasPrefill = true;
+                    } else {
+                        currentActivate++;
+                        hasDecode = true;
+                    }
+                } else {
+                    if (ctx->preTokens > 0) {
+                        currentActivate++;
+                    }
+                    if (ctx->preTokens == 0) {
+                        hasPrefill = true;
+                    }
                 }
                 orders.push_back({-scheduledDecodeTokens(ctx), it.first, ctx});
             }
@@ -14785,21 +15067,47 @@ namespace fastllm {
                     pagesLimit = totalPages * 4 / 5;
                 }
             }
-            // A prefetched request owns its hybrid linear-attention state and
-            // MTP rollback snapshots even while it is not selected for the
-            // current decode forward.  Limiting only seqLens below therefore
-            // limits per-step compute, not resident per-request CUDA memory.
-            // Keep excess requests pending before prefill so the number of
-            // resident request states cannot exceed the startup-validated MTP
-            // scheduler capacity.
-            bool canAddPrefill = currentActivate < mtpSchedulerLanes &&
+            // Long-prefill requests own per-context KV, hybrid-state, and MTP
+            // snapshots, while each quantum still runs as a single forward.
+            // Keep decode batching on the startup-validated fast-path width,
+            // but let explicitly enabled interleave admit independently
+            // reserved prefill contexts up to the single-GPU snapshot cap.
+            bool canAddPrefill = CanAdmitQwen35LongPrefill(
+                    currentActivate, longPrefillResidentLanes) &&
                 ((pagesLimit > 0) ? (busyPages < pagesLimit) : true);
+            bool forceDecode = interleaveLongPrefill &&
+                lastQuantumWasLongPrefill && hasDecode;
+            int continuedPrefillHandle = interleaveLongPrefill &&
+                !continuedPrefillCandidates.empty() ?
+                SelectQwen35LongPrefillHandle(
+                    continuedPrefillCandidates, lastLongPrefillTicket) : -1;
+            int newPrefillHandle = -1;
+            int newPrefillTokens = INT_MAX;
+            if (interleaveLongPrefill && canAddPrefill) {
+                for (const auto &item : orders) {
+                    if (item.context == nullptr ||
+                        ClassifyQwen35RequestPhase(*item.context) !=
+                            Qwen35RequestPhase::NewPrefill) {
+                        continue;
+                    }
+                    int promptTokens = (int)item.context->currentTokens.size();
+                    if (promptTokens < newPrefillTokens ||
+                        (promptTokens == newPrefillTokens &&
+                         (newPrefillHandle < 0 || item.handle < newPrefillHandle))) {
+                        newPrefillTokens = promptTokens;
+                        newPrefillHandle = item.handle;
+                    }
+                }
+            }
+            bool canRunPrefill = interleaveLongPrefill ?
+                (!forceDecode && (hasContinuedPrefill || canAddPrefill)) :
+                canAddPrefill;
 
             for (int isPrompt = 1; isPrompt >= 0 && seqLens.empty(); isPrompt--) {
-                if (isPrompt == 1 && !canAddPrefill) {
+                if (isPrompt == 1 && !canRunPrefill) {
                     continue;
                 }
-                if (isPrompt == 0 && hasPrefill && canAddPrefill) {
+                if (isPrompt == 0 && hasPrefill && canRunPrefill) {
                     continue;
                 }
 
@@ -14808,13 +15116,26 @@ namespace fastllm {
                     if (ctx == nullptr || ctx->isEnding) {
                         continue;
                     }
-                    if (isPrompt && ctx->preTokens != 0) {
+                    Qwen35RequestPhase requestPhase = interleaveLongPrefill ?
+                        ClassifyQwen35RequestPhase(*ctx) :
+                        (ctx->preTokens == 0 ? Qwen35RequestPhase::NewPrefill :
+                                               Qwen35RequestPhase::Decode);
+                    bool continuedLongPrefill = interleaveLongPrefill &&
+                        requestPhase == Qwen35RequestPhase::ContinuedPrefill;
+                    if (interleaveLongPrefill && isPrompt) {
+                        int selectedPrefillHandle = newPrefillHandle >= 0 ?
+                            newPrefillHandle : continuedPrefillHandle;
+                        if (selectedPrefillHandle >= 0 && ii.handle != selectedPrefillHandle) {
+                            continue;
+                        }
+                    }
+                    if (isPrompt && requestPhase == Qwen35RequestPhase::Decode) {
                         continue;
                     }
-                    if (!isPrompt && ctx->preTokens == 0) {
+                    if (!isPrompt && requestPhase != Qwen35RequestPhase::Decode) {
                         continue;
                     }
-                    if (isPrompt && ctx->cacheLen == 0 &&
+                    if (isPrompt && !continuedLongPrefill && ctx->cacheLen == 0 &&
                         tryRestorePrefixCache(ctx) < 0) {
                         releaseAndReinitRequest(ctx);
                     }
@@ -14843,6 +15164,17 @@ namespace fastllm {
 
                     if (!isPrompt) {
                         auto pageNeeds = collectDecodePageNeeds(ctx, scheduledTokens);
+                        if (interleaveLongPrefill &&
+                            !pageNeedsFitWithReservations(
+                                pageNeeds, outstandingPrefillReservations)) {
+                            auto singlePageNeeds = collectDecodePageNeeds(ctx, 1);
+                            if (!pageNeedsFitWithReservations(
+                                    singlePageNeeds, outstandingPrefillReservations)) {
+                                continue;
+                            }
+                            scheduledTokens = 1;
+                            pageNeeds.swap(singlePageNeeds);
+                        }
                         if (!pageNeeds.empty() && hasPagedManagerShortage(pageNeeds)) {
                             auto singlePageNeeds = collectDecodePageNeeds(ctx, 1);
                             int budgetedTokens = SelectQwen35DecodeTokensForPageBudget(
@@ -14858,6 +15190,15 @@ namespace fastllm {
                         if (!pageNeeds.empty()) {
                             auto combinedPageNeeds = selectedDecodePageNeeds;
                             accumulatePagedManagerNeeds(combinedPageNeeds, pageNeeds);
+                            if (interleaveLongPrefill) {
+                                auto reservedCombined = combinedPageNeeds;
+                                accumulatePagedManagerNeeds(
+                                    reservedCombined,
+                                    outstandingPrefillReservations);
+                                if (hasPagedManagerShortage(reservedCombined)) {
+                                    continue;
+                                }
+                            }
                             if (hasPagedManagerShortage(combinedPageNeeds)) {
                                 // This request fits by itself, but not together
                                 // with the requests already selected for this
@@ -14866,6 +15207,70 @@ namespace fastllm {
                                 continue;
                             }
                             selectedDecodePageNeeds.swap(combinedPageNeeds);
+                        }
+                    }
+
+                    if (interleaveLongPrefill && isPrompt &&
+                        ctx->multimodalInput.empty()) {
+                        if (!continuedLongPrefill &&
+                            (int)ctx->currentTokens.size() > prefillChunkSize) {
+                            Qwen35PrefillPageNeed wholeNeed = collectPrefillPageNeeds(
+                                ctx, (int)ctx->currentTokens.size());
+                            if (wholeNeed.impossible ||
+                                !pageNeedsFitWithReservations(
+                                    wholeNeed.needs,
+                                    outstandingPrefillReservations) ||
+                                !BeginQwen35LongPrefill(
+                                    *ctx, (int)ctx->currentTokens.size(),
+                                    ++nextLongPrefillTicket, wholeNeed.needs)) {
+                                continue;
+                            }
+                            continuedLongPrefill = true;
+                        }
+                        if (continuedLongPrefill) {
+                            selectedLongPrefillQuantum =
+                                PlanQwen35LongPrefillQuantum(*ctx, prefillChunkSize);
+                            if (selectedLongPrefillQuantum.length <= 0) {
+                                releaseAndReinitRequest(ctx);
+                                continue;
+                            }
+                            std::map<PagedCacheManager*, int> otherReservations =
+                                outstandingPrefillReservations;
+                            for (const auto &reservation : ctx->longPrefill.reservedPages) {
+                                auto reservationIt = otherReservations.find(reservation.first);
+                                if (reservationIt != otherReservations.end()) {
+                                    reservationIt->second = std::max(
+                                        0, reservationIt->second - reservation.second);
+                                }
+                            }
+                            Qwen35PrefillPageNeed chunkNeed = collectPrefillPageNeeds(
+                                ctx, selectedLongPrefillQuantum.length);
+                            if (chunkNeed.impossible ||
+                                !pageNeedsFitWithReservations(
+                                    chunkNeed.needs, otherReservations)) {
+                                continue;
+                            }
+                            selectedLongPrefill = true;
+                            scheduledTokens = selectedLongPrefillQuantum.length;
+                        } else {
+                            Qwen35PrefillPageNeed shortNeed =
+                                collectPrefillPageNeeds(ctx, scheduledTokens);
+                            if (shortNeed.impossible ||
+                                !pageNeedsFitWithReservations(
+                                    shortNeed.needs,
+                                    outstandingPrefillReservations)) {
+                                continue;
+                            }
+                        }
+                    }
+                    if (interleaveLongPrefill && isPrompt && isMultimodal) {
+                        Qwen35PrefillPageNeed multimodalNeed =
+                            collectPrefillPageNeeds(ctx, scheduledTokens);
+                        if (multimodalNeed.impossible ||
+                            !pageNeedsFitWithReservations(
+                                multimodalNeed.needs,
+                                outstandingPrefillReservations)) {
+                            continue;
                         }
                     }
 
@@ -14927,7 +15332,13 @@ namespace fastllm {
                             ctx->preTokens += seqLen;
                         }
                     } else {
-                        if (ctx->preTokens == 0) {
+                        if (selectedLongPrefill) {
+                            ctx->intParams["add_special_tokens"] =
+                                ctx->cacheLen > 0 ? false : ctx->generationConfig.add_special_tokens;
+                            ctx->intParams["promptLen"] =
+                                ctx->cacheLen + ctx->longPrefill.total;
+                            ctx->intParams["index"] = 0;
+                        } else if (ctx->preTokens == 0) {
                             ctx->intParams["add_special_tokens"] =
                                 ctx->cacheLen > 0 ? false : ctx->generationConfig.add_special_tokens;
                             ctx->intParams["promptLen"] =
@@ -14936,36 +15347,82 @@ namespace fastllm {
                         } else {
                             ctx->intParams["index"]++;
                         }
-                        Data inputIds, attentionMask, curPositionIds;
+                        Data fullInputIds, attentionMask, fullPositionIds;
                         std::vector<std::vector<float> > tokens(1);
                         tokens[0].reserve(ctx->currentTokens.size());
                         for (int token : ctx->currentTokens) {
                             tokens[0].push_back((float)token);
                         }
                         model->FillLLMInputs(tokens, ctx->intParams,
-                                             inputIds, attentionMask, curPositionIds);
+                                             fullInputIds, attentionMask, fullPositionIds);
                         ToDataType(attentionMask, model->dataType);
 
-                        seqLens.push_back(inputIds.Count(0));
-                        for (int i = 0; i < inputIds.Count(0); i++) {
-                            ids.push_back(((float*)inputIds.cpuData)[i]);
-                        }
-                        if (attentionMask.dims.empty()) {
+                        if (selectedLongPrefill) {
+                            int inputStart = selectedLongPrefillQuantum.cursor;
+                            int chunkLen = selectedLongPrefillQuantum.length;
+                            int inputEnd = inputStart + chunkLen;
+                            AssertInFastLLM(fullInputIds.cpuData != nullptr &&
+                                            inputStart >= 0 &&
+                                            inputEnd <= fullInputIds.Count(0),
+                                            "Qwen3.5 interleaved prefill got an invalid input slice.\n");
+                            seqLens.push_back(chunkLen);
+                            const float *fullIds = (const float*)fullInputIds.cpuData;
+                            for (int i = inputStart; i < inputEnd; i++) {
+                                ids.push_back(fullIds[i]);
+                            }
                             attentionMasks.push_back(nullptr);
+                            if (fullPositionIds.dims.empty() ||
+                                fullPositionIds.cpuData == nullptr) {
+                                positionIds.push_back(nullptr);
+                            } else {
+                                int lastDim = fullPositionIds.dims.back();
+                                int outer = fullPositionIds.Count(0) / lastDim;
+                                AssertInFastLLM(inputStart >= 0 &&
+                                                inputEnd <= lastDim,
+                                                "Qwen3.5 interleaved prefill got an invalid position slice.\n");
+                                std::vector<int> outDims = fullPositionIds.dims;
+                                outDims.back() = chunkLen;
+                                positionIds.push_back(new Data());
+                                ownedPositionIds.push_back(positionIds.back());
+                                positionIds.back()->dataType = fullPositionIds.dataType;
+                                positionIds.back()->Resize(outDims);
+                                positionIds.back()->Allocate();
+                                int unitSize = positionIds.back()->unitSize;
+                                int rowBytes = chunkLen * unitSize;
+                                int srcRowBytes = lastDim * unitSize;
+                                const uint8_t *srcPos =
+                                    (const uint8_t*)fullPositionIds.cpuData;
+                                uint8_t *dstPos =
+                                    (uint8_t*)positionIds.back()->cpuData;
+                                for (int row = 0; row < outer; row++) {
+                                    memcpy(dstPos + (size_t)row * rowBytes,
+                                           srcPos + (size_t)row * srcRowBytes +
+                                               (size_t)inputStart * unitSize,
+                                           rowBytes);
+                                }
+                            }
                         } else {
-                            attentionMasks.push_back(new Data());
-                            ownedAttentionMasks.push_back(attentionMasks.back());
-                            attentionMask.ToDevice(DataDevice::CPU);
-                            attentionMasks.back()->CopyFrom(attentionMask);
+                            seqLens.push_back(fullInputIds.Count(0));
+                            for (int i = 0; i < fullInputIds.Count(0); i++) {
+                                ids.push_back(((float*)fullInputIds.cpuData)[i]);
+                            }
+                            if (attentionMask.dims.empty()) {
+                                attentionMasks.push_back(nullptr);
+                            } else {
+                                attentionMasks.push_back(new Data());
+                                ownedAttentionMasks.push_back(attentionMasks.back());
+                                attentionMask.ToDevice(DataDevice::CPU);
+                                attentionMasks.back()->CopyFrom(attentionMask);
+                            }
+                            if (fullPositionIds.dims.empty()) {
+                                positionIds.push_back(nullptr);
+                            } else {
+                                positionIds.push_back(new Data());
+                                ownedPositionIds.push_back(positionIds.back());
+                                positionIds.back()->CopyFrom(fullPositionIds);
+                            }
+                            ctx->preTokens += seqLens.back();
                         }
-                        if (curPositionIds.dims.empty()) {
-                            positionIds.push_back(nullptr);
-                        } else {
-                            positionIds.push_back(new Data());
-                            ownedPositionIds.push_back(positionIds.back());
-                            positionIds.back()->CopyFrom(curPositionIds);
-                        }
-                        ctx->preTokens += seqLens.back();
                     }
 
                     for (int i = 0; i < model->block_cnt; i++) {
@@ -14997,7 +15454,150 @@ namespace fastllm {
                 std::vector<std::vector<int> > nextInputTokenLists;
                 std::vector<int> keptInputLens;
                 bool usedMtpForward = false;
+                bool completedLongPrefillIntermediate = false;
+                bool longPrefillMtpViable = true;
 
+                if (selectedLongPrefill && singleContext != nullptr) {
+                    std::vector<int> mtpDevices;
+                    std::map<int, int> mtpRatios;
+                    bool seedMtp = singleContext->longPrefill.mtpViable &&
+                        !Qwen35MtpDisabledByEnv() &&
+                        Qwen35MtpDraftsPerStep() > 0 &&
+                        model->HasMtpWeights() &&
+                        generationConfigs.size() == 1 &&
+                        Qwen35MtpSupportsGenerationConfig(generationConfigs[0]) &&
+                        !positionIds.empty() && positionIds[0] != nullptr &&
+                        GetQwen35GPUForwardDevices(
+                            model->deviceMap, mtpDevices, mtpRatios) &&
+                        !mtpDevices.empty();
+                    int expectedTokens = selectedLongPrefillQuantum.baseTokens;
+                    if (seedMtp) {
+                        std::lock_guard<std::mutex> guard(model->mtpCacheMutex);
+                        if (expectedTokens == 0) {
+                            model->mtpCaches.erase(singleContext);
+                        } else {
+                            auto mtpIt = model->mtpCaches.find(singleContext);
+                            seedMtp = mtpIt != model->mtpCaches.end() &&
+                                mtpIt->second.tokens == expectedTokens &&
+                                mtpIt->second.key.dims.size() >= 2 &&
+                                mtpIt->second.value.dims.size() >= 2 &&
+                                mtpIt->second.key.dims[1] == expectedTokens &&
+                                mtpIt->second.value.dims[1] == expectedTokens;
+                        }
+                    }
+
+                    bool oldCaptureAllHiddenStates =
+                        model->speculativeCaptureAllHiddenStates;
+                    model->speculativeCaptureAllHiddenStates = seedMtp;
+                    if (seedMtp) {
+                        model->speculativeHiddenStates.FreeSpace();
+                        model->speculativeHiddenStates.dims.clear();
+                        model->speculativeHiddenStates.strides.clear();
+                        model->speculativeHiddenStates.expansionDims.clear();
+                    }
+                    if (!seedMtp) {
+                        eraseMtpCache(singleContext);
+                    }
+                    try {
+                        ret = model->ForwardGPU(1, inputIds, attentionMasks,
+                                                positionIds, seqLens,
+                                                pastKeyValues, generationConfigs,
+                                                tokensManager, &logits);
+                    } catch (...) {
+                        model->speculativeCaptureAllHiddenStates =
+                            oldCaptureAllHiddenStates;
+                        if (seedMtp) {
+                            eraseMtpCache(singleContext);
+                        }
+                        throw;
+                    }
+                    model->speculativeCaptureAllHiddenStates =
+                        oldCaptureAllHiddenStates;
+                    AssertInFastLLM(!ret.empty(),
+                                    "Qwen3.5 interleaved target prefill returned no token.\n");
+
+                    int firstDraft = -1;
+                    bool mtpSeeded = false;
+                    if (seedMtp) {
+                        AssertInFastLLM(!ret.empty(),
+                                        "Qwen3.5 interleaved prefill returned no token.\n");
+                        std::vector<int> mtpInputTokens(
+                            selectedLongPrefillQuantum.length);
+                        for (int i = 0; i < selectedLongPrefillQuantum.length; i++) {
+                            int globalIndex = selectedLongPrefillQuantum.cursor + i;
+                            int nextIndex = globalIndex + 1;
+                            mtpInputTokens[i] = nextIndex < singleContext->longPrefill.total ?
+                                singleContext->currentTokens[nextIndex] : ret.back();
+                        }
+                        std::lock_guard<std::mutex> guard(model->mtpCacheMutex);
+                        auto cacheIt = model->mtpCaches.find(singleContext);
+                        if (cacheIt == model->mtpCaches.end()) {
+                            if (expectedTokens == 0) {
+                                cacheIt = model->mtpCaches.emplace(
+                                    singleContext, MtpKvCache()).first;
+                            } else {
+                                seedMtp = false;
+                            }
+                        }
+                        if (seedMtp && cacheIt->second.tokens == expectedTokens) {
+                            try {
+                                firstDraft = model->RunMtpGreedyDraft(
+                                    mtpDevices[0], mtpDevices, cacheIt->second,
+                                    model->speculativeHiddenStates,
+                                    mtpInputTokens, *positionIds[0],
+                                    (int)mtpInputTokens.size() - 1,
+                                    nullptr,
+                                    !selectedLongPrefillQuantum.isLast);
+                            } catch (...) {
+                                model->mtpCaches.erase(singleContext);
+                                throw;
+                            }
+                            int newTokens = expectedTokens +
+                                selectedLongPrefillQuantum.length;
+                            mtpSeeded = cacheIt->second.tokens == newTokens &&
+                                cacheIt->second.key.dims.size() >= 2 &&
+                                cacheIt->second.value.dims.size() >= 2 &&
+                                cacheIt->second.key.dims[1] == newTokens &&
+                                cacheIt->second.value.dims[1] == newTokens;
+                        }
+                        if (!mtpSeeded) {
+                            model->mtpCaches.erase(singleContext);
+                        }
+                    }
+                    longPrefillMtpViable = seedMtp && mtpSeeded;
+                    int physicalTokens = expectedTokens +
+                        selectedLongPrefillQuantum.length;
+                    if (physicalTokens % pageLen == 0) {
+                        singleContext->TryRecordPagedCache(model);
+                    }
+                    if (selectedLongPrefillQuantum.isLast) {
+                        if (longPrefillMtpViable && firstDraft >= 0) {
+                            int nextToken = ret.back();
+                            usedMtpForward = true;
+                            acceptedTokenLists = {{nextToken}};
+                            nextInputTokenLists = {{nextToken, firstDraft}};
+                            keptInputLens = {selectedLongPrefillQuantum.length};
+                        }
+                    } else {
+                        usedMtpForward = true;
+                        completedLongPrefillIntermediate = true;
+                    }
+                    if (model->verbose) {
+                        int doneTokens = selectedLongPrefillQuantum.cursor +
+                            selectedLongPrefillQuantum.length;
+                        printf("[Prompt] Interleaved Long Prefill handle=%d (%d/%d, %d%%).\n",
+                               handles.empty() ? -1 : handles[0],
+                               doneTokens, singleContext->longPrefill.total,
+                               doneTokens * 100 / singleContext->longPrefill.total);
+                        if (selectedLongPrefillQuantum.isLast &&
+                            longPrefillMtpViable && firstDraft >= 0) {
+                            printf("[Qwen3.5 MTP] long prefill cache seeded: tokens=%d.\n",
+                                   selectedLongPrefillQuantum.baseTokens +
+                                   selectedLongPrefillQuantum.length);
+                        }
+                        fflush(stdout);
+                    }
+                } else
                 if (selectedMultimodal && singleContext != nullptr) {
                     ret = model->ForwardMultimodal(
                         inputIds,
@@ -15217,10 +15817,12 @@ namespace fastllm {
                 } else {
                     auto batchStartTime = std::chrono::system_clock::now();
                     if (seqLens.size() > 1) {
-                        usedMtpForward = model->Qwen35MTPBatchForward(
-                            true, tokenContexts, inputIds, attentionMasks, positionIds,
-                            seqLens, pastKeyValues, generationConfigs,
-                            acceptedTokenLists, nextInputTokenLists, keptInputLens);
+                        if (Qwen35BatchedMtpEnabled()) {
+                            usedMtpForward = model->Qwen35MTPBatchForward(
+                                true, tokenContexts, inputIds, attentionMasks, positionIds,
+                                seqLens, pastKeyValues, generationConfigs,
+                                acceptedTokenLists, nextInputTokenLists, keptInputLens);
+                        }
                     } else {
                         usedMtpForward = model->Qwen35MTPForward(
                             true, singleContext, inputIds, attentionMasks, positionIds,
@@ -15311,6 +15913,46 @@ namespace fastllm {
 
                 forwardLocker.unlock();
                 dictLocker.lock();
+                if (selectedLongPrefill && !handles.empty()) {
+                    auto contextIt = model->responseContextDict.dicts.find(handles[0]);
+                    ResponseContext *commitContext =
+                        contextIt == model->responseContextDict.dicts.end() ?
+                        nullptr : contextIt->second;
+                    if (commitContext != singleContext ||
+                        !CommitQwen35LongPrefillQuantum(
+                            *commitContext, selectedLongPrefillQuantum,
+                            longPrefillMtpViable)) {
+                        if (commitContext == singleContext) {
+                            releaseAndReinitRequest(commitContext);
+                        }
+                        completedLongPrefillIntermediate = true;
+                    } else {
+                        lastLongPrefillTicket = commitContext->longPrefill.ticket;
+                        lastQuantumWasLongPrefill = true;
+                        if (commitContext->longPrefill.inProgress) {
+                            int remaining = commitContext->longPrefill.total -
+                                commitContext->longPrefill.cursor;
+                            Qwen35PrefillPageNeed remainingNeed =
+                                collectPrefillPageNeeds(commitContext, remaining);
+                            if (remainingNeed.impossible) {
+                                releaseAndReinitRequest(commitContext);
+                            } else {
+                                commitContext->longPrefill.reservedPages =
+                                    remainingNeed.needs;
+                            }
+                        }
+                    }
+                    if (completedLongPrefillIntermediate) {
+                        acceptedTokenLists.clear();
+                        nextInputTokenLists.clear();
+                        keptInputLens.clear();
+                        handles.clear();
+                        tokenContexts.clear();
+                        selectedIsPrompt = false;
+                    }
+                } else {
+                    lastQuantumWasLongPrefill = false;
+                }
 
                 if (selectedIsPrompt) {
                     for (int i = 0; i < (int)handles.size(); i++) {

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -121,6 +121,34 @@ namespace fastllm {
         return lowered != "false" && lowered != "0" &&
                lowered != "no" && lowered != "off";
     }
+    bool Qwen35Turbo3KvEnabled() {
+        const char *env = std::getenv("FASTLLM_QWEN35_TURBO3_KV");
+        if (env == nullptr || env[0] == 0) {
+            return false;
+        }
+        std::string lowered(env);
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                       [](unsigned char c) { return (char)std::tolower(c); });
+        return lowered == "true" || lowered == "1" ||
+               lowered == "yes" || lowered == "on";
+    }
+    DataType ResolveQwen35CudaCacheType(DataType cacheType, DataType computeType) {
+        if (cacheType == DataType::FLOAT16 ||
+            cacheType == DataType::BFLOAT16 ||
+            cacheType == DataType::FP8_E4M3 ||
+            IsPackedKVCacheDataType(cacheType)) {
+            return cacheType;
+        }
+        return computeType;
+    }
+
+    size_t Qwen35PagedCachePageBytes(
+            DataType type, int pageLen, int numHeads, int headDim) {
+        AssertInFastLLM(pageLen > 0 && numHeads > 0 && headDim > 0,
+                        "Qwen3.5 paged cache page shape is invalid.\n");
+        return GetDataBytes(type, (size_t)pageLen * numHeads, headDim);
+    }
+
 
     Qwen35RequestPhase ClassifyQwen35RequestPhase(const ResponseContext &context) {
         if (context.longPrefill.inProgress &&
@@ -1434,14 +1462,6 @@ namespace fastllm {
             return DataType::FLOAT16;
         }
 
-        static DataType ResolveQwen35ThreadTpCacheType(DataType cacheType, DataType computeType) {
-            if (cacheType == DataType::FLOAT16 ||
-                cacheType == DataType::BFLOAT16 ||
-                cacheType == DataType::FP8_E4M3) {
-                return cacheType;
-            }
-            return computeType;
-        }
 
         static void PrepareQwen35EmbeddingWeightType(Data &embedWeight,
                                                      DataType outputType,
@@ -4288,33 +4308,79 @@ namespace fastllm {
                     *generatedAppendParams = true;
                 }
 
-                bool fillLastPageLensOnDevice = merged->dataDevice == DataDevice::CUDA &&
+                const bool packedKV =
+                    IsPackedKVCacheDataType(((Data*)pagedCacheKManager)->dataType) ||
+                    IsPackedKVCacheDataType(((Data*)pagedCacheVManager)->dataType);
+                bool fillLastPageLensOnDevice = !packedKV &&
+                                                 merged->dataDevice == DataDevice::CUDA &&
                                                  !merged->multiDeviceData &&
                                                  !externalDecodeMeta &&
                                                  !(*generatedDecodeParams);
-                Qwen35CudaQGateKVRMSNormRopeSplitAppendPagedCache(
-                    runner, *merged, *qNormWeight, *kNormWeight, *allPositionIds,
-                    *q, *gate,
-                    *(Data*)pagedCacheKManager, *(Data*)pagedCacheVManager,
-                    *insertIndexs, *insertPositions,
-                    numAttentionHeads, numKeyValueHeads, headDim,
-                    rotaryDim, mropeSections, rmsNormEps, ropeBase, ropeScale,
-                    kCaches.pageLen, batch, true,
-                    fillLastPageLensOnDevice ? lastPageLens : nullptr);
+                if (packedKV) {
+                    AssertInFastLLM(!externalDecodeMeta &&
+                                    ((Data*)pagedCacheKManager)->dataType == DataType::Q8_0_KV &&
+                                    ((Data*)pagedCacheVManager)->dataType == DataType::TURBO3_KV &&
+                                    headDim == 256,
+                                    "Qwen3.5 packed decode requires non-graph q8_0 K + turbo3 V with head_dim=256.\n");
+                    int qgateDim = numAttentionHeads * headDim * 2;
+                    int kvDim = numKeyValueHeads * headDim;
+                    Qwen3CudaSplit(runner, *merged, -1, 0, qgateDim, *qgate);
+                    Qwen3CudaSplit(runner, *merged, -1, qgateDim, qgateDim + kvDim, *k);
+                    Qwen3CudaSplit(runner, *merged, -1, qgateDim + kvDim,
+                                   qgateDim + kvDim * 2, *v);
 
-                if (!externalDecodeMeta) {
+                    qgate->Reshape({bsz, seqlen, numAttentionHeads, headDim * 2});
+                    Qwen3CudaSplit(runner, *qgate, -1, 0, headDim, *q);
+                    Qwen3CudaSplit(runner, *qgate, -1, headDim, headDim * 2, *gate);
+                    gate->Reshape({bsz, seqlen, numAttentionHeads * headDim});
+                    k->Reshape({bsz, seqlen, numKeyValueHeads, headDim});
+                    v->Reshape({bsz, seqlen, numKeyValueHeads, headDim});
+
+                    Qwen3CudaRMSNorm(runner, *q, *qNormWeight, rmsNormEps, *q);
+                    Qwen3CudaRMSNorm(runner, *k, *kNormWeight, rmsNormEps, *k);
+                    Qwen35CudaApplyRotary(runner, *q, *allPositionIds,
+                                          rotaryDim, mropeSections, ropeBase, ropeScale);
+                    Qwen35CudaApplyRotary(runner, *k, *allPositionIds,
+                                          rotaryDim, mropeSections, ropeBase, ropeScale);
+                    Qwen3CudaPermuteSelf(runner, *q, {0, 2, 1, 3});
+                    q->Reshape({-1, seqlen, headDim});
+                    k->Reshape({batch, numKeyValueHeads, headDim});
+                    v->Reshape({batch, numKeyValueHeads, headDim});
+                    Qwen3CudaAppendPagedCacheBatch(runner, *pagedCacheKManager,
+                                                   *batchPastKeys, *k,
+                                                   *insertIndexs, *insertPositions);
+                    Qwen3CudaAppendPagedCacheBatch(runner, *pagedCacheVManager,
+                                                   *batchPastValues, *v,
+                                                   *insertIndexs, *insertPositions);
                     for (int b = 0; b < batch; b++) {
-                        auto updatePageMeta = [](Data *cache, PagedCacheManager *mgr) {
-                            if (cache->pageIndex.empty() || cache->lastPageLen >= cache->pageLen) {
-                                cache->pageIndex.push_back(mgr->GetUnusedPageIndex(true));
-                                cache->lastPageLen = 1;
-                            } else {
-                                cache->lastPageLen++;
-                            }
-                            Qwen35AdvancePagedCacheLogicalTokens(*cache, 1);
-                        };
-                        updatePageMeta((*batchPastKeys)[b], pagedCacheKManager);
-                        updatePageMeta((*batchPastValues)[b], pagedCacheVManager);
+                        Qwen35AdvancePagedCacheLogicalTokens(*(*batchPastKeys)[b], 1);
+                        Qwen35AdvancePagedCacheLogicalTokens(*(*batchPastValues)[b], 1);
+                    }
+                } else {
+                    Qwen35CudaQGateKVRMSNormRopeSplitAppendPagedCache(
+                        runner, *merged, *qNormWeight, *kNormWeight, *allPositionIds,
+                        *q, *gate,
+                        *(Data*)pagedCacheKManager, *(Data*)pagedCacheVManager,
+                        *insertIndexs, *insertPositions,
+                        numAttentionHeads, numKeyValueHeads, headDim,
+                        rotaryDim, mropeSections, rmsNormEps, ropeBase, ropeScale,
+                        kCaches.pageLen, batch, true,
+                        fillLastPageLensOnDevice ? lastPageLens : nullptr);
+
+                    if (!externalDecodeMeta) {
+                        for (int b = 0; b < batch; b++) {
+                            auto updatePageMeta = [](Data *cache, PagedCacheManager *mgr) {
+                                if (cache->pageIndex.empty() || cache->lastPageLen >= cache->pageLen) {
+                                    cache->pageIndex.push_back(mgr->GetUnusedPageIndex(true));
+                                    cache->lastPageLen = 1;
+                                } else {
+                                    cache->lastPageLen++;
+                                }
+                                Qwen35AdvancePagedCacheLogicalTokens(*cache, 1);
+                            };
+                            updatePageMeta((*batchPastKeys)[b], pagedCacheKManager);
+                            updatePageMeta((*batchPastValues)[b], pagedCacheVManager);
+                        }
                     }
                 }
                 if (!externalDecodeMeta && !(*generatedDecodeParams)) {
@@ -5849,6 +5915,7 @@ namespace fastllm {
         int vocabSize = it->second.dims[0];
         FastllmCudaSetDevice(rootDevice);
 
+
         size_t logitsBytes = (size_t)batch * (size_t)vocabSize * sizeof(float);
         FastllmCudaMallocBigBuffer(logitsBytes);
         DataType computeType = ResolveQwen35ThreadTpComputeType(this->dataType);
@@ -5883,7 +5950,7 @@ namespace fastllm {
                 fflush(stdout);
             }
         }
-        if (GetFastllmEnv().cudaGraph) {
+        if (GetFastllmEnv().cudaGraph && this->kvCacheDataType != DataType::TURBO3_KV) {
             if (threadTpWorkerGroup.HasWorkers()) {
                 threadTpWorkerGroup.Stop();
             }
@@ -5893,6 +5960,34 @@ namespace fastllm {
         }
         Qwen35ReleaseThreadLocalCudaSamplingBuffers();
 #endif
+    }
+
+    void Qwen3_5Model::SetKVCacheDataType(DataType dataType) {
+        if (dataType != DataType::TURBO3_KV) {
+            basellm::SetKVCacheDataType(dataType);
+            return;
+        }
+        AssertInFastLLM(Qwen35Turbo3KvEnabled(),
+                        "Qwen3.5 turbo3 KV cache requires FASTLLM_QWEN35_TURBO3_KV=1.\n");
+        AssertInFastLLM(this->head_dim == 256,
+                        "Qwen3.5 turbo3 KV cache currently requires head_dim=256.\n");
+#ifndef USE_CUDA
+        ErrorInFastLLM("Qwen3.5 turbo3 KV cache requires CUDA support.\n");
+#endif
+        this->kvCacheDataType = dataType;
+        this->useCustomKVCacheDataType = true;
+        printf("[Qwen3.5] Turbo3 paged KV enabled: K=q8_0, V=turbo3, head_dim=256.\n");
+        fflush(stdout);
+    }
+    std::pair<DataType, DataType> Qwen3_5Model::GetKVCacheDataTypes(int layerIndex) const {
+        if (layerIndex >= 0 && Qwen35LayerIsLinearAttention(this, layerIndex)) {
+            DataType cacheType = Qwen35LinearAttentionCacheDataType(this->dataType);
+            return {cacheType, cacheType};
+        }
+        if (this->kvCacheDataType == DataType::TURBO3_KV) {
+            return {DataType::Q8_0_KV, DataType::TURBO3_KV};
+        }
+        return basellm::GetKVCacheDataTypes(layerIndex);
     }
 
     PagedCacheManager* Qwen3_5Model::GetPagedKVCacheManager(int layerIndex, bool isKey) const {
@@ -6356,15 +6451,16 @@ namespace fastllm {
             for (int b = 0; b < batch; b++) {
                 for (int i = 0; i < block_cnt; i++) {
                     bool isLinearLayer = Qwen35LayerIsLinearAttention(this, i);
-                    DataType cacheType = isLinearLayer ?
-                        Qwen35LinearAttentionCacheDataType(this->dataType) : this->kvCacheDataType;
-                    pastKeyValuesStorage.push_back(std::make_pair(Data(cacheType),
-                                                                  Data(cacheType)));
+                    auto types = this->GetKVCacheDataTypes(i);
+                    pastKeyValuesStorage.emplace_back(
+                        std::piecewise_construct,
+                        std::forward_as_tuple(types.first),
+                        std::forward_as_tuple(types.second));
                     pastKeyValuesStorage.back().first.SetKVCache();
                     pastKeyValuesStorage.back().second.SetKVCache();
                     if (isLinearLayer) {
-                        Qwen35PrepareLinearAttentionCache(pastKeyValuesStorage.back().first, cacheType);
-                        Qwen35PrepareLinearAttentionCache(pastKeyValuesStorage.back().second, cacheType);
+                        Qwen35PrepareLinearAttentionCache(pastKeyValuesStorage.back().first, types.first);
+                        Qwen35PrepareLinearAttentionCache(pastKeyValuesStorage.back().second, types.second);
                     }
                     pastKeyValues.push_back(std::make_pair(&pastKeyValuesStorage.back().first,
                                                            &pastKeyValuesStorage.back().second));
@@ -6443,6 +6539,9 @@ namespace fastllm {
         return false;
 #else
         (void)ratios;
+        if (this->kvCacheDataType == DataType::TURBO3_KV) {
+            return false;
+        }
         const int maxCudaGraphDecodeBatch = Qwen35MaxCudaGraphDecodeBatch(this);
         if (!Qwen35CudaGraphEnabled() || batch <= 0 || batch > maxCudaGraphDecodeBatch ||
             !all1 || isPrefill || (int)seqLens.size() < batch ||
@@ -10226,9 +10325,9 @@ namespace fastllm {
                 } else {
                     pastKeyValues[idx].first->isLinearAttention = false;
                     pastKeyValues[idx].second->isLinearAttention = false;
-                    keyCacheType = ResolveQwen35ThreadTpCacheType(
+                    keyCacheType = ResolveQwen35CudaCacheType(
                         pastKeyValues[idx].first->dataType, computeType);
-                    valueCacheType = ResolveQwen35ThreadTpCacheType(
+                    valueCacheType = ResolveQwen35CudaCacheType(
                         pastKeyValues[idx].second->dataType, computeType);
                 }
                 for (int r = 0; r < (int)devices.size(); r++) {
@@ -10263,9 +10362,9 @@ namespace fastllm {
                 } else {
                     pastKeyValues[idx].first->isLinearAttention = false;
                     pastKeyValues[idx].second->isLinearAttention = false;
-                    keyCacheType = ResolveQwen35ThreadTpCacheType(
+                    keyCacheType = ResolveQwen35CudaCacheType(
                         pastKeyValues[idx].first->dataType, computeType);
-                    valueCacheType = ResolveQwen35ThreadTpCacheType(
+                    valueCacheType = ResolveQwen35CudaCacheType(
                         pastKeyValues[idx].second->dataType, computeType);
                 }
                 PrepareQwen35SingleCudaCache(*pastKeyValues[idx].first, device, keyCacheType);
@@ -11104,8 +11203,9 @@ namespace fastllm {
             PagedCacheManager *manager = cache.pagedKVCacheData;
             AssertInFastLLM(manager != nullptr && manager->dims.size() == 4,
                             "Qwen3.5 MTP validation paged cache manager is invalid.\n");
-            size_t pageBytes = (size_t)manager->pageLen * manager->dims[2] *
-                               manager->dims[3] * manager->unitSize / manager->unitSizeDiv;
+            size_t pageBytes = Qwen35PagedCachePageBytes(
+                manager->dataType, manager->pageLen,
+                manager->dims[2], manager->dims[3]);
             size_t srcOffset = (size_t)srcPage * pageBytes;
             size_t dstOffset = (size_t)dstPage * pageBytes;
             if (manager->dataDevice == DataDevice::CUDA) {
@@ -19176,10 +19276,26 @@ namespace fastllm {
                 v.Reshape(qkvSize);
                 PreparePagedAttentionInputs(q, k, v, this->dataType);
 
+                auto makeCacheDesc = [](const Data &src, DataType targetType) {
+                    Data desc(targetType);
+                    desc.dims = src.dims;
+                    desc.strides = src.strides;
+                    desc.dataDevice = src.dataDevice;
+                    desc.dataDeviceIds = src.dataDeviceIds;
+                    desc.multiDeviceData = src.multiDeviceData;
+                    desc.tpLayout = src.tpLayout;
+                    desc.tpAxis = src.tpAxis;
+                    desc.tpGlobalDims = src.tpGlobalDims;
+                    desc.tpRanges = src.tpRanges;
+                    desc.UpdateUnitSize();
+                    return desc;
+                };
+                Data kCacheDesc = makeCacheDesc(k, pastKey.dataType);
+                Data vCacheDesc = makeCacheDesc(v, pastValue.dataType);
                 PagedCacheManager *pagedCacheKManager = AllocatePagedCacheManager(
-                    i * 2, PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE, k);
+                    i * 2, PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE, kCacheDesc);
                 PagedCacheManager *pagedCacheVManager = AllocatePagedCacheManager(
-                    i * 2 + 1, PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE, v);
+                    i * 2 + 1, PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE, vCacheDesc);
                 AppendPagedCache(*pagedCacheKManager, pastKey, k);
                 AppendPagedCache(*pagedCacheVManager, pastValue, v);
                 AttentionPaged(q, pastKey, pastValue, qkv, q.dims[0] / k.dims[0], 1.0 / sqrt(head_dim), 1, pagedAttentionInited);

--- a/test/api/test_usage_accounting.py
+++ b/test/api/test_usage_accounting.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 import sys
 
 
@@ -65,6 +67,7 @@ async def model_deltas():
 def make_completion():
     completion = object.__new__(FastLLmCompletion)
     completion.model = FakeModel()
+    completion._ensure_handle_tracking()
     completion.model_name = "test-model"
     completion.conversation_handles = {}
     return completion
@@ -225,8 +228,72 @@ def test_stream_and_nonstream_include_native_usage():
     asyncio.run(run_test())
 
 
+def test_owned_handle_launches_remain_concurrent():
+    completion = make_completion()
+    launch_barrier = threading.Barrier(2)
+
+    def launch(handle):
+        launch_barrier.wait(timeout=2)
+        return handle
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(
+            completion._launch_owned_handle, "request-a", lambda: launch(1))
+        second = executor.submit(
+            completion._launch_owned_handle, "request-b", lambda: launch(2))
+        assert first.result(timeout=3) == 1
+        assert second.result(timeout=3) == 2
+
+    assert completion.conversation_handles == {
+        "request-a": 1,
+        "request-b": 2,
+    }
+
+
+def test_stale_disconnect_cannot_abort_reused_handle():
+    class TrackingModel(FakeModel):
+        def __init__(self):
+            self.aborted_handles = []
+
+        def abort_handle(self, handle):
+            self.aborted_handles.append(handle)
+
+    completion = make_completion()
+    completion.model = TrackingModel()
+    completion._launch_owned_handle("request-a", lambda: 1)
+
+    launch_entered = threading.Event()
+    release_launch = threading.Event()
+
+    def launch_reused_handle():
+        launch_entered.set()
+        assert release_launch.wait(timeout=2)
+        return 1
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        launch_b = executor.submit(
+            completion._launch_owned_handle,
+            "request-b",
+            launch_reused_handle,
+        )
+        assert launch_entered.wait(timeout=2)
+        stale_cleanup = executor.submit(
+            lambda: asyncio.run(completion.check_disconnect(
+                RawRequest(), "request-a", 1)))
+        release_launch.set()
+
+        assert launch_b.result(timeout=3) == 1
+        assert stale_cleanup.result(timeout=3) is None
+
+    assert completion.model.aborted_handles == []
+    assert completion.conversation_handles == {"request-b": 1}
+    assert completion._handle_owners == {1: "request-b"}
+
+
 if __name__ == "__main__":
     test_usage_protocol_mappings()
     test_stream_adapter_supports_new_and_legacy_models()
     test_stream_and_nonstream_include_native_usage()
+    test_owned_handle_launches_remain_concurrent()
+    test_stale_disconnect_cannot_abort_reused_handle()
     print("usage accounting tests passed")

--- a/test/apiserver/socketWriteTest.cpp
+++ b/test/apiserver/socketWriteTest.cpp
@@ -1,0 +1,219 @@
+#include <cstdio>
+#include <cstring>
+
+#include <set>
+#include <string>
+#include <vector>
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include "../../example/apiserver/socket_writer.h"
+#include "../../example/apiserver/stop_parser.h"
+#include "../../include/utils/stop_token_matcher.h"
+#include "../../include/utils/stop_string_matcher.h"
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        std::fprintf(stderr, "check failed at line %d: %s\n", \
+                     __LINE__, #condition); \
+        return 1; \
+    } \
+} while (false)
+
+int main() {
+    CHECK(FormatSseData("{\"ok\":true}") ==
+          "data: {\"ok\":true}\r\n\r\n");
+    CHECK(FormatSseData("[DONE]") == "data: [DONE]\r\n\r\n");
+    CHECK(FormatSseData("{\n\t\"ok\": true\n}") ==
+          "data: {\r\ndata: \t\"ok\": true\r\ndata: }\r\n\r\n");
+
+    auto encodeStop = [](const std::string &stop) {
+        OpenAIStopEncoding encoding;
+        if (stop == "single-a") {
+            encoding.tokenSequence = {101};
+        } else if (stop == "single-b") {
+            encoding.tokenSequence = {202};
+        } else if (stop == "multiple") {
+            encoding.tokenSequence = {1, 2};
+        }
+        return encoding;
+    };
+
+    auto exactTokenLookup = [](const std::string &stop, int &tokenId) {
+        if (stop == "vocab-entry") {
+            tokenId = 303;
+            return true;
+        }
+        return false;
+    };
+    auto fallbackEncode = [](const std::string &stop) {
+        if (stop == "fallback-single") {
+            return std::vector<int>{404};
+        }
+        return std::vector<int>{1, 2};
+    };
+    OpenAIStopEncoding vocabEncoding = EncodeOpenAIStop(
+        "vocab-entry", exactTokenLookup, fallbackEncode);
+    CHECK(vocabEncoding.exactTokenId == 303);
+    CHECK(vocabEncoding.tokenSequence == std::vector<int>({1, 2}));
+    OpenAIStopEncoding fallbackEncoding = EncodeOpenAIStop(
+        "fallback-single", exactTokenLookup, fallbackEncode);
+    CHECK(fallbackEncoding.exactTokenId == -1);
+    CHECK(fallbackEncoding.tokenSequence == std::vector<int>{404});
+
+    std::multiset<int> stopTokenIds;
+    std::vector<std::vector<int>> parsedStopSequences;
+    std::vector<std::string> parsedStopStrings;
+    std::string stopError;
+    CHECK(ParseOpenAIStop(json11::Json(), encodeStop, stopTokenIds,
+                          parsedStopSequences, parsedStopStrings, stopError));
+    CHECK(stopTokenIds.empty());
+    CHECK(parsedStopSequences.empty());
+    CHECK(parsedStopStrings.empty());
+    CHECK(stopError.empty());
+
+    CHECK(ParseOpenAIStop(json11::Json("single-a"), encodeStop,
+                          stopTokenIds, parsedStopSequences,
+                          parsedStopStrings, stopError));
+    CHECK(stopTokenIds.size() == 1);
+    CHECK(stopTokenIds.count(101) == 1);
+    CHECK(parsedStopSequences.empty());
+    CHECK(parsedStopStrings == std::vector<std::string>{"single-a"});
+
+    parsedStopStrings.clear();
+    stopTokenIds.clear();
+    CHECK(ParseOpenAIStop(json11::Json::array{"single-a", "single-b"},
+                          encodeStop, stopTokenIds, parsedStopSequences,
+                          parsedStopStrings, stopError));
+    CHECK(stopTokenIds.size() == 2);
+    CHECK(stopTokenIds.count(101) == 1);
+    CHECK(stopTokenIds.count(202) == 1);
+    CHECK(parsedStopSequences.empty());
+    parsedStopStrings.clear();
+    stopTokenIds.clear();
+
+    CHECK(ParseOpenAIStop(json11::Json("multiple"), encodeStop,
+                          stopTokenIds, parsedStopSequences,
+                          parsedStopStrings, stopError));
+    CHECK(stopTokenIds.empty());
+    CHECK(parsedStopSequences ==
+          std::vector<std::vector<int>>({{1, 2}}));
+    parsedStopStrings.clear();
+
+    stopTokenIds.insert(7);
+    CHECK(!ParseOpenAIStop(json11::Json::array{"single-a", 42},
+                           encodeStop, stopTokenIds, parsedStopSequences,
+                           parsedStopStrings, stopError));
+    CHECK(stopTokenIds.size() == 1);
+    CHECK(stopTokenIds.count(7) == 1);
+    CHECK(parsedStopSequences ==
+          std::vector<std::vector<int>>({{1, 2}}));
+    CHECK(stopError.find("string or an array of strings") !=
+          std::string::npos);
+
+    CHECK(!ParseOpenAIStop(json11::Json(true), encodeStop,
+                           stopTokenIds, parsedStopSequences,
+                           parsedStopStrings, stopError));
+    CHECK(stopTokenIds.size() == 1);
+    CHECK(stopTokenIds.count(7) == 1);
+    CHECK(stopError.find("string or an array of strings") !=
+          std::string::npos);
+
+    CHECK(!ParseOpenAIStop(json11::Json(""), encodeStop,
+                           stopTokenIds, parsedStopSequences,
+                           parsedStopStrings, stopError));
+    CHECK(stopTokenIds.size() == 1);
+    CHECK(stopTokenIds.count(7) == 1);
+    CHECK(stopError.find("must not be empty") != std::string::npos);
+    CHECK(parsedStopStrings.empty());
+
+    std::vector<std::vector<int>> stopSequences{{11, 12, 13}};
+    std::vector<int> pendingStopTokens;
+    std::vector<int> readyTokens;
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 11,
+                        readyTokens) == 0);
+    CHECK(readyTokens.empty());
+    CHECK(pendingStopTokens == std::vector<int>{11});
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 12,
+                        readyTokens) == 0);
+    CHECK(readyTokens.empty());
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 13,
+                        readyTokens) == 3);
+    CHECK(readyTokens.empty());
+    CHECK(pendingStopTokens.empty());
+
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 11,
+                        readyTokens) == 0);
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 99,
+                        readyTokens) == 0);
+    CHECK(readyTokens == std::vector<int>({11, 99}));
+    CHECK(pendingStopTokens.empty());
+
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 11,
+                        readyTokens) == 0);
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 11,
+                        readyTokens) == 0);
+    CHECK(readyTokens == std::vector<int>{11});
+    CHECK(pendingStopTokens == std::vector<int>{11});
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 12,
+                        readyTokens) == 0);
+    FlushPendingStopTokens(pendingStopTokens, readyTokens);
+    CHECK(readyTokens == std::vector<int>({11, 12}));
+    CHECK(pendingStopTokens.empty());
+
+    stopSequences = {{21, 22}, {22, 23}};
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 21,
+                        readyTokens) == 0);
+    CHECK(PushStopToken(stopSequences, pendingStopTokens, 22,
+                        readyTokens) == 2);
+    CHECK(readyTokens.empty());
+    CHECK(pendingStopTokens.empty());
+
+    pendingStopTokens = {31, 32};
+    std::vector<int> emittedTokens;
+    FlushPendingStopTokensTo(pendingStopTokens, [&](int token) {
+        emittedTokens.push_back(token);
+    });
+    CHECK(emittedTokens == std::vector<int>({31, 32}));
+    CHECK(pendingStopTokens.empty());
+
+    std::vector<std::string> stopStrings{"<|end|>"};
+    std::string pendingStopText;
+    std::string readyText;
+    CHECK(!PushStopText(stopStrings, pendingStopText, "answer?<",
+                        readyText));
+    CHECK(readyText == "answer?");
+    CHECK(pendingStopText == "<");
+    CHECK(!PushStopText(stopStrings, pendingStopText, "|end",
+                        readyText));
+    CHECK(readyText.empty());
+    CHECK(pendingStopText == "<|end");
+    CHECK(PushStopText(stopStrings, pendingStopText, "|>ignored",
+                       readyText));
+    CHECK(readyText.empty());
+    CHECK(pendingStopText.empty());
+
+    CHECK(!PushStopText(stopStrings, pendingStopText, "plain text",
+                        readyText));
+    CHECK(readyText == "plain text");
+    CHECK(pendingStopText.empty());
+
+#ifndef _WIN32
+    int sockets[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+
+    const char payload[] = "ready";
+    CHECK(WriteAllToSocket(sockets[0], payload, sizeof(payload) - 1));
+    char received[sizeof(payload)] = {};
+    CHECK(read(sockets[1], received, sizeof(payload) - 1) ==
+          static_cast<ssize_t>(sizeof(payload) - 1));
+    CHECK(std::memcmp(payload, received, sizeof(payload) - 1) == 0);
+
+    close(sockets[1]);
+    CHECK(!WriteAllToSocket(sockets[0], payload, sizeof(payload) - 1));
+    close(sockets[0]);
+#endif
+    return 0;
+}

--- a/test/apiserver/socketWriteTest.cpp
+++ b/test/apiserver/socketWriteTest.cpp
@@ -10,6 +10,8 @@
 #endif
 
 #include "../../example/apiserver/socket_writer.h"
+#include "../../example/apiserver/http_request_reader.h"
+#include "../../example/apiserver/openai_output_parser.h"
 #include "../../example/apiserver/stop_parser.h"
 #include "../../include/utils/stop_token_matcher.h"
 #include "../../include/utils/stop_string_matcher.h"
@@ -28,6 +30,26 @@ int main() {
     CHECK(FormatSseData("[DONE]") == "data: [DONE]\r\n\r\n");
     CHECK(FormatSseData("{\n\t\"ok\": true\n}") ==
           "data: {\r\ndata: \t\"ok\": true\r\ndata: }\r\n\r\n");
+
+    CHECK(ResolveOpenAIFinishReason(false, false, 42, 256) == "stop");
+    CHECK(ResolveOpenAIFinishReason(false, false, 256, 256) == "length");
+    CHECK(ResolveOpenAIFinishReason(false, true, 256, 256) == "stop");
+    CHECK(ResolveOpenAIFinishReason(true, false, 256, 256) == "tool_calls");
+
+    const std::string getRequest =
+        "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    CHECK(IsHttpRequestComplete(getRequest.data(), getRequest.size()));
+    const std::string emptyPost =
+        "POST /v1/chat/completions HTTP/1.1\r\n"
+        "Host: localhost\r\nContent-Length: 0\r\n\r\n";
+    CHECK(IsHttpRequestComplete(emptyPost.data(), emptyPost.size()));
+    const std::string partialPost =
+        "POST /v1/chat/completions HTTP/1.1\r\n"
+        "Content-Length: 5\r\n\r\nabc";
+    CHECK(!IsHttpRequestComplete(partialPost.data(), partialPost.size()));
+    const std::string completePost = partialPost + "de";
+    CHECK(IsHttpRequestComplete(completePost.data(), completePost.size()));
+    CHECK(!IsHttpRequestComplete("GET /health HTTP/1.1\r\n", 22));
 
     auto encodeStop = [](const std::string &stop) {
         OpenAIStopEncoding encoding;
@@ -199,6 +221,109 @@ int main() {
                         readyText));
     CHECK(readyText == "plain text");
     CHECK(pendingStopText.empty());
+
+    CHECK(OpenAIReasoningParser::PromptEndsInReasoning(
+        "<|im_start|>assistant\n<think>\n"));
+    CHECK(!OpenAIReasoningParser::PromptEndsInReasoning(
+        "<|im_start|>assistant\n<think>\n\n</think>\n\n"));
+    CHECK(OpenAIReasoningParser::PromptEndsInReasoning(
+        "<think>old</think><think>new"));
+
+    OpenAIReasoningParser reasoningParser(true);
+    std::string reasoningText;
+    std::string answerText;
+    for (const std::string &fragment :
+         std::vector<std::string>{"work", "\n", "</", "think", ">",
+                                  "\n", "OK"}) {
+        OpenAIReasoningDelta delta = reasoningParser.Push(fragment);
+        reasoningText += delta.reasoningContent;
+        answerText += delta.content;
+    }
+    CHECK(reasoningText == "work\n");
+    CHECK(answerText == "\nOK");
+    CHECK(reasoningParser.Flush().Empty());
+
+    OpenAIReasoningParser longMarkerParser(true);
+    OpenAIReasoningDelta longMarkerDelta =
+        longMarkerParser.Push("analysis</thinking>answer");
+    CHECK(longMarkerDelta.reasoningContent == "analysis");
+    CHECK(longMarkerDelta.content == "answer");
+
+    OpenAIReasoningParser disabledReasoningParser(false);
+    OpenAIReasoningDelta disabledDelta =
+        disabledReasoningParser.Push("plain answer");
+    CHECK(disabledDelta.reasoningContent.empty());
+    CHECK(disabledDelta.content == "plain answer");
+
+    OpenAIReasoningParser unclosedReasoningParser(true);
+    OpenAIReasoningDelta unclosedDelta =
+        unclosedReasoningParser.Push("unfinished </thi");
+    OpenAIReasoningDelta unclosedTrailing = unclosedReasoningParser.Flush();
+    CHECK(unclosedDelta.reasoningContent +
+          unclosedTrailing.reasoningContent == "unfinished </thi");
+    CHECK(unclosedDelta.content.empty());
+    CHECK(unclosedTrailing.content.empty());
+
+    OpenAIToolCallParser toolParser(true);
+    std::string toolText;
+    std::vector<OpenAIParsedToolCall> parsedToolCalls;
+    for (const std::string &fragment : std::vector<std::string>{
+             "\n<tool", "_call>\n<function=builtin_", "web_search>\n",
+             "</function>\n</tool_call>"}) {
+        OpenAIToolCallDelta delta = toolParser.Push(fragment);
+        toolText += delta.content;
+        parsedToolCalls.insert(parsedToolCalls.end(), delta.toolCalls.begin(),
+                               delta.toolCalls.end());
+    }
+    CHECK(toolText == "\n");
+    CHECK(parsedToolCalls.size() == 1);
+    CHECK(parsedToolCalls[0].name == "builtin_web_search");
+    CHECK(parsedToolCalls[0].arguments == "{}");
+    CHECK(toolParser.Flush().Empty());
+
+    OpenAIToolCallParser typoToolParser(true);
+    OpenAIToolCallDelta typoToolDelta = typoToolParser.Push(
+        "<tool_call>\n<fuction=builtin_web_search>\n"
+        "<parameter=query>\n原神 最新消息 2024\n</parameter>\n"
+        "</function>\n</tool_call>");
+    CHECK(typoToolDelta.content.empty());
+    CHECK(typoToolDelta.toolCalls.size() == 1);
+    CHECK(typoToolDelta.toolCalls[0].name == "builtin_web_search");
+    CHECK(typoToolDelta.toolCalls[0].arguments ==
+          "{\"query\":\"原神 最新消息 2024\"}");
+
+    OpenAIToolCallParser parameterToolParser(true);
+    OpenAIToolCallDelta parameterDelta = parameterToolParser.Push(
+        "<tool_call>\n<function=search>\n"
+        "<parameter=query>\n原神 latest\n</parameter>\n"
+        "<parameter=limit>\n3\n</parameter>\n"
+        "</function>\n</tool_call>\n"
+        "<tool_call>\n<function=lookup>\n"
+        "<parameter=filters>\n{\"lang\":\"zh\"}\n</parameter>\n"
+        "</function>\n</tool_call>");
+    CHECK(parameterDelta.toolCalls.size() == 2);
+    CHECK(parameterDelta.toolCalls[0].name == "search");
+    CHECK(parameterDelta.toolCalls[0].arguments ==
+          "{\"limit\":3,\"query\":\"原神 latest\"}");
+    CHECK(parameterDelta.toolCalls[1].name == "lookup");
+    CHECK(parameterDelta.toolCalls[1].arguments ==
+          "{\"filters\":{\"lang\":\"zh\"}}");
+
+    OpenAIToolCallParser disabledToolParser(false);
+    OpenAIToolCallDelta disabledToolDelta = disabledToolParser.Push(
+        "literal <tool_call><function=demo></function></tool_call>");
+    CHECK(disabledToolDelta.content ==
+          "literal <tool_call><function=demo></function></tool_call>");
+    CHECK(disabledToolDelta.toolCalls.empty());
+
+    OpenAIToolCallParser unfinishedToolParser(true);
+    OpenAIToolCallDelta unfinishedToolDelta = unfinishedToolParser.Push(
+        "before<tool_call><function=demo>");
+    OpenAIToolCallDelta unfinishedToolTrailing = unfinishedToolParser.Flush();
+    CHECK(unfinishedToolDelta.content + unfinishedToolTrailing.content ==
+          "before<tool_call><function=demo>");
+    CHECK(unfinishedToolDelta.toolCalls.empty());
+    CHECK(unfinishedToolTrailing.toolCalls.empty());
 
 #ifndef _WIN32
     int sockets[2];

--- a/test/benchmark/test_benchmark_metrics.py
+++ b/test/benchmark/test_benchmark_metrics.py
@@ -1,0 +1,107 @@
+import importlib
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_DIR = REPO_ROOT / "tools"
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+benchmark = importlib.import_module("fastllm_pytools.benchmark")
+
+
+class FakeFastllmLib:
+    def __init__(self):
+        self.next_handle = 1
+        self.finished = set()
+        self.fetches = {}
+
+    def launch_response_llm_model(self, *args):
+        handle = self.next_handle
+        self.next_handle += 1
+        self.fetches[handle] = [100 + handle, -1]
+        return handle
+
+    def can_fetch_response_llm_model(self, model, handle):
+        return True
+
+    def fetch_response_llm_model(self, model, handle):
+        token = self.fetches[handle].pop(0)
+        if token <= -1:
+            self.finished.add(handle)
+        return token
+
+
+class FakeModel:
+    model = 7
+
+    def __init__(self, fastllm_lib):
+        self.fastllm_lib = fastllm_lib
+
+    def stop_token_ctypes(self, stop_token_ids):
+        return 0, None
+
+    def get_response_statistics(self, handle):
+        if handle in self.fastllm_lib.finished:
+            return None
+        return {
+            "cached_input_tokens": handle - 1,
+            "missed_input_tokens": 3 - (handle - 1),
+            "output_tokens": 1,
+        }
+
+
+def test_run_batch_records_native_cache_statistics():
+    fake_llm = types.ModuleType("fastllm_pytools.llm")
+    fake_llm.fastllm_lib = FakeFastllmLib()
+    model = FakeModel(fake_llm.fastllm_lib)
+    original_llm = sys.modules.get("fastllm_pytools.llm")
+    sys.modules["fastllm_pytools.llm"] = fake_llm
+    try:
+        result = benchmark._run_batch(
+            model,
+            [1, 2, 3],
+            output_tokens=1,
+            batch=2,
+            generation_args={
+                "do_sample": False,
+                "top_p": 1.0,
+                "top_k": 1,
+                "temperature": 1.0,
+                "repeat_penalty": 1.0,
+            },
+        )
+    finally:
+        if original_llm is None:
+            sys.modules.pop("fastllm_pytools.llm", None)
+        else:
+            sys.modules["fastllm_pytools.llm"] = original_llm
+
+    assert result["response_statistics_available"] is True
+    assert result["cached_input_tokens"] == 1
+    assert result["missed_input_tokens"] == 5
+    assert result["native_output_tokens"] == 2
+    assert result["requests"][0]["response_statistics"] == {
+        "cached_input_tokens": 0,
+        "missed_input_tokens": 3,
+        "output_tokens": 1,
+    }
+
+
+def test_write_result_json_is_machine_readable():
+    result = {"input_tokens": 3, "requests": [{"finish_code": -1}]}
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output = Path(temp_dir) / "result.json"
+        benchmark._write_result_json(output, result)
+        assert json.loads(output.read_text(encoding="utf-8")) == result
+        assert not (Path(str(output) + ".tmp")).exists()
+
+
+if __name__ == "__main__":
+    test_run_batch_records_native_cache_statistics()
+    test_write_result_json_is_machine_readable()
+    print("benchmark metrics tests passed")

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -15,6 +15,7 @@
 #include "devices/cpu/cpudevice.h"
 #include "devices/cuda/cudadevice.h"
 #include "devices/cuda/fastllm-cuda.cuh"
+#include "devices/cuda/attention/fastllm-paged-attention-native.cuh"
 #include "devices/multicuda/fastllm-multicuda.cuh"
 #endif
 
@@ -2878,6 +2879,395 @@ namespace {
                    "recurrent sequence accepted N=11");
         }
     }
+    void RunCudaSm70PagedGqa6DecodeRegression() {
+        if (getCudaInfos()->cudaArch != 700) {
+            std::cout << "SM70 paged GQA6 decode regression: SKIP (requires CC 7.0)\n";
+            return;
+        }
+
+        constexpr int batch = 1;
+        constexpr int numKvHeads = 4;
+        constexpr int group = 6;
+        constexpr int numQHeads = numKvHeads * group;
+        constexpr int headDim = 256;
+        constexpr int pageLen = 128;
+        constexpr int maxPages = 4;
+        const float scale = 1.0f / std::sqrt((float)headDim);
+
+        fastllm::Data q = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+            MakeRegressionValues(numQHeads * batch * headDim, 0.41f, 0.04f));
+        fastllm::Data cacheDesc = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numKvHeads, 1, headDim},
+            std::vector<float>(numKvHeads * headDim, 0.0f));
+        fastllm::PagedCacheManager *pagedK = fastllm::AllocatePagedCacheManager(
+            60000, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        fastllm::PagedCacheManager *pagedV = fastllm::AllocatePagedCacheManager(
+            60001, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        fastllm::Data pagedKValues = MakeCudaTensor(
+            fastllm::DataType::FLOAT16,
+            {maxPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(maxPages * pageLen * numKvHeads * headDim,
+                                 0.83f, 0.03f));
+        fastllm::Data pagedVValues = MakeCudaTensor(
+            fastllm::DataType::FLOAT16,
+            {maxPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(maxPages * pageLen * numKvHeads * headDim,
+                                 1.27f, 0.05f));
+        FastllmCudaCopyFromDeviceToDevice(
+            pagedK->cudaData, pagedKValues.cudaData, pagedKValues.GetBytes());
+        FastllmCudaCopyFromDeviceToDevice(
+            pagedV->cudaData, pagedVValues.cudaData, pagedVValues.GetBytes());
+
+        fastllm::Data kCaches(fastllm::DataType::FLOAT16);
+        fastllm::Data vCaches(fastllm::DataType::FLOAT16);
+        kCaches.Resize({numKvHeads, 1, headDim});
+        vCaches.Resize({numKvHeads, 1, headDim});
+        kCaches.isKVCache = vCaches.isKVCache = true;
+        kCaches.isPagedKVCache = vCaches.isPagedKVCache = true;
+        kCaches.pageLen = vCaches.pageLen = pageLen;
+        kCaches.pagedKVCacheData = pagedK;
+        vCaches.pagedKVCacheData = pagedV;
+
+        fastllm::Data qSizes = MakeIntTensor({batch + 1}, {0, 1});
+        qSizes.ToDevice(fastllm::DataDevice::CUDA);
+        for (const auto &fixture : std::vector<std::pair<std::vector<int32_t>, int>>{
+                 {{2}, 17}, {{2, 0}, 1}, {{2, 0, 3}, 17}}) {
+            const std::vector<int32_t> &physicalPages = fixture.first;
+            int lastPageLen = fixture.second;
+            fastllm::Data pageSizes = MakeIntTensor(
+                {batch + 1}, {0, (int32_t)physicalPages.size()});
+            fastllm::Data pageIndexs = MakeIntTensor(
+                {(int)physicalPages.size()}, physicalPages);
+            fastllm::Data lastPageLens = MakeIntTensor({batch}, {lastPageLen});
+            pageSizes.ToDevice(fastllm::DataDevice::CUDA);
+            pageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+            lastPageLens.ToDevice(fastllm::DataDevice::CUDA);
+
+            fastllm::Data reference = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                std::vector<float>(numQHeads * batch * headDim, 0.0f));
+            {
+                ScopedEnvVar disableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "0");
+                ScopedEnvVar disableNativeGqa("FASTLLM_PAGED_GQA_DECODE", "0");
+                Expect(FastllmCudaHalfPagedAttentionBatch(
+                           q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                           lastPageLens, reference, group, scale, 1,
+                           false, true, false, -1),
+                       "native per-Q-head paged decode rejected the SM70 fixture.");
+            }
+
+            fastllm::Data actual = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                std::vector<float>(numQHeads * batch * headDim, 0.0f));
+            {
+                ScopedEnvVar defaultSm70("FASTLLM_CUDA_SM70_PAGED_XQA", nullptr);
+                Expect(FastllmCudaTrySm70PagedAttentionDecode(
+                           q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                           lastPageLens, actual, group, scale, 1),
+                       "default SM70 paged GQA6 decode route rejected an eligible fixture.");
+            }
+            FastllmCudaSyncCurrentThreadStream();
+            int kvLen = ((int)physicalPages.size() - 1) * pageLen + lastPageLen;
+            ExpectFloatNear(ToFloatVector(reference), ToFloatVector(actual),
+                            3e-3f, 3e-3f,
+                            "SM70 paged GQA6 decode kvLen=" + std::to_string(kvLen));
+
+            if (physicalPages.size() == 3) {
+                fastllm::Data graphOutput = MakeCudaTensor(
+                    fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                    std::vector<float>(numQHeads * batch * headDim, 0.0f));
+                ScopedEnvVar defaultSm70("FASTLLM_CUDA_SM70_PAGED_XQA", nullptr);
+                Expect(FastllmCudaHalfPagedAttentionBatch(
+                           q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                           lastPageLens, graphOutput, group, scale, 1,
+                           false, true, false, -1),
+                       "SM70 paged XQA graph warmup failed.");
+                FastllmCudaMemset0(graphOutput.cudaData, graphOutput.GetBytes());
+                void *graph = nullptr;
+                void *graphExec = nullptr;
+                Expect(FastllmCudaGraphBeginCapture(),
+                       "SM70 paged XQA graph capture did not start.");
+                Expect(FastllmCudaHalfPagedAttentionBatch(
+                           q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                           lastPageLens, graphOutput, group, scale, 1,
+                           false, false, true, -1),
+                       "SM70 paged XQA rejected graph capture.");
+                Expect(FastllmCudaGraphEndCapture(&graph) && graph != nullptr,
+                       "SM70 paged XQA graph capture failed.");
+                Expect(FastllmCudaGraphInstantiate(graph, &graphExec) && graphExec != nullptr,
+                       "SM70 paged XQA graph instantiate failed.");
+                Expect(FastllmCudaGraphLaunch(graphExec),
+                       "SM70 paged XQA graph replay failed.");
+                ExpectFloatNear(ToFloatVector(reference), ToFloatVector(graphOutput),
+                                3e-3f, 3e-3f,
+                                "SM70 paged XQA graph replay");
+                FastllmCudaGraphExecDestroy(graphExec);
+                FastllmCudaGraphDestroy(graph);
+            }
+
+            fastllm::Data untouched = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                std::vector<float>(numQHeads * batch * headDim, 0.25f));
+            const std::vector<float> untouchedReference = ToFloatVector(untouched);
+            {
+                ScopedEnvVar enableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "1");
+                Expect(!FastllmCudaTrySm70PagedAttentionDecode(
+                           q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                           lastPageLens, untouched, 5, scale, 1),
+                       "SM70 paged decode accepted an unsupported GQA group.");
+            }
+            ExpectFloatNear(untouchedReference, ToFloatVector(untouched),
+                            0.0f, 0.0f,
+                            "rejected SM70 paged decode modified output");
+
+            fastllm::Data stridedOutput = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                std::vector<float>(numQHeads * batch * headDim, 0.25f));
+            const std::vector<uint64_t> contiguousStrides = stridedOutput.strides;
+            const std::vector<float> stridedReference = ToFloatVector(stridedOutput);
+            stridedOutput.strides[0] += headDim;
+            bool acceptedStridedOutput;
+            {
+                ScopedEnvVar enableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "1");
+                acceptedStridedOutput = FastllmCudaTrySm70PagedAttentionDecode(
+                    q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                    lastPageLens, stridedOutput, group, scale, 1);
+            }
+            FastllmCudaSyncCurrentThreadStream();
+            stridedOutput.strides = contiguousStrides;
+            Expect(!acceptedStridedOutput,
+                   "SM70 paged decode accepted a noncontiguous output view.");
+            ExpectFloatNear(stridedReference, ToFloatVector(stridedOutput),
+                            0.0f, 0.0f,
+                            "rejected SM70 paged decode modified strided output");
+        }
+
+        {
+            constexpr int batchTwo = 2;
+            fastllm::Data qBatch = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batchTwo, headDim},
+                MakeRegressionValues(numQHeads * batchTwo * headDim, 2.41f, 0.04f));
+            fastllm::Data qSizesBatch = MakeIntTensor({batchTwo + 1}, {0, 1, 2});
+            fastllm::Data pageSizesBatch = MakeIntTensor({batchTwo + 1}, {0, 2, 5});
+            fastllm::Data pageIndexsBatch = MakeIntTensor({5}, {3, 0, 2, 1, 3});
+            fastllm::Data lastPageLensBatch = MakeIntTensor({batchTwo}, {17, 29});
+            qSizesBatch.ToDevice(fastllm::DataDevice::CUDA);
+            pageSizesBatch.ToDevice(fastllm::DataDevice::CUDA);
+            pageIndexsBatch.ToDevice(fastllm::DataDevice::CUDA);
+            lastPageLensBatch.ToDevice(fastllm::DataDevice::CUDA);
+
+            fastllm::Data referenceBatch = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batchTwo, headDim},
+                std::vector<float>(numQHeads * batchTwo * headDim, 0.0f));
+            {
+                ScopedEnvVar disableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "0");
+                ScopedEnvVar disableNativeGqa("FASTLLM_PAGED_GQA_DECODE", "0");
+                Expect(FastllmCudaHalfPagedAttentionBatch(
+                           qBatch, kCaches, vCaches, qSizesBatch, pageSizesBatch,
+                           pageIndexsBatch, lastPageLensBatch, referenceBatch,
+                           group, scale, 1, false, true, false, -1),
+                       "native per-Q-head paged decode rejected batch-two fixture.");
+            }
+            fastllm::Data actualBatch = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batchTwo, headDim},
+                std::vector<float>(numQHeads * batchTwo * headDim, 0.0f));
+            {
+                ScopedEnvVar defaultSm70("FASTLLM_CUDA_SM70_PAGED_XQA", nullptr);
+                Expect(FastllmCudaTrySm70PagedAttentionDecode(
+                           qBatch, kCaches, vCaches, qSizesBatch, pageSizesBatch,
+                           pageIndexsBatch, lastPageLensBatch, actualBatch,
+                           group, scale, 1),
+                       "default SM70 paged XQA rejected batch-two fixture.");
+            }
+            FastllmCudaSyncCurrentThreadStream();
+            ExpectFloatNear(ToFloatVector(referenceBatch), ToFloatVector(actualBatch),
+                            3e-3f, 3e-3f,
+                            "SM70 paged XQA batch-two nonzero pageStart");
+        }
+
+        {
+            fastllm::Data qConcurrent[2] = {
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               MakeRegressionValues(numQHeads * headDim, 3.41f, 0.04f)),
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               MakeRegressionValues(numQHeads * headDim, 4.41f, 0.04f))
+            };
+            fastllm::Data qSizesConcurrent[2] = {
+                MakeIntTensor({2}, {0, 1}), MakeIntTensor({2}, {0, 1})
+            };
+            fastllm::Data pageSizesConcurrent[2] = {
+                MakeIntTensor({2}, {0, 3}), MakeIntTensor({2}, {0, 2})
+            };
+            fastllm::Data pageIndexsConcurrent[2] = {
+                MakeIntTensor({3}, {2, 0, 3}), MakeIntTensor({2}, {1, 3})
+            };
+            fastllm::Data lastPageLensConcurrent[2] = {
+                MakeIntTensor({1}, {17}), MakeIntTensor({1}, {29})
+            };
+            fastllm::Data referenceConcurrent[2] = {
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               std::vector<float>(numQHeads * headDim, 0.0f)),
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               std::vector<float>(numQHeads * headDim, 0.0f))
+            };
+            fastllm::Data actualConcurrent[2] = {
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               std::vector<float>(numQHeads * headDim, 0.0f)),
+                MakeCudaTensor(fastllm::DataType::FLOAT16,
+                               {numQHeads, batch, headDim},
+                               std::vector<float>(numQHeads * headDim, 0.0f))
+            };
+            for (int worker = 0; worker < 2; worker++) {
+                qSizesConcurrent[worker].ToDevice(fastllm::DataDevice::CUDA);
+                pageSizesConcurrent[worker].ToDevice(fastllm::DataDevice::CUDA);
+                pageIndexsConcurrent[worker].ToDevice(fastllm::DataDevice::CUDA);
+                lastPageLensConcurrent[worker].ToDevice(fastllm::DataDevice::CUDA);
+                ScopedEnvVar disableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "0");
+                ScopedEnvVar disableNativeGqa("FASTLLM_PAGED_GQA_DECODE", "0");
+                Expect(FastllmCudaHalfPagedAttentionBatch(
+                           qConcurrent[worker], kCaches, vCaches,
+                           qSizesConcurrent[worker], pageSizesConcurrent[worker],
+                           pageIndexsConcurrent[worker], lastPageLensConcurrent[worker],
+                           referenceConcurrent[worker], group, scale, 1,
+                           false, true, false, -1),
+                       "native per-Q-head concurrent reference failed.");
+            }
+            ScopedEnvVar defaultSm70("FASTLLM_CUDA_SM70_PAGED_XQA", nullptr);
+            std::exception_ptr workerErrors[2];
+            std::thread workers[2];
+            for (int worker = 0; worker < 2; worker++) {
+                workers[worker] = std::thread([&, worker]() {
+                    try {
+                        FastllmCudaSetDevice(0);
+                        Expect(FastllmCudaTrySm70PagedAttentionDecode(
+                                   qConcurrent[worker], kCaches, vCaches,
+                                   qSizesConcurrent[worker], pageSizesConcurrent[worker],
+                                   pageIndexsConcurrent[worker], lastPageLensConcurrent[worker],
+                                   actualConcurrent[worker], group, scale, 1),
+                               "concurrent SM70 paged XQA route rejected fixture.");
+                        FastllmCudaSyncCurrentThreadStream();
+                    } catch (...) {
+                        workerErrors[worker] = std::current_exception();
+                    }
+                });
+            }
+            for (int worker = 0; worker < 2; worker++) {
+                workers[worker].join();
+                if (workerErrors[worker] != nullptr) {
+                    std::rethrow_exception(workerErrors[worker]);
+                }
+                ExpectFloatNear(ToFloatVector(referenceConcurrent[worker]),
+                                ToFloatVector(actualConcurrent[worker]),
+                                3e-3f, 3e-3f,
+                                "SM70 paged XQA concurrent worker " +
+                                    std::to_string(worker));
+            }
+        }
+    }
+
+    void RunCudaSm70PagedGqa6DecodeBenchmark() {
+        if (getCudaInfos()->cudaArch != 700) {
+            throw std::runtime_error("sm70_paged_xqa_bench requires CC 7.0.");
+        }
+        constexpr int batch = 1;
+        constexpr int numKvHeads = 4;
+        constexpr int group = 6;
+        constexpr int numQHeads = numKvHeads * group;
+        constexpr int headDim = 256;
+        constexpr int pageLen = 128;
+        constexpr int maxTokens = 131072;
+        constexpr int maxPages = maxTokens / pageLen;
+        constexpr int warmup = 5;
+        constexpr int iterations = 30;
+        const float scale = 1.0f / std::sqrt((float)headDim);
+
+        fastllm::Data q = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+            MakeRegressionValues(numQHeads * headDim, 0.41f, 0.04f));
+        fastllm::Data cacheDesc = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numKvHeads, 1, headDim},
+            std::vector<float>(numKvHeads * headDim, 0.0f));
+        fastllm::PagedCacheManager *pagedK = fastllm::AllocatePagedCacheManager(
+            60002, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        fastllm::PagedCacheManager *pagedV = fastllm::AllocatePagedCacheManager(
+            60003, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        FastllmCudaMemset0(pagedK->cudaData, pagedK->GetBytes());
+        FastllmCudaMemset0(pagedV->cudaData, pagedV->GetBytes());
+
+        fastllm::Data kCaches(fastllm::DataType::FLOAT16);
+        fastllm::Data vCaches(fastllm::DataType::FLOAT16);
+        kCaches.Resize({numKvHeads, 1, headDim});
+        vCaches.Resize({numKvHeads, 1, headDim});
+        kCaches.isKVCache = vCaches.isKVCache = true;
+        kCaches.isPagedKVCache = vCaches.isPagedKVCache = true;
+        kCaches.pageLen = vCaches.pageLen = pageLen;
+        kCaches.pagedKVCacheData = pagedK;
+        vCaches.pagedKVCacheData = pagedV;
+
+        fastllm::Data qSizes = MakeIntTensor({2}, {0, 1});
+        qSizes.ToDevice(fastllm::DataDevice::CUDA);
+        std::cout << "route,kv_tokens,avg_ms,speedup_vs_per_q_head\n";
+        for (int kvTokens : {8192, 32768, 131072}) {
+            int pages = kvTokens / pageLen;
+            std::vector<int32_t> physicalPages(pages);
+            std::iota(physicalPages.begin(), physicalPages.end(), 0);
+            fastllm::Data pageSizes = MakeIntTensor({2}, {0, pages});
+            fastllm::Data pageIndexs = MakeIntTensor({pages}, physicalPages);
+            fastllm::Data lastPageLens = MakeIntTensor({1}, {pageLen});
+            pageSizes.ToDevice(fastllm::DataDevice::CUDA);
+            pageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+            lastPageLens.ToDevice(fastllm::DataDevice::CUDA);
+            fastllm::Data output = MakeCudaTensor(
+                fastllm::DataType::FLOAT16, {numQHeads, batch, headDim},
+                std::vector<float>(numQHeads * headDim, 0.0f));
+
+            auto measure = [&](bool xqa) {
+                ScopedEnvVar sm70Route("FASTLLM_CUDA_SM70_PAGED_XQA", xqa ? "1" : "0");
+                ScopedEnvVar nativeGqa("FASTLLM_PAGED_GQA_DECODE", "0");
+                for (int i = 0; i < warmup; i++) {
+                    Expect(FastllmCudaHalfPagedAttentionBatch(
+                               q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                               lastPageLens, output, group, scale, 1,
+                               false, false, false, -1),
+                           "paged decode benchmark route rejected its fixture.");
+                }
+                FastllmCudaSyncCurrentThreadStream();
+                void *start = FastllmCudaEventCreateTiming();
+                void *end = FastllmCudaEventCreateTiming();
+                FastllmCudaEventRecordCurrentThread(start);
+                for (int i = 0; i < iterations; i++) {
+                    Expect(FastllmCudaHalfPagedAttentionBatch(
+                               q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                               lastPageLens, output, group, scale, 1,
+                               false, false, false, -1),
+                           "paged decode benchmark route failed during timing.");
+                }
+                FastllmCudaEventRecordCurrentThread(end);
+                FastllmCudaEventSynchronize(end);
+                float averageMs = FastllmCudaEventElapsedTime(start, end) / iterations;
+                FastllmCudaEventDestroy(start);
+                FastllmCudaEventDestroy(end);
+                return averageMs;
+            };
+
+            float perQHeadMs = measure(false);
+            float xqaMs = measure(true);
+            std::cout << "per_q_head," << kvTokens << ',' << perQHeadMs << ",1\n";
+            std::cout << "sm70_xqa," << kvTokens << ',' << xqaMs << ','
+                      << (perQHeadMs / xqaMs) << '\n';
+        }
+    }
+
 #endif
 
     struct PastKeyBatch {
@@ -4877,6 +5267,29 @@ int main() {
             throw std::runtime_error("iq4xs_mmq_bench requires a CUDA build.");
 #endif
         }
+        if (only != nullptr && std::string(only) == "sm70_paged_xqa_bench") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("sm70_paged_xqa_bench requires CUDA.");
+            }
+            RunCudaSm70PagedGqa6DecodeBenchmark();
+            return 0;
+#else
+            throw std::runtime_error("sm70_paged_xqa_bench requires a CUDA build.");
+#endif
+        }
+        if (only != nullptr && std::string(only) == "sm70_paged_xqa") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("sm70_paged_xqa regression requires CUDA.");
+            }
+            RunCudaSm70PagedGqa6DecodeRegression();
+            std::cout << "SM70 paged GQA6 decode regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error("sm70_paged_xqa regression requires a CUDA build.");
+#endif
+        }
         bool ranAny = false;
         if (only != nullptr && std::string(only) == "mtp9_snapshots") {
 #ifdef USE_CUDA
@@ -4966,6 +5379,7 @@ int main() {
             RunCudaInt8Batch1MoeRegression();
             RunCudaGgufIq4xsQ5DequantRegression();
             RunCudaConvMultiTokenSnapshotsRegression();
+            RunCudaSm70PagedGqa6DecodeRegression();
             ranCrossDeviceViewRegression = RunCudaCrossDeviceViewRejectionRegression();
             RunMultiCudaReplicatedExpansionRegression();
 #ifndef USE_ROCM

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -3327,6 +3327,52 @@ namespace {
                         3e-3f, 3e-3f,
                         "SM70 FlashAttention qLen2 four-page FP8");
 
+        constexpr int mtpQLen = 3;
+        fastllm::Data mtpQ = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, mtpQLen, headDim},
+            MakeRegressionValues(numQHeads * mtpQLen * headDim, 2.73f, 0.035f));
+        fastllm::Data mtpQSizes = MakeIntTensor({2}, {0, mtpQLen});
+        fastllm::Data mtpPageSizes = MakeIntTensor({2}, {0, 1});
+        fastllm::Data mtpPageIndexs = MakeIntTensor({1}, {2});
+        fastllm::Data mtpLastPage = MakeIntTensor({1}, {17});
+        mtpQSizes.ToDevice(fastllm::DataDevice::CUDA);
+        mtpPageSizes.ToDevice(fastllm::DataDevice::CUDA);
+        mtpPageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+        mtpLastPage.ToDevice(fastllm::DataDevice::CUDA);
+        fastllm::Data mtpReference = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, mtpQLen, headDim},
+            std::vector<float>(numQHeads * mtpQLen * headDim, 0.0f));
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(FastllmCudaHalfPagedAttentionBatch(
+                       mtpQ, kCaches, vCaches, mtpQSizes, mtpPageSizes,
+                       mtpPageIndexs, mtpLastPage, mtpReference, group,
+                       scale, 1, false, true, false, -1),
+                   "native prefill rejected the MTP qLen3 FP8 fixture.");
+        }
+        fastllm::Data mtpActual = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, mtpQLen, headDim},
+            std::vector<float>(numQHeads * mtpQLen * headDim, 0.0f));
+        Expect(FastllmCudaHalfPagedAttentionBatch(
+                   mtpQ, kCaches, vCaches, mtpQSizes, mtpPageSizes,
+                   mtpPageIndexs, mtpLastPage, mtpActual, group,
+                   scale, 1, false, true, false, -1),
+               "SM70 FlashAttention public route rejected MTP qLen3 FP8.");
+        FastllmCudaSyncCurrentThreadStream();
+        const std::vector<int> expectedMtpOutputDims =
+            {mtpQLen, numQHeads, headDim};
+        const std::vector<uint64_t> expectedMtpOutputStrides =
+            {(uint64_t)numQHeads * headDim, (uint64_t)headDim, 1};
+        Expect(mtpReference.dims == expectedMtpOutputDims &&
+                   mtpReference.strides == expectedMtpOutputStrides,
+               "native MTP qLen3 output violated the token-major contract.");
+        Expect(mtpActual.dims == expectedMtpOutputDims &&
+                   mtpActual.strides == expectedMtpOutputStrides,
+               "SM70 MTP qLen3 output violated the token-major contract.");
+        ExpectFloatNear(ToFloatVector(mtpReference), ToFloatVector(mtpActual),
+                        3e-3f, 3e-3f,
+                        "SM70 FlashAttention MTP qLen3 token-major output");
+
         constexpr int raggedBatch = 5;
         constexpr int raggedTokens = 30;
         fastllm::Data raggedQ = MakeCudaTensor(

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -67,6 +67,41 @@ namespace {
     private:
         std::filesystem::path path;
     };
+    int SetRegressionEnv(const std::string &name, const char *value) {
+#ifdef _WIN32
+        return _putenv_s(name.c_str(), value == nullptr ? "" : value);
+#else
+        return value == nullptr ? unsetenv(name.c_str()) :
+            setenv(name.c_str(), value, 1);
+#endif
+    }
+
+    class ScopedEnvVar {
+    public:
+        ScopedEnvVar(const std::string &name, const char *value) : name(name) {
+            const char *current = std::getenv(name.c_str());
+            hadValue = current != nullptr;
+            if (hadValue) {
+                oldValue = current;
+            }
+            int rc = SetRegressionEnv(name, value);
+            if (rc != 0) {
+                throw std::runtime_error("failed to update regression environment variable: " + name);
+            }
+        }
+
+        ~ScopedEnvVar() {
+            SetRegressionEnv(name, hadValue ? oldValue.c_str() : nullptr);
+        }
+
+        ScopedEnvVar(const ScopedEnvVar &) = delete;
+        ScopedEnvVar &operator=(const ScopedEnvVar &) = delete;
+
+    private:
+        std::string name;
+        std::string oldValue;
+        bool hadValue = false;
+    };
 
     class MoeAtypeConfigTestModel final : public fastllm::basellm {
     public:
@@ -200,7 +235,51 @@ namespace {
 
     std::string MakeTempGGUFPath(const std::string &name) {
         auto ticks = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-        return "/tmp/" + name + "-" + std::to_string(ticks) + ".gguf";
+        return (std::filesystem::temp_directory_path() /
+                (name + "-" + std::to_string(ticks) + ".gguf")).string();
+    }
+
+    void RunRegressionFixtureScopeRegression() {
+        const std::string envName = "FASTLLM_REGRESSION_SCOPED_ENV_TEST";
+        const char *original = std::getenv(envName.c_str());
+        const bool hadOriginal = original != nullptr;
+        const std::string originalValue = hadOriginal ? original : "";
+
+        {
+            ScopedEnvVar outer(envName, "outer");
+            Expect(std::string(std::getenv(envName.c_str())) == "outer",
+                   "scoped environment fixture did not apply a value.");
+            {
+                ScopedEnvVar inner(envName, "inner");
+                Expect(std::string(std::getenv(envName.c_str())) == "inner",
+                       "nested environment fixture did not apply a value.");
+            }
+            Expect(std::string(std::getenv(envName.c_str())) == "outer",
+                   "nested environment fixture did not restore its parent value.");
+        }
+        const char *restored = std::getenv(envName.c_str());
+        Expect((hadOriginal && restored != nullptr && originalValue == restored) ||
+                   (!hadOriginal && restored == nullptr),
+               "environment fixture did not restore the original value.");
+
+        {
+            ScopedEnvVar unset(envName, nullptr);
+            Expect(std::getenv(envName.c_str()) == nullptr,
+                   "environment fixture did not apply an unset value.");
+            {
+                ScopedEnvVar inner(envName, "temporary");
+            }
+            Expect(std::getenv(envName.c_str()) == nullptr,
+                   "environment fixture did not restore an unset parent value.");
+        }
+        restored = std::getenv(envName.c_str());
+        Expect((hadOriginal && restored != nullptr && originalValue == restored) ||
+                   (!hadOriginal && restored == nullptr),
+               "unset environment fixture did not restore the original value.");
+
+        std::filesystem::path ggufPath = MakeTempGGUFPath("fastllm-fixture-scope");
+        Expect(ggufPath.parent_path() == std::filesystem::temp_directory_path(),
+               "synthetic GGUF fixture ignored the platform temporary directory.");
     }
 
     void WriteSyntheticQwen35GGUF(const std::string &path,
@@ -479,11 +558,9 @@ namespace {
     }
 
     void RunQwen35MixedQuantGGUFProjectionRegression() {
-        std::string path = MakeTempGGUFPath("fastllm-qwen35-mixed-quant");
-        const char *oldTiled = std::getenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
-        const bool hadTiled = oldTiled != nullptr;
-        const std::string oldTiledValue = hadTiled ? oldTiled : "";
-        setenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED", "0", 1);
+        ScopedTempDirectory tempDir("fastllm-qwen35-mixed-quant-");
+        std::string path = (tempDir.Path() / "model.gguf").string();
+        ScopedEnvVar tiledLayout("FASTLLM_QWEN35_GGUF_VHEAD_TILED", "0");
         WriteSyntheticQwen35GGUF(path, {
             MakeSyntheticQuantTensor("blk.0.attn_qkv.weight", {256, 256}, GGML_TYPE_Q5_K),
             MakeSyntheticQuantTensor("blk.0.attn_gate.weight", {256, 256}, GGML_TYPE_IQ4_XS),
@@ -494,12 +571,6 @@ namespace {
             MakeSyntheticQuantTensor("blk.3.attn_v.weight", {256, 256}, GGML_TYPE_Q5_K),
         });
         auto model = fastllm::CreateLLMModelFromGGUFFile(path, "");
-        if (hadTiled) {
-            setenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED", oldTiledValue.c_str(), 1);
-        } else {
-            unsetenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
-        }
-        std::remove(path.c_str());
 
         const std::string gdnPrefix = "model.language_model.layers.0.linear_attn.";
         RequireWeight(*model, gdnPrefix + "in_proj_qkv.weight");
@@ -573,22 +644,41 @@ namespace {
 
     void RunQwen35SplitGdnProjectionLayoutRegression() {
         const std::string prefix = "model.language_model.layers.0.";
-        fastllm::WeightMap weights;
-        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_qkv.weight", {10, 4},
-                               fastllm::DataType::FLOAT32);
-        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_z.weight", {6, 4},
-                               fastllm::DataType::FLOAT32);
-        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_ba.weight", {4, 4},
-                               fastllm::DataType::FLOAT32);
+        auto add = [&](fastllm::WeightMap &weights, const std::string &suffix) {
+            weights.AddEmptyWeight(prefix + suffix, {4, 4},
+                                   fastllm::DataType::FLOAT32);
+        };
 
-        Expect(fastllm::ResolveQwen35GdnProjectionLayout(weights, prefix) ==
+        fastllm::WeightMap qkvZBa;
+        add(qkvZBa, "linear_attn.in_proj_qkv.weight");
+        add(qkvZBa, "linear_attn.in_proj_z.weight");
+        add(qkvZBa, "linear_attn.in_proj_ba.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(qkvZBa, prefix) ==
                    fastllm::Qwen35GdnProjectionLayout::QkvZBa,
-               "qwen35 mixed-quant qkv/z plus ba should be a valid GDN projection layout.");
+               "qwen35 qkv/z plus ba should be a valid GDN projection layout.");
 
-        weights.weight.erase(prefix + "linear_attn.in_proj_z.weight");
-        Expect(fastllm::ResolveQwen35GdnProjectionLayout(weights, prefix) ==
+        qkvZBa.weight.erase(prefix + "linear_attn.in_proj_z.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(qkvZBa, prefix) ==
                    fastllm::Qwen35GdnProjectionLayout::Missing,
                "qwen35 split GDN projection must require both qkv and z weights.");
+
+        fastllm::WeightMap qkvzBa;
+        add(qkvzBa, "linear_attn.in_proj_qkvz.weight");
+        add(qkvzBa, "linear_attn.in_proj_ba.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(qkvzBa, prefix) ==
+                   fastllm::Qwen35GdnProjectionLayout::QkvzBa,
+               "qwen35 qkvz plus ba should be a valid GDN projection layout.");
+
+        fastllm::WeightMap qkvzba;
+        add(qkvzba, "linear_attn.in_proj_qkvzba.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(qkvzba, prefix) ==
+                   fastllm::Qwen35GdnProjectionLayout::Qkvzba,
+               "qwen35 merged qkvzba should be a valid GDN projection layout.");
+        add(qkvzba, "linear_attn.in_proj_qkvz.weight");
+        add(qkvzba, "linear_attn.in_proj_ba.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(qkvzba, prefix) ==
+                   fastllm::Qwen35GdnProjectionLayout::Qkvzba,
+               "qwen35 merged qkvzba must take precedence over split weights.");
     }
 
     void ExpectFloatNear(const std::vector<float> &expected,
@@ -690,11 +780,16 @@ namespace {
         Expect(rejected, "unsupported KV cache dtype was not rejected.");
 
         MoeAtypeConfigTestModel model;
-        model.kvCacheDataType = fastllm::DataType::FLOAT16;
+        model.SetKVCacheDataType(fastllm::DataType::FLOAT16);
+        Expect(model.useCustomKVCacheDataType &&
+               model.kvCacheDataType == fastllm::DataType::FLOAT16,
+               "explicit F16 KV cache dtype was not preserved.");
+#ifdef USE_CUDA
         model.SetKVCacheDataType(fastllm::ParseKVCacheDataType("fp8_e4m3"));
         Expect(model.useCustomKVCacheDataType &&
                model.kvCacheDataType == fastllm::DataType::FP8_E4M3,
-               "explicit FP8 KV cache dtype was not preserved after F16 activation setup.");
+               "explicit FP8 KV cache dtype was not preserved after F16 setup.");
+#endif
     }
 
     void RunQwen35DecodePageBudgetRegression() {
@@ -3514,25 +3609,15 @@ namespace {
                                 std::vector<int>{0}, false);
         std::vector<fastllm::Data*> biases(weights.size(), nullptr);
 
-        const char *oldSmallBatchEnv =
-            std::getenv("FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH");
-        const bool hadSmallBatchEnv = oldSmallBatchEnv != nullptr;
-        const std::string oldSmallBatchEnvValue =
-            hadSmallBatchEnv ? oldSmallBatchEnv : "";
-        setenv("FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH", "0", 1);
         {
+            ScopedEnvVar smallBatchRoute(
+                "FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH", "0");
             ScopedFirstDevice guard("cuda");
             fastllm::MergeMOE(
                 batchInput, fallbackIndex, fallbackScore, weights, biases,
                 fallbackW1, fallbackW2, fallbackW3,
                 fallbackInput, fallbackIntermediate,
                 0.0f, fallbackOutput);
-        }
-        if (hadSmallBatchEnv) {
-            setenv("FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH",
-                   oldSmallBatchEnvValue.c_str(), 1);
-        } else {
-            unsetenv("FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH");
         }
         // Different expert batching produces a different FP32 reduction tree.
         // Both paths already pass the dense reference checks above; constrain
@@ -4768,6 +4853,7 @@ int main() {
             throw std::runtime_error("gguf_dequant regression requires a CUDA build.");
 #endif
         }
+        RunRegressionFixtureScopeRegression();
         if (only != nullptr && std::string(only) == "qwen35_gguf") {
             RunQwen35GGUFConfigRegression();
             RunQwen35GGUFWeightMappingRegression();
@@ -4823,6 +4909,8 @@ int main() {
 #endif
         RunQwen35GGUFConfigRegression();
         RunQwen35GGUFWeightMappingRegression();
+        RunQwen35GGUFFailFastRegression();
+        RunQwen35GGUFWorkerExceptionRegression();
         RunQwen35MixedQuantGGUFProjectionRegression();
         RunCpuEmbeddingDirectInMemoryLowMemRegression();
         RunQwen35SplitGdnProjectionLayoutRegression();
@@ -4830,7 +4918,7 @@ int main() {
 #ifdef USE_CUDA
         RunQwen35OutProjTpLayoutRegression();
 #endif
-        std::cout << "qwen35 GGUF config, weight mapping, and embedding regression: PASS\n";
+        std::cout << "qwen35 GGUF config, fail-fast, mapping, layout, and embedding regression: PASS\n";
         RunModelTokenCapacityRegression();
         std::cout << "model and paged-cache token capacity regression: PASS\n";
         RunKVCacheDataTypeConfigRegression();

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -658,6 +658,70 @@ namespace {
                "qwen35 grouped out_proj TP scheme must stay contiguous.");
     }
 #endif
+    void RunModelTokenCapacityRegression() {
+        const int previousMaxTokens = fastllm::GetMaxTokens();
+        MoeAtypeConfigTestModel model;
+
+        model.SetTokenLimit(131072);
+        Expect(model.tokensLimit == 131072,
+               "model token limit did not preserve the configured capacity.");
+        Expect(fastllm::GetMaxTokens() == 131072,
+               "model token limit did not configure the paged-cache allocator capacity.");
+
+        fastllm::SetMaxTokens(previousMaxTokens);
+    }
+
+    void RunKVCacheDataTypeConfigRegression() {
+        Expect(fastllm::ParseKVCacheDataType("auto") == fastllm::DataType::DATA_AUTO_NONE,
+               "auto KV cache dtype did not preserve automatic selection.");
+        Expect(fastllm::ParseKVCacheDataType("float16") == fastllm::DataType::FLOAT16,
+               "float16 KV cache dtype was not parsed.");
+        Expect(fastllm::ParseKVCacheDataType("bfloat16") == fastllm::DataType::BFLOAT16,
+               "bfloat16 KV cache dtype was not parsed.");
+        Expect(fastllm::ParseKVCacheDataType("fp8_e4m3") == fastllm::DataType::FP8_E4M3,
+               "fp8_e4m3 KV cache dtype was not parsed.");
+
+        bool rejected = false;
+        try {
+            (void)fastllm::ParseKVCacheDataType("int4");
+        } catch (const std::invalid_argument &) {
+            rejected = true;
+        }
+        Expect(rejected, "unsupported KV cache dtype was not rejected.");
+
+        MoeAtypeConfigTestModel model;
+        model.kvCacheDataType = fastllm::DataType::FLOAT16;
+        model.SetKVCacheDataType(fastllm::ParseKVCacheDataType("fp8_e4m3"));
+        Expect(model.useCustomKVCacheDataType &&
+               model.kvCacheDataType == fastllm::DataType::FP8_E4M3,
+               "explicit FP8 KV cache dtype was not preserved after F16 activation setup.");
+    }
+
+    void RunQwen35DecodePageBudgetRegression() {
+        const std::vector<std::pair<int, int> > requestedFits = {
+            {2, 2}, {1, 4}
+        };
+        const std::vector<std::pair<int, int> > requestedShort = {
+            {2, 1}, {1, 4}
+        };
+        const std::vector<std::pair<int, int> > singleFits = {
+            {0, 1}, {1, 4}
+        };
+        const std::vector<std::pair<int, int> > singleShort = {
+            {1, 0}, {1, 4}
+        };
+
+        Expect(fastllm::SelectQwen35DecodeTokensForPageBudget(
+                   10, requestedFits, singleFits) == 10,
+               "qwen35 page budget rejected a valid MTP validation.");
+        Expect(fastllm::SelectQwen35DecodeTokensForPageBudget(
+                   10, requestedShort, singleFits) == 1,
+               "qwen35 page budget did not fall back to one target token.");
+        Expect(fastllm::SelectQwen35DecodeTokensForPageBudget(
+                   10, requestedShort, singleShort) == 0,
+               "qwen35 page budget hid a true single-token cache shortage.");
+    }
+
     void RunMoeAtypeConfigRegression() {
         MoeAtypeConfigTestModel model;
 
@@ -4767,6 +4831,12 @@ int main() {
         RunQwen35OutProjTpLayoutRegression();
 #endif
         std::cout << "qwen35 GGUF config, weight mapping, and embedding regression: PASS\n";
+        RunModelTokenCapacityRegression();
+        std::cout << "model and paged-cache token capacity regression: PASS\n";
+        RunKVCacheDataTypeConfigRegression();
+        std::cout << "KV cache dtype configuration regression: PASS\n";
+        RunQwen35DecodePageBudgetRegression();
+        std::cout << "qwen35 exact-window decode page budget regression: PASS\n";
         RunMoeAtypeConfigRegression();
         std::cout << "moe_atype auto/explicit configuration regression: PASS\n";
         ranAny = true;

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -1332,6 +1332,7 @@ namespace {
         Expect(count == (int) values.size(), "INT32 tensor element count mismatch.");
         fastllm::Data data(fastllm::DataType::INT32, dims);
         data.Allocate();
+        data.cpuIntDatas.assign(values.begin(), values.end());
         if (count > 0) {
             std::memcpy(data.cpuData, values.data(), (size_t) count * sizeof(int32_t));
         }
@@ -3170,6 +3171,389 @@ namespace {
                                 "SM70 paged XQA concurrent worker " +
                                     std::to_string(worker));
             }
+        }
+    }
+
+    void RunCudaSm70FlashAttentionPrefillRegression() {
+        if (getCudaInfos()->cudaArch != 700) {
+            std::cout << "SM70 FlashAttention prefill regression: SKIP (requires CC 7.0)\n";
+            return;
+        }
+        ScopedEnvVar enableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "1");
+
+        constexpr int batch = 1;
+        constexpr int qLen = 10;
+        constexpr int numKvHeads = 4;
+        constexpr int group = 6;
+        constexpr int numQHeads = numKvHeads * group;
+        constexpr int headDim = 256;
+        constexpr int pageLen = 128;
+        constexpr int maxPages = 4;
+        const float scale = 1.0f / std::sqrt((float)headDim);
+
+        fastllm::Data q = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            MakeRegressionValues(numQHeads * qLen * headDim, 5.41f, 0.04f));
+        fastllm::Data cacheDesc = MakeCudaTensor(
+            fastllm::DataType::FP8_E4M3, {numKvHeads, 1, headDim},
+            std::vector<float>(numKvHeads * headDim, 0.0f));
+        fastllm::PagedCacheManager *pagedK = fastllm::AllocatePagedCacheManager(
+            61000, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        fastllm::PagedCacheManager *pagedV = fastllm::AllocatePagedCacheManager(
+            61001, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+            cacheDesc, pageLen, maxPages);
+        fastllm::Data pagedKValues = MakeCudaTensor(
+            fastllm::DataType::FP8_E4M3,
+            {maxPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(maxPages * pageLen * numKvHeads * headDim,
+                                 0.83f, 0.03f));
+        fastllm::Data pagedVValues = MakeCudaTensor(
+            fastllm::DataType::FP8_E4M3,
+            {maxPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(maxPages * pageLen * numKvHeads * headDim,
+                                 1.27f, 0.05f));
+        FastllmCudaCopyFromDeviceToDevice(
+            pagedK->cudaData, pagedKValues.cudaData, pagedKValues.GetBytes());
+        FastllmCudaCopyFromDeviceToDevice(
+            pagedV->cudaData, pagedVValues.cudaData, pagedVValues.GetBytes());
+
+        fastllm::Data kCaches(fastllm::DataType::FP8_E4M3);
+        fastllm::Data vCaches(fastllm::DataType::FP8_E4M3);
+        kCaches.Resize({numKvHeads, qLen, headDim});
+        vCaches.Resize({numKvHeads, qLen, headDim});
+        kCaches.isKVCache = vCaches.isKVCache = true;
+        kCaches.isPagedKVCache = vCaches.isPagedKVCache = true;
+        kCaches.pageLen = vCaches.pageLen = pageLen;
+        kCaches.pagedKVCacheData = pagedK;
+        vCaches.pagedKVCacheData = pagedV;
+
+        fastllm::Data qSizes = MakeIntTensor({batch + 1}, {0, qLen});
+        fastllm::Data pageSizes = MakeIntTensor({batch + 1}, {0, 3});
+        fastllm::Data pageIndexs = MakeIntTensor({3}, {2, 0, 3});
+        fastllm::Data lastPageLens = MakeIntTensor({batch}, {17});
+        qSizes.ToDevice(fastllm::DataDevice::CUDA);
+        pageSizes.ToDevice(fastllm::DataDevice::CUDA);
+        pageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+        lastPageLens.ToDevice(fastllm::DataDevice::CUDA);
+
+        fastllm::Data reference = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.0f));
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(FastllmCudaHalfPagedAttentionBatch(
+                       q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                       lastPageLens, reference, group, scale, 1,
+                       false, true, false, -1),
+                   "native paged prefill rejected the SM70 qLen10 FP8 fixture.");
+        }
+
+        fastllm::Data actual = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.0f));
+        Expect(FastllmCudaTrySm70FlashAttentionPrefill(
+                   q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                   lastPageLens, actual, group, scale, 1),
+               "SM70 FlashAttention route rejected qLen10 page128 FP8 fixture.");
+        FastllmCudaSyncCurrentThreadStream();
+        ExpectFloatNear(ToFloatVector(reference), ToFloatVector(actual),
+                        3e-3f, 3e-3f,
+                        "SM70 FlashAttention qLen10 page128 FP8");
+
+        fastllm::Data untouched = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.25f));
+        const std::vector<float> untouchedReference = ToFloatVector(untouched);
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(!FastllmCudaTrySm70FlashAttentionPrefill(
+                       q, kCaches, vCaches, qSizes, pageSizes, pageIndexs,
+                       lastPageLens, untouched, group, scale, 1),
+                   "disabled SM70 FlashAttention route accepted fixture.");
+        }
+        ExpectFloatNear(untouchedReference, ToFloatVector(untouched),
+                        0.0f, 0.0f,
+                        "rejected SM70 FlashAttention route modified output");
+
+        fastllm::Data wrongShape = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, 1, headDim},
+            MakeRegressionValues(numQHeads * headDim, 2.19f, 0.02f));
+        fastllm::Data wrongShapeOutput = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, 1, headDim},
+            std::vector<float>(numQHeads * headDim, -0.375f));
+        const std::vector<float> wrongShapeReference =
+            ToFloatVector(wrongShapeOutput);
+        Expect(!FastllmCudaTrySm70FlashAttentionPrefill(
+                   wrongShape, kCaches, vCaches, qSizes, pageSizes,
+                   pageIndexs, lastPageLens, wrongShapeOutput, group, scale, 1),
+               "SM70 FlashAttention route accepted unsupported qLen1.");
+        ExpectFloatNear(wrongShapeReference, ToFloatVector(wrongShapeOutput),
+                        0.0f, 0.0f,
+                        "unsupported SM70 FlashAttention shape modified output");
+
+        constexpr int shortQLen = 2;
+        fastllm::Data shortQ = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, shortQLen, headDim},
+            MakeRegressionValues(numQHeads * shortQLen * headDim, 3.71f, 0.03f));
+        fastllm::Data shortQSizes = MakeIntTensor({2}, {0, shortQLen});
+        fastllm::Data fourPageSizes = MakeIntTensor({2}, {0, 4});
+        fastllm::Data fourPageIndexs = MakeIntTensor({4}, {2, 0, 3, 1});
+        fastllm::Data fullLastPage = MakeIntTensor({1}, {pageLen});
+        shortQSizes.ToDevice(fastllm::DataDevice::CUDA);
+        fourPageSizes.ToDevice(fastllm::DataDevice::CUDA);
+        fourPageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+        fullLastPage.ToDevice(fastllm::DataDevice::CUDA);
+        fastllm::Data shortReference = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, shortQLen, headDim},
+            std::vector<float>(numQHeads * shortQLen * headDim, 0.0f));
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(FastllmCudaHalfPagedAttentionBatch(
+                       shortQ, kCaches, vCaches, shortQSizes, fourPageSizes,
+                       fourPageIndexs, fullLastPage, shortReference, group,
+                       scale, 1, false, true, false, -1),
+                   "native prefill rejected qLen2 four-page FP8 fixture.");
+        }
+        fastllm::Data shortActual = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, shortQLen, headDim},
+            std::vector<float>(numQHeads * shortQLen * headDim, 0.0f));
+        Expect(FastllmCudaTrySm70FlashAttentionPrefill(
+                   shortQ, kCaches, vCaches, shortQSizes, fourPageSizes,
+                   fourPageIndexs, fullLastPage, shortActual, group, scale, 1),
+               "SM70 FlashAttention route rejected qLen2 four-page FP8 fixture.");
+        FastllmCudaSyncCurrentThreadStream();
+        ExpectFloatNear(ToFloatVector(shortReference), ToFloatVector(shortActual),
+                        3e-3f, 3e-3f,
+                        "SM70 FlashAttention qLen2 four-page FP8");
+
+        constexpr int raggedBatch = 5;
+        constexpr int raggedTokens = 30;
+        fastllm::Data raggedQ = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, raggedTokens, headDim},
+            MakeRegressionValues(numQHeads * raggedTokens * headDim,
+                                 4.63f, 0.025f));
+        fastllm::Data raggedQSizes =
+            MakeIntTensor({raggedBatch + 1}, {0, 2, 6, 12, 20, 30});
+        fastllm::Data raggedPageSizes =
+            MakeIntTensor({raggedBatch + 1}, {0, 1, 2, 3, 4, 5});
+        fastllm::Data raggedPageIndexs =
+            MakeIntTensor({raggedBatch}, {2, 0, 3, 1, 2});
+        fastllm::Data raggedLastPageLens =
+            MakeIntTensor({raggedBatch}, {17, 31, 49, 83, 127});
+        raggedQSizes.ToDevice(fastllm::DataDevice::CUDA);
+        raggedPageSizes.ToDevice(fastllm::DataDevice::CUDA);
+        raggedPageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+        raggedLastPageLens.ToDevice(fastllm::DataDevice::CUDA);
+        fastllm::Data raggedReference = MakeCudaTensor(
+            fastllm::DataType::FLOAT16,
+            {numQHeads, raggedTokens, headDim},
+            std::vector<float>(numQHeads * raggedTokens * headDim, 0.0f));
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(FastllmCudaHalfPagedAttentionBatch(
+                       raggedQ, kCaches, vCaches, raggedQSizes,
+                       raggedPageSizes, raggedPageIndexs, raggedLastPageLens,
+                       raggedReference, group, scale, 1,
+                       false, true, false, -1),
+                   "native prefill rejected ragged batch5 FP8 fixture.");
+        }
+        fastllm::Data raggedActual = MakeCudaTensor(
+            fastllm::DataType::FLOAT16,
+            {numQHeads, raggedTokens, headDim},
+            std::vector<float>(numQHeads * raggedTokens * headDim, 0.0f));
+        Expect(FastllmCudaTrySm70FlashAttentionPrefill(
+                   raggedQ, kCaches, vCaches, raggedQSizes,
+                   raggedPageSizes, raggedPageIndexs, raggedLastPageLens,
+                   raggedActual, group, scale, 1),
+               "SM70 FlashAttention route rejected ragged batch5 FP8 fixture.");
+        FastllmCudaSyncCurrentThreadStream();
+        ExpectFloatNear(ToFloatVector(raggedReference),
+                        ToFloatVector(raggedActual), 3e-3f, 3e-3f,
+                        "SM70 FlashAttention ragged batch5 FP8");
+
+        constexpr int longPages = 64;
+        fastllm::PagedCacheManager *longPagedK =
+            fastllm::AllocatePagedCacheManager(
+                61002,
+                fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+                cacheDesc, pageLen, longPages);
+        fastllm::PagedCacheManager *longPagedV =
+            fastllm::AllocatePagedCacheManager(
+                61003,
+                fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+                cacheDesc, pageLen, longPages);
+        const int longCacheElements =
+            longPages * pageLen * numKvHeads * headDim;
+        fastllm::Data longKValues = MakeCudaTensor(
+            fastllm::DataType::FP8_E4M3,
+            {longPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(longCacheElements, 0.57f, 0.015f));
+        fastllm::Data longVValues = MakeCudaTensor(
+            fastllm::DataType::FP8_E4M3,
+            {longPages, pageLen, numKvHeads, headDim},
+            MakeRegressionValues(longCacheElements, 1.11f, 0.02f));
+        FastllmCudaCopyFromDeviceToDevice(
+            longPagedK->cudaData, longKValues.cudaData, longKValues.GetBytes());
+        FastllmCudaCopyFromDeviceToDevice(
+            longPagedV->cudaData, longVValues.cudaData, longVValues.GetBytes());
+        fastllm::Data longKCaches(fastllm::DataType::FP8_E4M3);
+        fastllm::Data longVCaches(fastllm::DataType::FP8_E4M3);
+        longKCaches.Resize({numKvHeads, qLen, headDim});
+        longVCaches.Resize({numKvHeads, qLen, headDim});
+        longKCaches.isKVCache = longVCaches.isKVCache = true;
+        longKCaches.isPagedKVCache = longVCaches.isPagedKVCache = true;
+        longKCaches.pageLen = longVCaches.pageLen = pageLen;
+        longKCaches.pagedKVCacheData = longPagedK;
+        longVCaches.pagedKVCacheData = longPagedV;
+        std::vector<int32_t> longPhysicalPages(longPages);
+        for (int page = 0; page < longPages; ++page) {
+            longPhysicalPages[page] = (page * 17) % longPages;
+        }
+        fastllm::Data longPageSizes = MakeIntTensor({2}, {0, longPages});
+        fastllm::Data longPageIndexs =
+            MakeIntTensor({longPages}, longPhysicalPages);
+        fastllm::Data longLastPage = MakeIntTensor({1}, {pageLen});
+        longPageSizes.ToDevice(fastllm::DataDevice::CUDA);
+        longPageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+        longLastPage.ToDevice(fastllm::DataDevice::CUDA);
+        fastllm::Data longReference = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.0f));
+        {
+            ScopedEnvVar disableRoute("FASTLLM_CUDA_SM70_FLASH_ATTN", "0");
+            Expect(FastllmCudaHalfPagedAttentionBatch(
+                       q, longKCaches, longVCaches, qSizes, longPageSizes,
+                       longPageIndexs, longLastPage, longReference, group,
+                       scale, 1, false, true, false, -1),
+                   "native prefill rejected 8192-token FP8 fixture.");
+        }
+        ScopedEnvVar allowLongKv(
+            "FASTLLM_CUDA_SM70_FLASH_ATTN_MAX_KV", "8192");
+        fastllm::Data longActual = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.0f));
+        Expect(FastllmCudaTrySm70FlashAttentionPrefill(
+                   q, longKCaches, longVCaches, qSizes, longPageSizes,
+                   longPageIndexs, longLastPage, longActual, group, scale, 1),
+               "SM70 FlashAttention route rejected 8192-token FP8 fixture.");
+        FastllmCudaSyncCurrentThreadStream();
+        ExpectFloatNear(ToFloatVector(longReference), ToFloatVector(longActual),
+                        3e-3f, 3e-3f,
+                        "SM70 FlashAttention 8192-token FP8");
+
+        fastllm::Data longRejected = MakeCudaTensor(
+            fastllm::DataType::FLOAT16, {numQHeads, qLen, headDim},
+            std::vector<float>(numQHeads * qLen * headDim, 0.125f));
+        const std::vector<float> longRejectedReference =
+            ToFloatVector(longRejected);
+        {
+            ScopedEnvVar defaultKvLimit(
+                "FASTLLM_CUDA_SM70_FLASH_ATTN_MAX_KV", nullptr);
+            Expect(!FastllmCudaTrySm70FlashAttentionPrefill(
+                       q, longKCaches, longVCaches, qSizes, longPageSizes,
+                       longPageIndexs, longLastPage, longRejected,
+                       group, scale, 1),
+                   "SM70 FlashAttention route accepted KV8192 above default limit.");
+        }
+        ExpectFloatNear(longRejectedReference, ToFloatVector(longRejected),
+                        0.0f, 0.0f,
+                        "long-KV SM70 FlashAttention rejection modified output");
+
+        const char *bench = std::getenv("FASTLLM_SM70_FLASH_ATTN_BENCH");
+        if (bench != nullptr && std::string(bench) != "0") {
+            constexpr int warmup = 3;
+            constexpr int iterations = 20;
+            auto measure = [&](bool useRoute, fastllm::Data &benchQ,
+                               fastllm::Data &benchK, fastllm::Data &benchV,
+                               fastllm::Data &benchQSizes,
+                               fastllm::Data &benchPageSizes,
+                               fastllm::Data &benchPageIndexs,
+                               fastllm::Data &benchLastPageLens,
+                               fastllm::Data &benchOutput) {
+                ScopedEnvVar route("FASTLLM_CUDA_SM70_FLASH_ATTN",
+                                   useRoute ? "1" : "0");
+                auto launch = [&]() {
+                    if (useRoute) {
+                        return FastllmCudaTrySm70FlashAttentionPrefill(
+                            benchQ, benchK, benchV, benchQSizes,
+                            benchPageSizes, benchPageIndexs,
+                            benchLastPageLens, benchOutput, group, scale, 1);
+                    }
+                    return FastllmCudaHalfPagedAttentionBatch(
+                        benchQ, benchK, benchV, benchQSizes, benchPageSizes,
+                        benchPageIndexs, benchLastPageLens, benchOutput,
+                        group, scale, 1, false, false, false, -1);
+                };
+                for (int i = 0; i < warmup; ++i) {
+                    Expect(launch(), "SM70 prefill benchmark warmup failed.");
+                }
+                FastllmCudaSyncCurrentThreadStream();
+                void *start = FastllmCudaEventCreateTiming();
+                void *end = FastllmCudaEventCreateTiming();
+                FastllmCudaEventRecordCurrentThread(start);
+                for (int i = 0; i < iterations; ++i) {
+                    Expect(launch(), "SM70 prefill benchmark launch failed.");
+                }
+                FastllmCudaEventRecordCurrentThread(end);
+                FastllmCudaEventSynchronize(end);
+                const float averageMs =
+                    FastllmCudaEventElapsedTime(start, end) / iterations;
+                FastllmCudaEventDestroy(start);
+                FastllmCudaEventDestroy(end);
+                return averageMs;
+            };
+            std::cout << "shape,route,avg_ms,speedup_vs_native\n";
+            auto report = [&](const std::string &shape,
+                              fastllm::Data &benchQ,
+                              fastllm::Data &benchK,
+                              fastllm::Data &benchV,
+                              fastllm::Data &benchQSizes,
+                              fastllm::Data &benchPageSizes,
+                              fastllm::Data &benchPageIndexs,
+                              fastllm::Data &benchLastPageLens,
+                              fastllm::Data &nativeOutput,
+                              fastllm::Data &routeOutput) {
+                const float nativeMs = measure(
+                    false, benchQ, benchK, benchV, benchQSizes,
+                    benchPageSizes, benchPageIndexs, benchLastPageLens,
+                    nativeOutput);
+                const float routeMs = measure(
+                    true, benchQ, benchK, benchV, benchQSizes,
+                    benchPageSizes, benchPageIndexs, benchLastPageLens,
+                    routeOutput);
+                std::cout << shape << ",native," << nativeMs << ",1\n";
+                std::cout << shape << ",sm70_flash_attn," << routeMs << ','
+                          << nativeMs / routeMs << '\n';
+            };
+            report("b1_q10_kv273", q, kCaches, vCaches, qSizes, pageSizes,
+                   pageIndexs, lastPageLens, reference, actual);
+            report("b5_ragged_kv17_127", raggedQ, kCaches, vCaches,
+                   raggedQSizes, raggedPageSizes, raggedPageIndexs,
+                   raggedLastPageLens, raggedReference, raggedActual);
+            for (int kvTokens : {512, 1024, 2048, 4096}) {
+                const int pages = kvTokens / pageLen;
+                std::vector<int32_t> physicalPages(pages);
+                for (int page = 0; page < pages; ++page) {
+                    physicalPages[page] = (page * 17) % pages;
+                }
+                fastllm::Data crossPageSizes =
+                    MakeIntTensor({2}, {0, pages});
+                fastllm::Data crossPageIndexs =
+                    MakeIntTensor({pages}, physicalPages);
+                fastllm::Data crossLastPage =
+                    MakeIntTensor({1}, {pageLen});
+                crossPageSizes.ToDevice(fastllm::DataDevice::CUDA);
+                crossPageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+                crossLastPage.ToDevice(fastllm::DataDevice::CUDA);
+                report("b1_q10_kv" + std::to_string(kvTokens),
+                       q, longKCaches, longVCaches, qSizes,
+                       crossPageSizes, crossPageIndexs, crossLastPage,
+                       longReference, longActual);
+            }
+            report("b1_q10_kv8192", q, longKCaches, longVCaches, qSizes,
+                   longPageSizes, longPageIndexs, longLastPage,
+                   longReference, longActual);
         }
     }
 
@@ -5278,6 +5662,20 @@ int main() {
             throw std::runtime_error("sm70_paged_xqa_bench requires a CUDA build.");
 #endif
         }
+        if (only != nullptr && std::string(only) == "sm70_flash_attn_prefill_bench") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error(
+                    "sm70_flash_attn_prefill_bench requires CUDA.");
+            }
+            ScopedEnvVar bench("FASTLLM_SM70_FLASH_ATTN_BENCH", "1");
+            RunCudaSm70FlashAttentionPrefillRegression();
+            return 0;
+#else
+            throw std::runtime_error(
+                "sm70_flash_attn_prefill_bench requires a CUDA build.");
+#endif
+        }
         if (only != nullptr && std::string(only) == "sm70_paged_xqa") {
 #ifdef USE_CUDA
             if (!fastllm::HasDeviceType("cuda")) {
@@ -5288,6 +5686,20 @@ int main() {
             return 0;
 #else
             throw std::runtime_error("sm70_paged_xqa regression requires a CUDA build.");
+#endif
+        }
+        if (only != nullptr && std::string(only) == "sm70_flash_attn_prefill") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error(
+                    "sm70_flash_attn_prefill regression requires CUDA.");
+            }
+            RunCudaSm70FlashAttentionPrefillRegression();
+            std::cout << "SM70 FlashAttention prefill regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error(
+                "sm70_flash_attn_prefill regression requires a CUDA build.");
 #endif
         }
         bool ranAny = false;

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -124,6 +124,14 @@ namespace {
         int NumKeyValueHeads() const {
             return num_key_value_heads;
         }
+
+        void ConfigureTurbo3Fixture() {
+            head_dim = 256;
+            block_cnt = 2;
+            weight.AddEmptyWeight(
+                language_prefix + "layers.0.self_attn.o_proj.weight",
+                {1, 1}, fastllm::DataType::FLOAT32);
+        }
     };
 
 
@@ -795,6 +803,22 @@ namespace {
                "bfloat16 KV cache dtype was not parsed.");
         Expect(fastllm::ParseKVCacheDataType("fp8_e4m3") == fastllm::DataType::FP8_E4M3,
                "fp8_e4m3 KV cache dtype was not parsed.");
+        Expect(fastllm::ParseKVCacheDataType("turbo3") == fastllm::DataType::TURBO3_KV,
+               "turbo3 KV cache dtype was not parsed.");
+        Expect(fastllm::ResolveQwen35CudaCacheType(
+                   fastllm::DataType::Q8_0_KV, fastllm::DataType::FLOAT16) ==
+                   fastllm::DataType::Q8_0_KV,
+               "Qwen3.5 CUDA cache resolver downgraded Q8 packed K to FP16.");
+        Expect(fastllm::ResolveQwen35CudaCacheType(
+                   fastllm::DataType::TURBO3_KV, fastllm::DataType::FLOAT16) ==
+                   fastllm::DataType::TURBO3_KV,
+               "Qwen3.5 CUDA cache resolver downgraded Turbo3 packed V to FP16.");
+        Expect(fastllm::Qwen35PagedCachePageBytes(
+                   fastllm::DataType::Q8_0_KV, 128, 4, 256) == 139264,
+               "Qwen3.5 Q8 paged cache page bytes regressed.");
+        Expect(fastllm::Qwen35PagedCachePageBytes(
+                   fastllm::DataType::TURBO3_KV, 128, 4, 256) == 51200,
+               "Qwen3.5 Turbo3 paged cache page bytes regressed.");
 
         bool rejected = false;
         try {
@@ -814,6 +838,29 @@ namespace {
         Expect(model.useCustomKVCacheDataType &&
                model.kvCacheDataType == fastllm::DataType::FP8_E4M3,
                "explicit FP8 KV cache dtype was not preserved after F16 setup.");
+#endif
+#ifdef USE_CUDA
+        {
+            ScopedEnvVar disabled("FASTLLM_QWEN35_TURBO3_KV", nullptr);
+            Expect(!fastllm::Qwen35Turbo3KvEnabled(),
+                   "Qwen3.5 Turbo3 KV gate should default off.");
+        }
+        {
+            ScopedEnvVar enabled("FASTLLM_QWEN35_TURBO3_KV", "1");
+            Expect(fastllm::Qwen35Turbo3KvEnabled(),
+                   "Qwen3.5 Turbo3 KV gate ignored an explicit enable.");
+            Qwen35ConfigTestModel qwen;
+            qwen.ConfigureTurbo3Fixture();
+            qwen.SetKVCacheDataType(fastllm::DataType::TURBO3_KV);
+            auto attentionTypes = qwen.GetKVCacheDataTypes(0);
+            auto linearTypes = qwen.GetKVCacheDataTypes(1);
+            Expect(attentionTypes.first == fastllm::DataType::Q8_0_KV &&
+                   attentionTypes.second == fastllm::DataType::TURBO3_KV,
+                   "Qwen3.5 Turbo3 full-attention layer did not use asymmetric K/V dtypes.");
+            Expect(linearTypes.first == linearTypes.second &&
+                   !fastllm::IsPackedKVCacheDataType(linearTypes.first),
+                   "Qwen3.5 linear-attention layer should use a non-packed compute cache dtype.");
+        }
 #endif
     }
 
@@ -1577,6 +1624,287 @@ namespace {
                                  0.5f * std::cos((i + 3) * 0.043f - seed));
         }
         return values;
+    }
+
+    void ExpectPackedKvQuality(const std::vector<float> &expected,
+                               const std::vector<float> &actual,
+                               fastllm::DataType type,
+                               const std::string &name) {
+        Expect(expected.size() == actual.size(), name + " size mismatch.");
+        double dot = 0.0, expectedSq = 0.0, actualSq = 0.0, errorSq = 0.0;
+        for (size_t i = 0; i < expected.size(); i++) {
+            Expect(std::isfinite(expected[i]) && std::isfinite(actual[i]),
+                   name + " contains a non-finite value at index " + std::to_string(i));
+            double e = expected[i], a = actual[i], d = e - a;
+            dot += e * a;
+            expectedSq += e * e;
+            actualSq += a * a;
+            errorSq += d * d;
+        }
+        double cosine = dot / std::sqrt(std::max(1.0e-30, expectedSq * actualSq));
+        double relativeRmse = std::sqrt(errorSq / std::max(1.0e-30, expectedSq));
+        if (type == fastllm::DataType::Q8_0_KV) {
+            Expect(cosine > 0.999 && relativeRmse < 0.015,
+                   name + " Q8 quality regression: cosine=" + std::to_string(cosine) +
+                   ", relative_rmse=" + std::to_string(relativeRmse));
+        } else {
+            Expect(cosine > 0.90 && relativeRmse < 0.45,
+                   name + " Turbo3 quality regression: cosine=" + std::to_string(cosine) +
+                   ", relative_rmse=" + std::to_string(relativeRmse));
+        }
+    }
+
+    void RunCudaTurbo3KvRegression() {
+        using fastllm::DataType;
+        constexpr int pageLen = 3;
+        constexpr int maxPages = 3;
+        constexpr int numHeads = 2;
+        constexpr int headDim = 256;
+        constexpr int seqLen = 5;
+        FastllmCudaSetDevice(0);
+
+        Expect(fastllm::GetKVCacheRowBytes(DataType::Q8_0_KV, headDim) == 272,
+               "Q8 KV row bytes changed.");
+        Expect(fastllm::GetKVCacheRowBytes(DataType::TURBO3_KV, headDim) == 100,
+               "Turbo3 KV row bytes changed.");
+        Expect(fastllm::GetKVCacheRowBytes(DataType::Q8_0_KV, 257) == 306,
+               "Q8 KV partial row did not round up by 32 values.");
+        Expect(fastllm::GetKVCacheRowBytes(DataType::TURBO3_KV, 257) == 150,
+               "Turbo3 KV partial row did not round up by 128 values.");
+
+        std::vector<float> sourceValues = MakeRegressionValues(
+            numHeads * seqLen * headDim, 1.713f, 0.7f);
+        fastllm::Data source(DataType::FLOAT32,
+                             {numHeads, seqLen, headDim}, sourceValues);
+        fastllm::ToDataType(source, DataType::FLOAT16);
+        source.ToDevice(fastllm::DataDevice::CUDA);
+
+        int32_t hostPages[2] = {0, 1};
+        int32_t *cudaPages = (int32_t*)FastllmCudaMalloc(sizeof(hostPages));
+        FastllmCudaCopyFromHostToDevice(cudaPages, hostPages, sizeof(hostPages));
+
+        auto runType = [&](DataType type) {
+            size_t rowBytes = fastllm::GetKVCacheRowBytes(type, headDim);
+            size_t packedBytes = (size_t)maxPages * pageLen * numHeads * rowBytes;
+            uint8_t *packed = (uint8_t*)FastllmCudaMalloc(packedBytes);
+            Expect(packed != nullptr, "packed KV allocation failed.");
+            Expect(cudaMemset(packed, 0, packedBytes) == cudaSuccess,
+                   "packed KV memset failed.");
+
+            Expect(FastllmCudaPackedKVCacheCopy(
+                       packed, 0, pageLen, numHeads, headDim, type,
+                       (uint8_t*)source.cudaData, source.dataType,
+                       seqLen, 0, 3, 0),
+                   "packed KV first prefill page write failed.");
+            Expect(FastllmCudaPackedKVCacheCopy(
+                       packed, 1, pageLen, numHeads, headDim, type,
+                       (uint8_t*)source.cudaData, source.dataType,
+                       seqLen, 3, 2, 0),
+                   "packed KV second prefill page write failed.");
+
+            for (int head = 0; head < numHeads; head++) {
+                void *gatherHalf = FastllmCudaMalloc((size_t)seqLen * headDim * sizeof(uint16_t));
+                void *gatherFloat = FastllmCudaMalloc((size_t)seqLen * headDim * sizeof(float));
+                Expect(FastllmCudaPackedKVCacheGatherHeadRangeToHalf(
+                           packed, type, cudaPages, 0, seqLen,
+                           pageLen, numHeads, headDim, head, gatherHalf),
+                       "packed KV prefill gather failed.");
+                Expect(FastllmHalfToFloat(gatherHalf, gatherFloat, seqLen * headDim),
+                       "packed KV gathered half conversion failed.");
+                std::vector<float> actual((size_t)seqLen * headDim);
+                FastllmCudaCopyFromDeviceToHost(
+                    actual.data(), gatherFloat, actual.size() * sizeof(float));
+                std::vector<float> expected(actual.size());
+                for (int token = 0; token < seqLen; token++) {
+                    std::copy_n(sourceValues.begin() +
+                                    ((size_t)head * seqLen + token) * headDim,
+                                headDim, expected.begin() + (size_t)token * headDim);
+                }
+                ExpectPackedKvQuality(expected, actual, type,
+                                      "packed KV cross-page head " + std::to_string(head));
+                FastllmCudaFree(gatherFloat);
+                FastllmCudaFree(gatherHalf);
+            }
+
+            constexpr int decodeBatch = 2;
+            std::vector<float> decodeValues = MakeRegressionValues(
+                decodeBatch * numHeads * headDim, 2.419f, 0.6f);
+            fastllm::Data decode(DataType::FLOAT32,
+                                 {decodeBatch, numHeads, headDim}, decodeValues);
+            fastllm::ToDataType(decode, DataType::FLOAT16);
+            decode.ToDevice(fastllm::DataDevice::CUDA);
+            int32_t decodePageHost[decodeBatch] = {2, 0};
+            int32_t decodeOffsetHost[decodeBatch] = {1, 2};
+            int32_t *decodeMeta = (int32_t*)FastllmCudaMalloc(4 * sizeof(int32_t));
+            FastllmCudaCopyFromHostToDevice(decodeMeta, decodePageHost,
+                                            decodeBatch * sizeof(int32_t));
+            FastllmCudaCopyFromHostToDevice(decodeMeta + decodeBatch,
+                                            decodeOffsetHost,
+                                            decodeBatch * sizeof(int32_t));
+            Expect(FastllmCudaPackedKVCacheCopyBatch(
+                       packed, decodeMeta, decodeMeta + decodeBatch,
+                       pageLen, decodeBatch, numHeads, headDim, type,
+                       (uint8_t*)decode.cudaData, decode.dataType),
+                   "packed KV batch decode write failed.");
+            for (int b = 0; b < decodeBatch; b++) {
+                int32_t *onePage = decodeMeta + b;
+                for (int head = 0; head < numHeads; head++) {
+                    void *gatherHalf = FastllmCudaMalloc(headDim * sizeof(uint16_t));
+                    void *gatherFloat = FastllmCudaMalloc(headDim * sizeof(float));
+                    Expect(FastllmCudaPackedKVCacheGatherHeadRangeToHalf(
+                               packed, type, onePage, decodeOffsetHost[b], 1,
+                               pageLen, numHeads, headDim, head, gatherHalf),
+                           "packed KV batch decode gather failed.");
+                    Expect(FastllmHalfToFloat(gatherHalf, gatherFloat, headDim),
+                           "packed KV batch gathered half conversion failed.");
+                    std::vector<float> actual(headDim), expected(headDim);
+                    FastllmCudaCopyFromDeviceToHost(
+                        actual.data(), gatherFloat, actual.size() * sizeof(float));
+                    std::copy_n(decodeValues.begin() +
+                                    ((size_t)b * numHeads + head) * headDim,
+                                headDim, expected.begin());
+                    ExpectPackedKvQuality(expected, actual, type,
+                                          "packed KV batch request " + std::to_string(b) +
+                                          " head " + std::to_string(head));
+                    FastllmCudaFree(gatherFloat);
+                    FastllmCudaFree(gatherHalf);
+                }
+            }
+            FastllmCudaFree(decodeMeta);
+            FastllmCudaFree(packed);
+        };
+
+        runType(DataType::Q8_0_KV);
+        runType(DataType::TURBO3_KV);
+        fastllm::ClearAllPagedCacheManagers();
+        {
+            constexpr int attentionBatch = 2;
+            constexpr int group = 1;
+            const float attentionScale = 1.0f / std::sqrt((float)headDim);
+            std::vector<float> valueValues = MakeRegressionValues(
+                numHeads * seqLen * headDim, 3.117f, 0.55f);
+            fastllm::Data valueSource(DataType::FLOAT32,
+                                      {numHeads, seqLen, headDim}, valueValues);
+            fastllm::ToDataType(valueSource, DataType::FLOAT16);
+            valueSource.ToDevice(fastllm::DataDevice::CUDA);
+
+            auto allocateManager = [&](int id, DataType type) {
+                fastllm::Data desc(type);
+                desc.dims = {numHeads, 1, headDim};
+                desc.strides = {(uint64_t)headDim, (uint64_t)headDim, 1};
+                desc.dataDevice = fastllm::DataDevice::CUDA;
+                desc.dataDeviceIds = {0};
+                desc.UpdateUnitSize();
+                return fastllm::AllocatePagedCacheManager(
+                    id, fastllm::PagedCacheManager::PAGED_CACHE_MANAGER_TYPE_KV_CACHE,
+                    desc, pageLen, maxPages);
+            };
+            fastllm::PagedCacheManager *referenceKManager =
+                allocateManager(61000, DataType::FLOAT16);
+            fastllm::PagedCacheManager *referenceVManager =
+                allocateManager(61001, DataType::FLOAT16);
+            fastllm::PagedCacheManager *packedKManager =
+                allocateManager(61002, DataType::Q8_0_KV);
+            fastllm::PagedCacheManager *packedVManager =
+                allocateManager(61003, DataType::TURBO3_KV);
+
+            for (int page = 0; page < 2; page++) {
+                int inputOffset = page * pageLen;
+                int copyLen = std::min(pageLen, seqLen - inputOffset);
+                FastllmCudaPagedCacheCopy(
+                    (uint8_t*)referenceKManager->cudaData, page, pageLen,
+                    numHeads, headDim, DataType::FLOAT16,
+                    (uint8_t*)source.cudaData, source.dataType,
+                    seqLen, inputOffset, copyLen, 0);
+                FastllmCudaPagedCacheCopy(
+                    (uint8_t*)referenceVManager->cudaData, page, pageLen,
+                    numHeads, headDim, DataType::FLOAT16,
+                    (uint8_t*)valueSource.cudaData, valueSource.dataType,
+                    seqLen, inputOffset, copyLen, 0);
+                FastllmCudaPagedCacheCopy(
+                    (uint8_t*)packedKManager->cudaData, page, pageLen,
+                    numHeads, headDim, DataType::Q8_0_KV,
+                    (uint8_t*)source.cudaData, source.dataType,
+                    seqLen, inputOffset, copyLen, 0);
+                FastllmCudaPagedCacheCopy(
+                    (uint8_t*)packedVManager->cudaData, page, pageLen,
+                    numHeads, headDim, DataType::TURBO3_KV,
+                    (uint8_t*)valueSource.cudaData, valueSource.dataType,
+                    seqLen, inputOffset, copyLen, 0);
+            }
+
+            auto makeCache = [&](DataType type, fastllm::PagedCacheManager *manager) {
+                fastllm::Data cache(type);
+                cache.Resize({numHeads, seqLen, headDim});
+                cache.SetKVCache();
+                cache.isPagedKVCache = true;
+                cache.pageLen = pageLen;
+                cache.pageIndex = {0, 1};
+                cache.lastPageLen = seqLen - pageLen;
+                cache.pagedKVCacheData = manager;
+                return cache;
+            };
+            fastllm::Data referenceK = makeCache(DataType::FLOAT16, referenceKManager);
+            fastllm::Data referenceV = makeCache(DataType::FLOAT16, referenceVManager);
+            fastllm::Data packedK = makeCache(DataType::Q8_0_KV, packedKManager);
+            fastllm::Data packedV = makeCache(DataType::TURBO3_KV, packedVManager);
+            fastllm::Data query = MakeCudaTensor(
+                DataType::FLOAT16, {numHeads * group, attentionBatch, headDim},
+                MakeRegressionValues(numHeads * group * attentionBatch * headDim, 3.771f, 0.08f));
+            fastllm::Data qSizes = MakeIntTensor({3}, {0, 1, 2});
+            fastllm::Data pageSizes = MakeIntTensor({3}, {0, 1, 2});
+            fastllm::Data pageIndexs = MakeIntTensor({2}, {0, 1});
+            fastllm::Data lastPageLens = MakeIntTensor({2}, {pageLen, seqLen - pageLen});
+            qSizes.ToDevice(fastllm::DataDevice::CUDA);
+            pageSizes.ToDevice(fastllm::DataDevice::CUDA);
+            pageIndexs.ToDevice(fastllm::DataDevice::CUDA);
+            lastPageLens.ToDevice(fastllm::DataDevice::CUDA);
+
+            fastllm::Data referenceOutput = MakeCudaTensor(
+                DataType::FLOAT16, {numHeads * group, attentionBatch, headDim},
+                std::vector<float>(numHeads * group * attentionBatch * headDim, 0.0f));
+            fastllm::Data packedOutput = MakeCudaTensor(
+                DataType::FLOAT16, {numHeads * group, attentionBatch, headDim},
+                std::vector<float>(numHeads * group * attentionBatch * headDim, 0.0f));
+            {
+                ScopedEnvVar disableSm70("FASTLLM_CUDA_SM70_PAGED_XQA", "0");
+                ScopedEnvVar disableNativeGqa("FASTLLM_PAGED_GQA_DECODE", "0");
+                Expect(FastllmCudaHalfPagedAttentionBatchFastllmFallback(
+                           query, referenceK, referenceV,
+                           qSizes, pageSizes, pageIndexs, lastPageLens,
+                           referenceOutput, group, attentionScale),
+                       "FP16 paged attention reference failed.");
+                Expect(FastllmCudaHalfPagedAttentionBatchFastllmFallback(
+                           query, packedK, packedV,
+                           qSizes, pageSizes, pageIndexs, lastPageLens,
+                           packedOutput, group, attentionScale),
+                       "packed paged attention failed.");
+            }
+            ExpectPackedKvQuality(ToFloatVector(referenceOutput),
+                                  ToFloatVector(packedOutput),
+                                  DataType::TURBO3_KV,
+                                  "packed paged attention output");
+            fastllm::Data referenceSingleOutput = MakeCudaTensor(
+                DataType::FLOAT16, {numHeads * group, attentionBatch, headDim},
+                std::vector<float>(numHeads * group * attentionBatch * headDim, 0.0f));
+            fastllm::Data packedSingleOutput = MakeCudaTensor(
+                DataType::FLOAT16, {numHeads * group, attentionBatch, headDim},
+                std::vector<float>(numHeads * group * attentionBatch * headDim, 0.0f));
+            Expect(FastllmCudaHalfPagedAttentionFastllmFallback(
+                       query, referenceK, referenceV, referenceSingleOutput,
+                       group, attentionScale),
+                   "FP16 single paged attention reference failed.");
+            Expect(FastllmCudaHalfPagedAttentionFastllmFallback(
+                       query, packedK, packedV, packedSingleOutput,
+                       group, attentionScale),
+                   "packed single paged attention failed.");
+            ExpectPackedKvQuality(ToFloatVector(referenceSingleOutput),
+                                  ToFloatVector(packedSingleOutput),
+                                  DataType::TURBO3_KV,
+                                  "packed single paged attention output");
+        }
+        fastllm::ClearAllPagedCacheManagers();
+        FastllmCudaFree(cudaPages);
     }
 
     void RunCudaGreedyTieBreakRegression() {
@@ -5832,6 +6160,19 @@ int main() {
             RunQwen35LongPrefillStateRegression();
             std::cout << "qwen35 long prefill state regression: PASS\n";
             return 0;
+        }
+        if (only != nullptr && std::string(only) == "turbo3_kv") {
+            RunKVCacheDataTypeConfigRegression();
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("turbo3_kv regression requires CUDA.");
+            }
+            RunCudaTurbo3KvRegression();
+            std::cout << "Qwen3.5 Turbo3 packed KV regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error("turbo3_kv regression requires a CUDA build.");
+#endif
         }
         if (only != nullptr && std::string(only) == "iq4xs_mmq_bench") {
 #ifdef USE_CUDA

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -3,6 +3,9 @@
 #include "model.h"
 #include "models/basellm.h"
 #include "devices/cpu/computeutils.h"
+#include "model.h"
+#include "models/qwen3_5.h"
+#include "gguf.h"
 
 #if defined(USE_CUDA) && !defined(USE_ROCM)
 #include <cuda_runtime_api.h>
@@ -32,6 +35,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <map>
 
 namespace {
     class ScopedTempDirectory {
@@ -75,6 +79,17 @@ namespace {
             return "";
         }
     };
+    class Qwen35ConfigTestModel final : public fastllm::Qwen3_5Model {
+    public:
+        const fastllm::Data &InvScaleData() const {
+            return inv_scale_data;
+        }
+
+        int NumKeyValueHeads() const {
+            return num_key_value_heads;
+        }
+    };
+
 
     class ScopedFirstDevice {
     public:
@@ -99,6 +114,481 @@ namespace {
         if (!condition) {
             throw std::runtime_error(message);
         }
+    }
+    std::vector<float> ToFloatVector(fastllm::Data data);
+    void ExpectFloatNear(const std::vector<float> &expected, const std::vector<float> &actual,
+                         float atol, float rtol, const std::string &name);
+
+    struct SyntheticGGUFTensor {
+        std::string name;
+        std::vector<int64_t> dims;
+        std::vector<float> values;
+        int32_t ggmlType = GGML_TYPE_F32;
+        std::vector<uint8_t> rawData;
+    };
+
+    uint64_t SyntheticGGUFTensorBytes(const SyntheticGGUFTensor &tensor) {
+        if (tensor.ggmlType == GGML_TYPE_F32) {
+            return (uint64_t)tensor.values.size() * sizeof(float);
+        }
+        return tensor.rawData.size();
+    }
+
+    SyntheticGGUFTensor MakeSyntheticQuantTensor(
+            const std::string &name,
+            const std::vector<int64_t> &dims,
+            ggml_type type) {
+        Expect(!dims.empty() && dims[0] % ggml_blck_size(type) == 0,
+               "synthetic quantized GGUF row width must match the block size.");
+        int64_t rows = 1;
+        for (size_t i = 1; i < dims.size(); i++) {
+            rows *= dims[i];
+        }
+        SyntheticGGUFTensor tensor;
+        tensor.name = name;
+        tensor.dims = dims;
+        tensor.ggmlType = type;
+        tensor.rawData.resize(ggml_row_size(type, dims[0]) * rows, 0);
+        return tensor;
+    }
+
+    template <typename T>
+    void WritePod(std::ofstream &out, T value) {
+        out.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+
+    void WriteGGUFString(std::ofstream &out, const std::string &value) {
+        WritePod<uint64_t>(out, value.size());
+        out.write(value.data(), (std::streamsize)value.size());
+    }
+
+    void WriteGGUFStringKV(std::ofstream &out, const std::string &key,
+                           const std::string &value) {
+        WriteGGUFString(out, key);
+        WritePod<int32_t>(out, 8);
+        WriteGGUFString(out, value);
+    }
+
+    void WriteGGUFUInt32KV(std::ofstream &out, const std::string &key,
+                           uint32_t value) {
+        WriteGGUFString(out, key);
+        WritePod<int32_t>(out, 4);
+        WritePod<uint32_t>(out, value);
+    }
+
+    void WriteGGUFFloat32KV(std::ofstream &out, const std::string &key,
+                            float value) {
+        WriteGGUFString(out, key);
+        WritePod<int32_t>(out, 6);
+        WritePod<float>(out, value);
+    }
+
+    void WriteGGUFInt32ArrayKV(std::ofstream &out, const std::string &key,
+                               const std::vector<int32_t> &values) {
+        WriteGGUFString(out, key);
+        WritePod<int32_t>(out, 9);
+        WritePod<int32_t>(out, 5);
+        WritePod<uint64_t>(out, values.size());
+        for (int32_t value : values) {
+            WritePod<int32_t>(out, value);
+        }
+    }
+
+    uint64_t Pad32(uint64_t value) {
+        return (value + 31) / 32 * 32;
+    }
+
+    std::string MakeTempGGUFPath(const std::string &name) {
+        auto ticks = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        return "/tmp/" + name + "-" + std::to_string(ticks) + ".gguf";
+    }
+
+    void WriteSyntheticQwen35GGUF(const std::string &path,
+                                  const std::vector<SyntheticGGUFTensor> &tensors,
+                                  const std::string &arch = "qwen35",
+                                  uint32_t nextnPredictLayers = 1) {
+        std::ofstream out(path, std::ios::binary);
+        Expect(out.good(), "failed to create synthetic GGUF file.");
+
+        WritePod<uint32_t>(out, 0x46554747u);
+        WritePod<uint32_t>(out, 3u);
+        WritePod<uint64_t>(out, tensors.size());
+        WritePod<uint64_t>(out, 18u);
+
+        WriteGGUFStringKV(out, "general.architecture", arch);
+        WriteGGUFStringKV(out, "general.name", "synthetic qwen35");
+        WriteGGUFUInt32KV(out, arch + ".block_count", 65);
+        WriteGGUFUInt32KV(out, arch + ".nextn_predict_layers", nextnPredictLayers);
+        WriteGGUFUInt32KV(out, arch + ".embedding_length", 5120);
+        WriteGGUFUInt32KV(out, arch + ".context_length", 262144);
+        WriteGGUFUInt32KV(out, arch + ".feed_forward_length", 17408);
+        WriteGGUFUInt32KV(out, arch + ".attention.head_count", 24);
+        WriteGGUFUInt32KV(out, arch + ".attention.head_count_kv", 4);
+        WriteGGUFUInt32KV(out, arch + ".attention.key_length", 256);
+        WriteGGUFUInt32KV(out, arch + ".attention.value_length", 256);
+        WriteGGUFFloat32KV(out, arch + ".attention.layer_norm_rms_epsilon", 1e-6f);
+        WriteGGUFFloat32KV(out, arch + ".rope.freq_base", 10000000.0f);
+        WriteGGUFInt32ArrayKV(out, arch + ".rope.dimension_sections", {11, 11, 10, 0});
+        WriteGGUFUInt32KV(out, arch + ".ssm.group_count", 16);
+        WriteGGUFUInt32KV(out, arch + ".ssm.state_size", 128);
+        WriteGGUFUInt32KV(out, arch + ".ssm.time_step_rank", 48);
+        WriteGGUFUInt32KV(out, arch + ".ssm.inner_size", 6144);
+
+        uint64_t offset = 0;
+        for (const auto &tensor : tensors) {
+            WriteGGUFString(out, tensor.name);
+            WritePod<uint32_t>(out, tensor.dims.size());
+            int64_t elements = 1;
+            for (int64_t dim : tensor.dims) {
+                WritePod<int64_t>(out, dim);
+                elements *= dim;
+            }
+            uint64_t bytes = SyntheticGGUFTensorBytes(tensor);
+            if (tensor.ggmlType == GGML_TYPE_F32) {
+                Expect(elements == (int64_t)tensor.values.size(),
+                       "synthetic GGUF tensor element mismatch.");
+            } else {
+                Expect(bytes > 0, "synthetic quantized GGUF tensor payload is empty.");
+            }
+            WritePod<int32_t>(out, tensor.ggmlType);
+            WritePod<uint64_t>(out, offset);
+            offset += Pad32(bytes);
+        }
+
+        uint64_t headerSize = (uint64_t)out.tellp();
+        uint64_t paddedHeader = Pad32(headerSize);
+        for (uint64_t i = headerSize; i < paddedHeader; i++) {
+            out.put('\0');
+        }
+
+        for (const auto &tensor : tensors) {
+            uint64_t bytes = SyntheticGGUFTensorBytes(tensor);
+            if (tensor.ggmlType == GGML_TYPE_F32) {
+                out.write(reinterpret_cast<const char*>(tensor.values.data()),
+                          (std::streamsize)bytes);
+            } else {
+                out.write(reinterpret_cast<const char*>(tensor.rawData.data()),
+                          (std::streamsize)bytes);
+            }
+            uint64_t paddedBytes = Pad32(bytes);
+            for (uint64_t i = bytes; i < paddedBytes; i++) {
+                out.put('\0');
+            }
+        }
+    }
+
+    const fastllm::Data &RequireWeight(const fastllm::basellm &model,
+                                       const std::string &name) {
+        auto it = model.weight.weight.find(name);
+        Expect(it != model.weight.weight.end(), "missing weight: " + name);
+        return it->second;
+    }
+
+    void RunQwen35GGUFConfigRegression() {
+        for (const std::string &arch : {std::string("qwen35"), std::string("qwen3_5")}) {
+            std::string path = MakeTempGGUFPath("fastllm-" + arch + "-config");
+            WriteSyntheticQwen35GGUF(path, {}, arch);
+            auto model = fastllm::CreateLLMModelFromFile(path);
+            std::remove(path.c_str());
+
+            Expect(model->model_type == "qwen3_5", arch + " GGUF should create a qwen3_5 model.");
+            Expect(model->block_cnt == 64, arch + " GGUF block_count must exclude nextn/MTP layers.");
+            Expect(model->embed_dim == 5120, arch + " hidden_size was not imported.");
+            Expect(model->num_attention_heads == 24, arch + " attention heads were not imported.");
+            Expect(model->num_key_value_heads == 4, arch + " KV heads were not imported.");
+            Expect(model->head_dim == 256, arch + " full-attention head_dim was not imported.");
+            Expect(model->max_positions == 262144, arch + " context length was not imported.");
+            Expect(model->weight.dicts["num_hidden_layers"] == "64",
+                   arch + " num_hidden_layers dict must use the main trunk layer count.");
+            Expect(model->weight.dicts["mtp_num_hidden_layers"] == "1",
+                   arch + " nextn_predict_layers should map to mtp_num_hidden_layers.");
+            Expect(model->weight.dicts["linear_num_key_heads"] == "16",
+                   arch + " ssm.group_count should map to linear_num_key_heads.");
+            Expect(model->weight.dicts["linear_num_value_heads"] == "48",
+                   arch + " ssm.time_step_rank should map to linear_num_value_heads.");
+            Expect(model->weight.dicts["linear_key_head_dim"] == "128",
+                   arch + " ssm.state_size should map to linear_key_head_dim.");
+            Expect(model->weight.dicts["linear_value_head_dim"] == "128",
+                   arch + " ssm.state_size should map to linear_value_head_dim.");
+            Qwen35ConfigTestModel runtimeModel;
+            runtimeModel.weight.dicts = model->weight.dicts;
+            runtimeModel.InitParams();
+            Expect(runtimeModel.NumKeyValueHeads() == 4,
+                   arch + " runtime KV head count was not initialized.");
+            std::vector<float> expectedInvScale(128, 1.0f / std::sqrt(128.0f));
+            Expect(runtimeModel.InvScaleData().dims == std::vector<int>({128}),
+                   arch + " runtime linear-attention scale shape was not initialized.");
+            ExpectFloatNear(expectedInvScale, ToFloatVector(runtimeModel.InvScaleData()),
+                            1e-7f, 1e-7f,
+                            arch + " runtime linear-attention inverse scale");
+            Expect(model->weight.dicts["ggufNormsPreOffset"] == "1" &&
+                       model->weight.dicts["ggufOutProjColumnsTiled"] == "1",
+                   arch + " GGUF runtime layout markers were not imported.");
+        }
+    }
+
+    void RunQwen35GGUFFailFastRegression() {
+        for (const auto &unsupported : std::vector<std::pair<std::string, uint32_t>>{
+                 {"qwen35moe", 1}, {"qwen35", 2}}) {
+            std::string path = MakeTempGGUFPath("fastllm-" + unsupported.first + "-unsupported");
+            WriteSyntheticQwen35GGUF(path, {}, unsupported.first, unsupported.second);
+            bool rejected = false;
+            try {
+                auto model = fastllm::CreateLLMModelFromGGUFFile(path, "");
+            } catch (const std::runtime_error &) {
+                rejected = true;
+            }
+            std::remove(path.c_str());
+            Expect(rejected, unsupported.first + " unsupported GGUF layout must fail fast.");
+        }
+    }
+
+    void RunQwen35GGUFWorkerExceptionRegression() {
+        std::string path = MakeTempGGUFPath("fastllm-qwen35-invalid-untile");
+        WriteSyntheticQwen35GGUF(path, {
+            {"blk.0.ssm_dt.bias", {47}, std::vector<float>(47, 1.0f)},
+        });
+        bool rejected = false;
+        try {
+            auto model = fastllm::CreateLLMModelFromGGUFFile(path, "");
+        } catch (const std::runtime_error &) {
+            rejected = true;
+        }
+        std::remove(path.c_str());
+        Expect(rejected, "invalid untile layout must propagate the worker exception.");
+    }
+
+    void RunQwen35GGUFWeightMappingRegression() {
+        constexpr int H = 16;
+        constexpr int R = 3;
+        constexpr int V = H * R;
+        constexpr int D = 128;
+        constexpr int qkRows = 2 * H * D;
+        constexpr int vRows = V * D;
+
+        auto makeValues = [](int rows, int width, float base) {
+            std::vector<float> values((size_t)rows * width);
+            for (int row = 0; row < rows; row++) {
+                for (int col = 0; col < width; col++) {
+                    values[(size_t)row * width + col] =
+                        base + (float)row * 0.25f + (float)col * 0.03125f;
+                }
+            }
+            return values;
+        };
+        auto untile = [](const std::vector<float> &source, int prefixRows,
+                         int perHeadRows, int width) {
+            std::vector<float> expected = source;
+            for (int h = 0; h < H; h++) {
+                for (int r = 0; r < R; r++) {
+                    for (int d = 0; d < perHeadRows; d++) {
+                        int srcRow = prefixRows + (r * H + h) * perHeadRows + d;
+                        int dstRow = prefixRows + (h * R + r) * perHeadRows + d;
+                        std::copy_n(source.begin() + (size_t)srcRow * width, width,
+                                    expected.begin() + (size_t)dstRow * width);
+                    }
+                }
+            }
+            return expected;
+        };
+
+        std::vector<float> aSource(V);
+        for (int i = 0; i < V; i++) {
+            aSource[i] = -std::exp(-0.01f * (float)(i + 1));
+        }
+        std::vector<float> expectedALog = untile(aSource, 0, 1, 1);
+        for (float &value : expectedALog) value = std::log(-value);
+
+        std::vector<float> alphaSource = makeValues(V, 1, 10.0f);
+        std::vector<float> betaSource = makeValues(V, 1, 20.0f);
+        std::vector<float> dtSource = makeValues(V, 1, 30.0f);
+        std::vector<float> convSource = makeValues(qkRows + vRows, 4, 40.0f);
+        std::vector<float> qkvSource = makeValues(qkRows + vRows, 1, 50.0f);
+        std::vector<float> gateSource = makeValues(vRows, 1, 60.0f);
+
+        std::vector<float> expectedBa = untile(betaSource, 0, 1, 1);
+        std::vector<float> expectedAlpha = untile(alphaSource, 0, 1, 1);
+        expectedBa.insert(expectedBa.end(), expectedAlpha.begin(), expectedAlpha.end());
+        std::vector<float> expectedDt = untile(dtSource, 0, 1, 1);
+        std::vector<float> expectedConv = untile(convSource, qkRows, D, 4);
+        std::vector<float> expectedQkvz = untile(qkvSource, qkRows, D, 1);
+        std::vector<float> expectedGate = untile(gateSource, 0, D, 1);
+        expectedQkvz.insert(expectedQkvz.end(), expectedGate.begin(), expectedGate.end());
+
+        std::string path = MakeTempGGUFPath("fastllm-qwen35-weights");
+        WriteSyntheticQwen35GGUF(path, {
+            {"blk.0.ssm_a", {V}, aSource},
+            {"blk.0.ssm_alpha.weight", {1, V}, alphaSource},
+            {"blk.0.ssm_beta.weight", {1, V}, betaSource},
+            {"blk.0.ssm_conv1d.weight", {4, qkRows + vRows}, convSource},
+            {"blk.0.ssm_dt.bias", {V}, dtSource},
+            {"blk.0.ssm_norm.weight", {D}, makeValues(D, 1, 70.0f)},
+            {"blk.0.ssm_out.weight", {1, 1}, {1.1f}},
+            {"blk.0.attn_qkv.weight", {1, qkRows + vRows}, qkvSource},
+            {"blk.0.attn_gate.weight", {1, vRows}, gateSource},
+            {"blk.64.nextn.eh_proj.weight", {1, 1}, {1.4f}},
+            {"blk.64.nextn.enorm.weight", {1}, {1.5f}},
+            {"blk.64.nextn.hnorm.weight", {1}, {1.6f}},
+            {"blk.64.nextn.shared_head_norm.weight", {1}, {1.7f}},
+            {"blk.64.attn_q.weight", {1, 1}, {1.8f}},
+            {"blk.64.attn_k.weight", {1, 1}, {1.9f}},
+            {"blk.64.attn_v.weight", {1, 1}, {2.0f}},
+            {"blk.64.attn_output.weight", {1, 1}, {2.1f}},
+            {"blk.64.attn_q_norm.weight", {1}, {2.2f}},
+            {"blk.64.attn_k_norm.weight", {1}, {2.3f}},
+            {"blk.64.attn_norm.weight", {1}, {2.4f}},
+            {"blk.64.post_attention_norm.weight", {1}, {2.5f}},
+            {"blk.64.ffn_gate.weight", {1, 1}, {2.6f}},
+            {"blk.64.ffn_up.weight", {1, 1}, {2.7f}},
+            {"blk.64.ffn_down.weight", {1, 2}, {2.8f, 2.9f}},
+        });
+        auto model = fastllm::CreateLLMModelFromGGUFFile(path, "");
+        std::remove(path.c_str());
+
+        const std::string prefix = "model.language_model.layers.0.linear_attn.";
+        ExpectFloatNear(expectedALog, ToFloatVector(RequireWeight(*model, prefix + "A_log")),
+                        2e-6f, 2e-6f, "qwen35 tiled ssm_a inverse transform");
+        ExpectFloatNear(expectedBa, ToFloatVector(RequireWeight(*model, prefix + "in_proj_ba.weight")),
+                        0.0f, 0.0f, "qwen35 tiled alpha/beta merge");
+        ExpectFloatNear(expectedDt, ToFloatVector(RequireWeight(*model, prefix + "dt_bias")),
+                        0.0f, 0.0f, "qwen35 tiled dt_bias");
+        const auto &convWeight = RequireWeight(*model, prefix + "conv1d.weight");
+        Expect(convWeight.dims == std::vector<int>({qkRows + vRows, 1, 4}),
+               "qwen35 GGUF conv1d weight must use [channels, 1, kernel] layout.");
+        ExpectFloatNear(expectedConv, ToFloatVector(convWeight), 0.0f, 0.0f,
+                        "qwen35 tiled conv1d channels");
+        ExpectFloatNear(expectedQkvz, ToFloatVector(RequireWeight(*model, prefix + "in_proj_qkvz.weight")),
+                        0.0f, 0.0f, "qwen35 tiled qkv/z merge");
+        RequireWeight(*model, prefix + "norm.weight");
+        RequireWeight(*model, prefix + "out_proj.weight");
+        Expect(model->weight.dicts["ggufNormsPreOffset"] == "1" &&
+                   model->weight.dicts["ggufOutProjColumnsTiled"] == "1",
+               "qwen35 GGUF runtime layout markers changed during weight import.");
+
+        RequireWeight(*model, "mtp.fc.weight");
+        RequireWeight(*model, "mtp.pre_fc_norm_embedding.weight");
+        RequireWeight(*model, "mtp.pre_fc_norm_hidden.weight");
+        RequireWeight(*model, "mtp.norm.weight");
+        RequireWeight(*model, "mtp.layers.0.self_attn.mergeqkv.weight");
+        RequireWeight(*model, "mtp.layers.0.self_attn.o_proj.weight");
+        RequireWeight(*model, "mtp.layers.0.mlp.gateup_proj.weight");
+        RequireWeight(*model, "mtp.layers.0.mlp.down_proj.weight");
+        Expect(model->weight.weight.find("model.language_model.layers.64.self_attn.q_proj.weight") ==
+                   model->weight.weight.end(),
+               "nextn decoder block must not remain in the trunk layer namespace.");
+    }
+
+    void RunQwen35MixedQuantGGUFProjectionRegression() {
+        std::string path = MakeTempGGUFPath("fastllm-qwen35-mixed-quant");
+        const char *oldTiled = std::getenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
+        const bool hadTiled = oldTiled != nullptr;
+        const std::string oldTiledValue = hadTiled ? oldTiled : "";
+        setenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED", "0", 1);
+        WriteSyntheticQwen35GGUF(path, {
+            MakeSyntheticQuantTensor("blk.0.attn_qkv.weight", {256, 256}, GGML_TYPE_Q5_K),
+            MakeSyntheticQuantTensor("blk.0.attn_gate.weight", {256, 256}, GGML_TYPE_IQ4_XS),
+            MakeSyntheticQuantTensor("blk.0.ssm_beta.weight", {256, 256}, GGML_TYPE_IQ4_XS),
+            MakeSyntheticQuantTensor("blk.0.ssm_alpha.weight", {256, 256}, GGML_TYPE_IQ4_XS),
+            MakeSyntheticQuantTensor("blk.3.attn_q.weight", {256, 256}, GGML_TYPE_IQ4_XS),
+            MakeSyntheticQuantTensor("blk.3.attn_k.weight", {256, 256}, GGML_TYPE_IQ4_XS),
+            MakeSyntheticQuantTensor("blk.3.attn_v.weight", {256, 256}, GGML_TYPE_Q5_K),
+        });
+        auto model = fastllm::CreateLLMModelFromGGUFFile(path, "");
+        if (hadTiled) {
+            setenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED", oldTiledValue.c_str(), 1);
+        } else {
+            unsetenv("FASTLLM_QWEN35_GGUF_VHEAD_TILED");
+        }
+        std::remove(path.c_str());
+
+        const std::string gdnPrefix = "model.language_model.layers.0.linear_attn.";
+        RequireWeight(*model, gdnPrefix + "in_proj_qkv.weight");
+        RequireWeight(*model, gdnPrefix + "in_proj_z.weight");
+        RequireWeight(*model, gdnPrefix + "in_proj_ba.weight");
+        Expect(model->weight.weight.find(gdnPrefix + "in_proj_qkvz.weight") ==
+                   model->weight.weight.end(),
+               "mixed Q5_K/IQ4_XS GDN projections must remain split.");
+        Expect(model->weight.weight.find(gdnPrefix + "in_proj_a.weight") ==
+                   model->weight.weight.end() &&
+               model->weight.weight.find(gdnPrefix + "in_proj_b.weight") ==
+                   model->weight.weight.end(),
+               "compatible IQ4_XS a/b projections should merge into ba.");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(
+                   model->weight, "model.language_model.layers.0.") ==
+                   fastllm::Qwen35GdnProjectionLayout::QkvZBa,
+               "mixed-quant GGUF should resolve to split qkv/z plus ba.");
+
+        const std::string attentionPrefix = "model.language_model.layers.3.";
+        RequireWeight(*model, attentionPrefix + "self_attn.q_proj.weight");
+        RequireWeight(*model, attentionPrefix + "self_attn.k_proj.weight");
+        RequireWeight(*model, attentionPrefix + "self_attn.v_proj.weight");
+        Expect(model->weight.weight.find(attentionPrefix + "self_attn.mergeqkv.weight") ==
+                   model->weight.weight.end(),
+               "mixed IQ4_XS/Q5_K attention projections must remain split.");
+        Expect(fastllm::ResolveQwen35AttentionProjectionLayout(
+                   model->weight, attentionPrefix) ==
+                   fastllm::Qwen35AttentionProjectionLayout::SplitQkv,
+               "mixed-quant GGUF should resolve to split q/k/v attention.");
+        Expect(model->weight.dicts["ggufOutProjColumnsTiled"] == "0",
+               "qwen35 grouped-layout override did not disable runtime out_proj reorder.");
+    }
+
+    void RunCpuEmbeddingDirectInMemoryLowMemRegression() {
+        // GGUF-loaded embedding weights live in cpuData with no fileName.
+        // CpuEmbeddingDirect must not try to fseek a null file handle in
+        // low-mem mode when the weight is already in memory.
+        bool prevLowMem = fastllm::GetLowMemMode();
+        fastllm::SetLowMemMode(true);
+
+        const int vocabSize = 4;
+        const int embSize = 3;
+        std::vector<float> weightValues = {
+            0.0f, 0.1f, 0.2f,   // token 0
+            1.0f, 1.1f, 1.2f,   // token 1
+            2.0f, 2.1f, 2.2f,   // token 2
+            3.0f, 3.1f, 3.2f    // token 3
+        };
+        fastllm::Data weight(fastllm::DataType::FLOAT32, {vocabSize, embSize}, weightValues);
+        Expect(weight.fileName.empty(), "in-memory weight should have no fileName.");
+
+        std::vector<float> inputValues = {0.0f, 3.0f, 1.0f};
+        fastllm::Data input(fastllm::DataType::FLOAT32, {3}, inputValues);
+        fastllm::Data output;
+
+        fastllm::Executor *executor = (fastllm::Executor*)fastllm::GetExecutor();
+        executor->RunOnDevice("cpu", "EmbeddingDirect",
+                              fastllm::DataDict{{"input", &input},
+                                                {"weight", &weight},
+                                                {"output", &output}},
+                              fastllm::FloatDict(), fastllm::IntDict());
+
+        fastllm::SetLowMemMode(prevLowMem);
+
+        std::vector<float> result = ToFloatVector(output);
+        ExpectFloatNear({0.0f, 0.1f, 0.2f,
+                         3.0f, 3.1f, 3.2f,
+                         1.0f, 1.1f, 1.2f}, result, 1e-6f, 1e-6f,
+                        "CpuEmbeddingDirect low-mem in-memory lookup");
+    }
+
+    void RunQwen35SplitGdnProjectionLayoutRegression() {
+        const std::string prefix = "model.language_model.layers.0.";
+        fastllm::WeightMap weights;
+        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_qkv.weight", {10, 4},
+                               fastllm::DataType::FLOAT32);
+        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_z.weight", {6, 4},
+                               fastllm::DataType::FLOAT32);
+        weights.AddEmptyWeight(prefix + "linear_attn.in_proj_ba.weight", {4, 4},
+                               fastllm::DataType::FLOAT32);
+
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(weights, prefix) ==
+                   fastllm::Qwen35GdnProjectionLayout::QkvZBa,
+               "qwen35 mixed-quant qkv/z plus ba should be a valid GDN projection layout.");
+
+        weights.weight.erase(prefix + "linear_attn.in_proj_z.weight");
+        Expect(fastllm::ResolveQwen35GdnProjectionLayout(weights, prefix) ==
+                   fastllm::Qwen35GdnProjectionLayout::Missing,
+               "qwen35 split GDN projection must require both qkv and z weights.");
     }
 
     void ExpectFloatNear(const std::vector<float> &expected,
@@ -127,8 +617,50 @@ namespace {
         }
     }
 
+    void RunQwen35SplitAttentionProjectionLayoutRegression() {
+        const std::string prefix = "model.language_model.layers.3.";
+        fastllm::WeightMap weights;
+        weights.AddEmptyWeight(prefix + "self_attn.q_proj.weight", {12, 4},
+                               fastllm::DataType::FLOAT32);
+        weights.AddEmptyWeight(prefix + "self_attn.k_proj.weight", {2, 4},
+                               fastllm::DataType::FLOAT32);
+        weights.AddEmptyWeight(prefix + "self_attn.v_proj.weight", {2, 4},
+                               fastllm::DataType::FLOAT32);
+
+        Expect(fastllm::ResolveQwen35AttentionProjectionLayout(weights, prefix) ==
+                   fastllm::Qwen35AttentionProjectionLayout::SplitQkv,
+               "qwen35 mixed-quant q/k/v should be a valid split attention layout.");
+
+        weights.weight.erase(prefix + "self_attn.v_proj.weight");
+        Expect(fastllm::ResolveQwen35AttentionProjectionLayout(weights, prefix) ==
+                   fastllm::Qwen35AttentionProjectionLayout::Missing,
+               "qwen35 split attention must require q, k, and v weights.");
+    }
+
+#ifdef USE_CUDA
+    void RunQwen35OutProjTpLayoutRegression() {
+        DivisionScheme keyScheme;
+        keyScheme[0] = {{0, 8}};
+        keyScheme[1] = {{8, 16}};
+
+        DivisionScheme tiled = fastllm::BuildQwen35LinearOutProjScheme(
+            keyScheme, 16, 48, 128, 256, true);
+        Expect(tiled[0] == DivisionScheme::mapped_type({
+                   {0, 1024}, {2048, 3072}, {4096, 5120}}) &&
+               tiled[1] == DivisionScheme::mapped_type({
+                   {1024, 2048}, {3072, 4096}, {5120, 6144}}),
+               "qwen35 tiled out_proj TP scheme changed layout.");
+
+        DivisionScheme grouped = fastllm::BuildQwen35LinearOutProjScheme(
+            keyScheme, 16, 48, 128, 256, false);
+        Expect(grouped[0] == DivisionScheme::mapped_type({{0, 3072}}) &&
+               grouped[1] == DivisionScheme::mapped_type({{3072, 6144}}),
+               "qwen35 grouped out_proj TP scheme must stay contiguous.");
+    }
+#endif
     void RunMoeAtypeConfigRegression() {
         MoeAtypeConfigTestModel model;
+
         Expect(!model.useCustomMoeAtype, "moe_atype should default to auto.");
 
         model.SetMoeAtype(fastllm::DataType::FLOAT32);
@@ -484,6 +1016,7 @@ namespace {
     }
 #endif
 
+
     fastllm::Data MakeTensor(fastllm::DataType dataType, const std::vector<int> &dims, float seed = 0.0f) {
         int count = 1;
         for (int dim : dims) {
@@ -741,6 +1274,45 @@ namespace {
                                  0.5f * std::cos((i + 3) * 0.043f - seed));
         }
         return values;
+    }
+
+    void RunCudaGreedyTieBreakRegression() {
+        constexpr int batch = 2;
+        constexpr int vocabSize = 300;
+        std::vector<float> logits((size_t)batch * vocabSize, -10.0f);
+        logits[1] = 7.0f;
+        logits[257] = 7.0f;
+        logits[vocabSize + 3] = 4.0f;
+        logits[vocabSize + 259] = 4.0f;
+
+        float *cudaLogits = (float *)FastllmCudaMalloc(logits.size() * sizeof(float));
+        int *cudaIds = (int *)FastllmCudaMalloc(batch * sizeof(int));
+        float *cudaScores = (float *)FastllmCudaMalloc(batch * sizeof(float));
+        FastllmCudaCopyFromHostToDevice(cudaLogits, logits.data(), logits.size() * sizeof(float));
+
+        Expect(FastllmCudaGreedySampling(cudaLogits, cudaIds, batch, vocabSize),
+               "greedy sampling kernel rejected tie-break fixture");
+        std::vector<int> plainIds(batch);
+        FastllmCudaCopyFromDeviceToHost(plainIds.data(), cudaIds, batch * sizeof(int));
+
+        Expect(FastllmCudaGreedySamplingWithScores(
+                   cudaLogits, cudaIds, cudaScores, batch, vocabSize),
+               "greedy sampling with scores rejected tie-break fixture");
+        std::vector<int> scoredIds(batch);
+        std::vector<float> scores(batch);
+        FastllmCudaCopyFromDeviceToHost(scoredIds.data(), cudaIds, batch * sizeof(int));
+        FastllmCudaCopyFromDeviceToHost(scores.data(), cudaScores, batch * sizeof(float));
+
+        FastllmCudaFree(cudaScores);
+        FastllmCudaFree(cudaIds);
+        FastllmCudaFree(cudaLogits);
+
+        Expect(plainIds == std::vector<int>({1, 3}),
+               "plain greedy sampling did not choose the lowest token id on a tie");
+        Expect(scoredIds == plainIds,
+               "greedy sampling kernels disagree on tied maximum logits");
+        ExpectFloatNear({7.0f, 4.0f}, scores, 0.0f, 0.0f,
+                        "greedy sampling tied maximum scores");
     }
 
     void RunCudaTritonChunkGdnPrefillRegression() {
@@ -1513,7 +2085,7 @@ namespace {
         fastllm::Data bias = MakeCudaTensor(fastllm::DataType::FLOAT32,
                                             {channels}, biasValues);
 
-        for (int tokenCount = 1; tokenCount <= 6; tokenCount++) {
+        for (int tokenCount = 1; tokenCount <= 10; tokenCount++) {
             std::vector<float> tokenValues =
                 MakeRegressionValues(rows * tokenCount, 1.7f + tokenCount, 0.4f);
             fastllm::Data allTokens = MakeCudaTensor(fastllm::DataType::FLOAT16,
@@ -1571,26 +2143,26 @@ namespace {
             ExpectFloatNear(ToFloatVector(sequentialCache), ToFloatVector(multiCache),
                             1e-3f, 1e-3f,
                             "multi-token conv final cache N=" + std::to_string(tokenCount));
-            if (tokenCount == 6) {
+            if (tokenCount == 10) {
                 fastllm::Data partialCache = MakeCudaTensor(
                     fastllm::DataType::FLOAT16, {batch, channels, 4}, initialCacheValues);
-                std::vector<fastllm::Data> partialSnapshots(5);
-                std::vector<fastllm::Data*> partialSnapshotPtrs(5);
-                for (int token = 0; token < 5; token++) {
+                std::vector<fastllm::Data> partialSnapshots(9);
+                std::vector<fastllm::Data*> partialSnapshotPtrs(9);
+                for (int token = 0; token < 9; token++) {
                     partialSnapshotPtrs[token] = &partialSnapshots[token];
                 }
                 fastllm::Data partialOutput;
                 Expect(FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16(
                            partialCache, allTokens, weight, bias, partialOutput,
-                           partialSnapshotPtrs.data(), 5),
-                       "multi-token conv rejected N=6 with five prefix snapshots");
+                           partialSnapshotPtrs.data(), 9),
+                       "multi-token conv rejected N=10 with nine prefix snapshots");
                 ExpectFloatNear(ToFloatVector(multiOutput), ToFloatVector(partialOutput),
                                 1e-3f, 1e-3f,
                                 "multi-token conv partial-snapshot output");
                 ExpectFloatNear(ToFloatVector(multiCache), ToFloatVector(partialCache),
                                 1e-3f, 1e-3f,
                                 "multi-token conv partial-snapshot final cache");
-                for (int token = 0; token < 5; token++) {
+                for (int token = 0; token < 9; token++) {
                     ExpectFloatNear(expectedCaches[token], ToFloatVector(partialSnapshots[token]),
                                     1e-3f, 1e-3f,
                                     "multi-token conv partial snapshot token=" +
@@ -1667,7 +2239,7 @@ namespace {
                        "multi-token conv accepted a snapshot count larger than N");
         }
         {
-            const int tooManyTokens = 7;
+            const int tooManyTokens = 11;
             fastllm::Data cache = MakeCudaTensor(fastllm::DataType::FLOAT16,
                                                  {batch, channels, 4}, initialCacheValues);
             fastllm::Data tokens = MakeCudaTensor(
@@ -1676,7 +2248,7 @@ namespace {
             fastllm::Data output;
             Expect(!FastllmCudaShiftAppendConv1DPerChannelSiluMultiTokenFloat16(
                        cache, tokens, weight, bias, output, nullptr, 0),
-                   "multi-token conv accepted N=7");
+                   "multi-token conv accepted N=11");
         }
     }
 
@@ -1957,7 +2529,7 @@ namespace {
         fastllm::Data dtBias = MakeCudaTensor(fastllm::DataType::FLOAT32,
                                               {numVHeads}, {0.15f, -0.08f});
 
-        for (int tokenCount = 2; tokenCount <= 6; tokenCount++) {
+        for (int tokenCount = 2; tokenCount <= 10; tokenCount++) {
             std::vector<float> convValues =
                 MakeRegressionValues(tokenCount * qkvDim, 2.1f + tokenCount, 0.12f);
             std::vector<float> baValues(tokenCount * numVHeads * 2);
@@ -2009,7 +2581,7 @@ namespace {
                 expectedStates[token] = ToFloatVector(sequentialState);
             }
 
-            int snapshotCount = std::min(tokenCount, 5);
+            int snapshotCount = std::min(tokenCount, 9);
             std::vector<fastllm::Data> snapshots(snapshotCount);
             std::vector<fastllm::Data*> snapshotPtrs(snapshotCount);
             for (int token = 0; token < snapshotCount; token++) {
@@ -2069,22 +2641,22 @@ namespace {
             ExpectFloatNear(ToFloatVector(sequentialState), ToFloatVector(sequenceState),
                             2e-3f, 2e-3f,
                             "recurrent final state N=" + std::to_string(tokenCount));
-            if (tokenCount == 6) {
+            if (tokenCount == 10) {
                 fastllm::Data rejectedState = MakeCudaTensor(
                     fastllm::DataType::FLOAT16,
                     {1, numVHeads, headKDim, headVDim}, initialStateValues);
                 rejectedState.isLinearAttentionTransposed = true;
-                fastllm::Data rejectedSnapshots[6];
-                fastllm::Data *rejectedSnapshotPtrs[6];
-                for (int token = 0; token < 6; token++) {
+                fastllm::Data rejectedSnapshots[10];
+                fastllm::Data *rejectedSnapshotPtrs[10];
+                for (int token = 0; token < 10; token++) {
                     rejectedSnapshotPtrs[token] = &rejectedSnapshots[token];
                 }
                 fastllm::Data rejectedOutput;
                 Expect(!FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16Snapshots(
                            convSequence, baSequence, normWeight, aLog, dtBias,
-                           rejectedState, rejectedOutput, rejectedSnapshotPtrs, 6,
+                           rejectedState, rejectedOutput, rejectedSnapshotPtrs, 10,
                            numKHeads, numVHeads, headKDim, headVDim, eps, qScale),
-                       "recurrent sequence accepted N=6 with six snapshots");
+                       "recurrent sequence accepted N=10 with ten snapshots");
             }
         }
 
@@ -2128,7 +2700,7 @@ namespace {
                        "recurrent snapshot sequence accepted nullptr tokenStates");
         }
         {
-            const int tooManyTokens = 7;
+            const int tooManyTokens = 11;
             fastllm::Data conv = MakeCudaTensor(
                 fastllm::DataType::FLOAT16, {1, tooManyTokens, qkvDim},
                 MakeRegressionValues(tooManyTokens * qkvDim, 6.4f, 0.12f));
@@ -2144,7 +2716,7 @@ namespace {
             Expect(!FastllmRecurrentGatedDeltaRuleSequenceFromConvBaTransposedFloat16(
                        conv, ba, normWeight, aLog, dtBias, state, output,
                        numKHeads, numVHeads, headKDim, headVDim, eps, qScale),
-                   "recurrent sequence accepted N=7");
+                   "recurrent sequence accepted N=11");
         }
     }
 #endif
@@ -2309,11 +2881,20 @@ namespace {
                "CPU AWQ regression requires complete quantization groups.");
         const int group = inputDim / groupCnt;
 
+        // The production INT4_GROUP path first quantizes activations to uint8
+        // per group. Use an exactly representable 1/64 grid and include both
+        // endpoints in every group, so the dense reference isolates weight
+        // packing/math instead of measuring expected activation quantization error.
         std::vector<float> inputValues((size_t)batch * inputDim);
         for (int b = 0; b < batch; b++) {
-            for (int x = 0; x < inputDim; x++) {
-                inputValues[(size_t)b * inputDim + x] =
-                    (float)((x * (b + 3) + 11 * b) % 251 - 125) / 64.0f;
+            for (int g = 0; g < group; g++) {
+                for (int local = 0; local < groupCnt; local++) {
+                    int code = local == 0 ? -128 :
+                               (local == 1 ? 127 :
+                                (((local * 17 + b * 23 + g * 7) & 255) - 128));
+                    int x = g * groupCnt + local;
+                    inputValues[(size_t)b * inputDim + x] = (float)code / 64.0f;
+                }
             }
         }
 
@@ -2889,8 +3470,11 @@ namespace {
         } else {
             unsetenv("FASTLLM_CUDA_MOE_INT4_GROUP_SMALL_BATCH");
         }
+        // Different expert batching produces a different FP32 reduction tree.
+        // Both paths already pass the dense reference checks above; constrain
+        // the remaining FP16 rounding difference to a tight numerical budget.
         ExpectFloatNear(ToFloatVector(fallbackOutput), ToFloatVector(batchOutput),
-                        0.0f, 0.0f,
+                        1e-5f, 1e-3f,
                         "CUDA INT4_GROUP small-batch fused versus generic MergeMOE");
     }
 
@@ -3012,6 +3596,859 @@ namespace {
                         "CUDA INT8 batch-1 fused MoE graph downstream consumer");
         FastllmCudaGraphExecDestroy(graphExec);
         FastllmCudaGraphDestroy(graph);
+    }
+
+    // ---------------------------------------------------------------------------
+    // CUDA GGUF IQ4_XS / Q5_0 dequant + SM70 MMQ regression.
+    //
+    // Dispatch branches covered for each format:
+    //   n <= 7  -> DP4A MMVQ (chunked, Q8_1 input quant)
+    //   8 <= n <= 64 (SM70, IQ4_XS only) -> SM70 IQ4_XS DP4A MMQ trial
+    //                  (Q8_1 input quant, FP32 accumulate). Trial/fallback:
+    //                  on rejection or unsupported device, falls through to
+    //                  the dequant+GEMM path below.
+    //   n >  7  -> dequant + cublas GEMM (when dequant enabled)
+    // The reference is CPU dequantize_row_* + dense FP32 matmul, modeling
+    // input-dtype rounding and Q8_1 quant/dequant for the Q8_1 paths.
+    //
+    // Route assertion: the env switch FASTLLM_DISABLE_GGUF_DEQUANT_IQ4XS_Q5_0
+    // nulls the FP16/BF16 dequantizer so n>7 falls back to chunked MMVQ. The
+    // SM70 MMQ trial is gated by FASTLLM_CUDA_SM70_IQ4XS_MMQ (default on for
+    // SM70). Without a production introspection helper, each case is checked
+    // against BOTH the Q8_1 and dequant+GEMM references and must match at
+    // least one within tolerance.
+    // ---------------------------------------------------------------------------
+    static const int8_t kIq4NlValuesCpu[16] = {
+        -127, -104, -83, -65, -49, -35, -22, -10,
+        1, 13, 25, 38, 53, 69, 89, 113
+    };
+
+    static void FillIq4XsBlock(block_iq4_xs &blk, uint32_t seed) {
+        // Deterministic pseudo-random fill that exercises all nibble values,
+        // all six-bit scale values, and the high-bit paths.
+        auto rng = [seed](uint32_t &s) -> uint8_t {
+            s = s * 1103515245u + 12345u;
+            return (uint8_t)((s >> 16) & 0xFF);
+        };
+        uint32_t s = seed;
+
+        // d: tiny fp16 so dequantized weights stay in a realistic ~0.01..0.1
+        // magnitude band, avoiding FP16-output saturation that obscures
+        // real decode errors behind cancellation noise.
+        uint16_t dBits = 0x0280u | ((uint16_t)rng(s) & 0x007Fu); // ~2^-16 band
+        std::memcpy(&blk.d, &dBits, sizeof(dBits));
+
+        // scales_h: 2 high bits per sub-block (8 sub-blocks -> 16 bits).
+        blk.scales_h = (uint16_t)(rng(s) | ((uint16_t)rng(s) << 8));
+
+        // scales_l: 4 low bits per sub-block, packed 2 per byte.
+        blk.scales_l[0] = rng(s);
+        blk.scales_l[1] = rng(s);
+        blk.scales_l[2] = rng(s);
+        blk.scales_l[3] = rng(s);
+
+        // qs: 128 nibbles (64 bytes), cycling through all 16 values.
+        for (int i = 0; i < QK_K / 2; i++) {
+            blk.qs[i] = rng(s);
+        }
+    }
+
+    static void FillQ5_0Block(block_q5_0 &blk, uint32_t seed) {
+        auto rng = [seed](uint32_t &s) -> uint8_t {
+            s = s * 1103515245u + 12345u;
+            return (uint8_t)((s >> 16) & 0xFF);
+        };
+        uint32_t s = seed;
+        // d: small fp16 so dequantized weights stay realistic (~0.01..0.1),
+        // avoiding FP16-output saturation that obscures decode errors.
+        uint16_t dBits = 0x1C00u | ((uint16_t)rng(s) & 0x01FFu); // ~2^-9 band
+        std::memcpy(&blk.d, &dBits, sizeof(dBits));
+
+        // qh: 5th bits for all 32 values.
+        uint32_t qhBits = ((uint32_t)rng(s)) | ((uint32_t)rng(s) << 8) |
+                         ((uint32_t)rng(s) << 16) | ((uint32_t)rng(s) << 24);
+        std::memcpy(blk.qh, &qhBits, sizeof(qhBits));
+
+        // qs: 16 low-nibble bytes.
+        for (int i = 0; i < QK5_0 / 2; i++) {
+            blk.qs[i] = rng(s);
+        }
+    }
+
+    // CPU reference dequant for iq4_xs (mirrors dequantize_row_iq4_xs).
+    static void CpuDequantIq4Xs(const block_iq4_xs *blocks, int64_t nblocks,
+                                 std::vector<float> &out) {
+        out.resize((size_t)nblocks * QK_K);
+        for (int64_t i = 0; i < nblocks; i++) {
+            uint16_t dBits;
+            std::memcpy(&dBits, &blocks[i].d, sizeof(dBits));
+            const float d = fastllm::half_to_float(dBits);
+            const uint8_t *qs = blocks[i].qs;
+            float *y = out.data() + (size_t)i * QK_K;
+            for (int ib = 0; ib < QK_K / 32; ib++) {
+                int ls = ((blocks[i].scales_l[ib / 2] >> (4 * (ib % 2))) & 0x0f) |
+                         (((blocks[i].scales_h >> (2 * ib)) & 0x3) << 4);
+                float dl = d * (float)(ls - 32);
+                for (int j = 0; j < 16; j++) {
+                    y[j]      = dl * (float)kIq4NlValuesCpu[qs[j] & 0xf];
+                    y[j + 16] = dl * (float)kIq4NlValuesCpu[qs[j] >> 4];
+                }
+                y += 32;
+                qs += 16;
+            }
+        }
+    }
+
+    // CPU reference dequant for q5_0 (mirrors dequantize_row_q5_0).
+    static void CpuDequantQ5_0(const block_q5_0 *blocks, int64_t nblocks,
+                                std::vector<float> &out) {
+        out.resize((size_t)nblocks * QK5_0);
+        for (int64_t i = 0; i < nblocks; i++) {
+            uint16_t dBits;
+            std::memcpy(&dBits, &blocks[i].d, sizeof(dBits));
+            const float d = fastllm::half_to_float(dBits);
+            uint32_t qh;
+            std::memcpy(&qh, blocks[i].qh, sizeof(qh));
+            float *y = out.data() + (size_t)i * QK5_0;
+            for (int j = 0; j < QK5_0 / 2; j++) {
+                uint8_t xh0 = (uint8_t)(((qh >> (j +  0)) << 4) & 0x10);
+                uint8_t xh1 = (uint8_t)((qh >> (j + 12)) & 0x10);
+                int x0 = ((blocks[i].qs[j] & 0x0f) | xh0) - 16;
+                int x1 = ((blocks[i].qs[j] >>  4) | xh1) - 16;
+                y[j]            = x0 * d;
+                y[j + QK5_0/2]  = x1 * d;
+            }
+        }
+    }
+
+    // Dense CPU matmul: output[n][k] = sum_m input_fp16[n][m] * weight_fp32[k][m].
+    // weight is [k][m] row-major (output_dim × input_dim), same as Linear convention.
+    static void CpuDenseMatmul(const std::vector<float> &inputFp32,
+                               int n, int m, int k,
+                               const std::vector<float> &weightFp32,
+                               std::vector<float> &out) {
+        out.assign((size_t)n * k, 0.0f);
+        for (int ni = 0; ni < n; ni++) {
+            for (int ki = 0; ki < k; ki++) {
+                float sum = 0.0f;
+                for (int mi = 0; mi < m; mi++) {
+                    sum += inputFp32[(size_t)ni * m + mi] *
+                           weightFp32[(size_t)ki * m + mi];
+                }
+                out[(size_t)ni * k + ki] = sum;
+            }
+        }
+    }
+
+    static float RoundToFp16(float value) {
+        return fastllm::half_to_float(fastllm::float_to_half(value));
+    }
+
+    static void RoundInputToFp16(std::vector<float> &values) {
+        for (float &value : values) {
+            value = RoundToFp16(value);
+        }
+    }
+
+    static void RoundOutputToFp16(std::vector<float> &values) {
+        constexpr float kMaxFp16 = 65504.0f;
+        for (float &value : values) {
+            value = RoundToFp16(std::max(-kMaxFp16, std::min(kMaxFp16, value)));
+        }
+    }
+
+    static void RoundWeightToFp16(std::vector<float> &values) {
+        for (float &value : values) {
+            value = RoundToFp16(value);
+        }
+    }
+
+    // --- BF16 rounding helpers (matching production conversion conventions) ---
+
+    // BF16 round-to-nearest-even (matches __float2bfloat16_rn used by CUDA
+    // dequant kernels and MMVQ/MMQ output casts).
+    static float RoundToBf16Rne(float value) {
+        uint32_t bits;
+        std::memcpy(&bits, &value, sizeof(bits));
+        uint32_t lsb = (bits >> 16) & 1;
+        bits += 0x7FFFu + lsb;
+        uint16_t bf16Bits = (uint16_t)(bits >> 16);
+        uint32_t restored = (uint32_t)bf16Bits << 16;
+        float result;
+        std::memcpy(&result, &restored, sizeof(result));
+        return result;
+    }
+
+    // BF16 truncation (matches Data(BFLOAT16,...) constructor's fp32->bf16
+    // cast used when constructing activation tensors from float vectors).
+    static float RoundToBf16Trunc(float value) {
+        uint32_t bits;
+        std::memcpy(&bits, &value, sizeof(bits));
+        uint16_t bf16Bits = (uint16_t)(bits >> 16);
+        uint32_t restored = (uint32_t)bf16Bits << 16;
+        float result;
+        std::memcpy(&result, &restored, sizeof(result));
+        return result;
+    }
+
+    static void RoundInputToBf16(std::vector<float> &values) {
+        for (float &v : values) { v = RoundToBf16Trunc(v); }
+    }
+
+    static void RoundOutputToBf16(std::vector<float> &values) {
+        for (float &v : values) { v = RoundToBf16Rne(v); }
+    }
+
+    static void RoundWeightToBf16(std::vector<float> &values) {
+        for (float &v : values) { v = RoundToBf16Rne(v); }
+    }
+
+    // Round input values to the activation dtype's precision, matching how
+    // the Data constructor casts float vectors to the target type.
+    static void RoundInputToDtype(std::vector<float> &values,
+                                  fastllm::DataType dtype) {
+        if (dtype == fastllm::DataType::FLOAT16) {
+            RoundInputToFp16(values);
+        } else if (dtype == fastllm::DataType::BFLOAT16) {
+            RoundInputToBf16(values);
+        }
+        // FLOAT32: no rounding.
+    }
+
+    // Round output values to the output dtype's precision, matching how CUDA
+    // kernels cast FP32 dot-product results to the output type.
+    static void RoundOutputToDtype(std::vector<float> &values,
+                                   fastllm::DataType dtype) {
+        if (dtype == fastllm::DataType::FLOAT16) {
+            RoundOutputToFp16(values);
+        } else if (dtype == fastllm::DataType::BFLOAT16) {
+            RoundOutputToBf16(values);
+        }
+        // FLOAT32: no rounding.
+    }
+
+    // Round weight values for the dequant+GEMM reference path. BF16 input uses
+    // the BF16 dequant kernel (__float2bfloat16_rn); FP16 and FP32 input both
+    // use the FP16 dequant kernel by default (no FASTLLM_GGUF_FP32_DEQUANT).
+    static void RoundWeightForGemm(std::vector<float> &values,
+                                   fastllm::DataType actDtype) {
+        if (actDtype == fastllm::DataType::BFLOAT16) {
+            RoundWeightToBf16(values);
+        } else {
+            RoundWeightToFp16(values);
+        }
+    }
+
+    static void QuantizeQ8_1DequantizeInPlace(std::vector<float> &values, int rowSize) {
+        Expect(rowSize % QK8_1 == 0, "Q8_1 reference input row size must be 32-aligned.");
+        Expect(values.size() % (size_t)rowSize == 0, "Q8_1 reference input size mismatch.");
+        for (size_t row = 0; row < values.size(); row += rowSize) {
+            for (int block = 0; block < rowSize; block += QK8_1) {
+                float amax = 0.0f;
+                for (int j = 0; j < QK8_1; j++) {
+                    amax = std::max(amax, std::fabs(values[row + block + j]));
+                }
+                const float d = amax == 0.0f ? 0.0f : amax / 127.0f;
+                const float dequantD = RoundToFp16(d);
+                for (int j = 0; j < QK8_1; j++) {
+                    const float q = d == 0.0f ? 0.0f : std::round(values[row + block + j] / d);
+                    values[row + block + j] = q * dequantD;
+                }
+            }
+        }
+    }
+
+    static void QuantizeQ8D4DequantizeInPlace(std::vector<float> &values,
+                                               int rowSize) {
+        Expect(rowSize % (4 * QK8_1) == 0,
+               "Q8 D4 reference input row size must be 128-aligned.");
+        Expect(values.size() % (size_t)rowSize == 0,
+               "Q8 D4 reference input size mismatch.");
+        for (size_t row = 0; row < values.size(); row += rowSize) {
+            for (int block128 = 0; block128 < rowSize;
+                 block128 += 4 * QK8_1) {
+                for (int group = 0; group < 4; group++) {
+                    const int block = block128 + group * QK8_1;
+                    float amax = 0.0f;
+                    for (int j = 0; j < QK8_1; j++) {
+                        amax = std::max(
+                            amax, std::fabs(values[row + block + j]));
+                    }
+                    const float d = amax == 0.0f ? 0.0f : amax / 127.0f;
+                    for (int j = 0; j < QK8_1; j++) {
+                        const float q = d == 0.0f
+                            ? 0.0f
+                            : std::round(values[row + block + j] / d);
+                        values[row + block + j] = q * d;
+                    }
+                }
+            }
+        }
+    }
+
+    static bool GgufDequantIq4xsQ50EnvDisabled() {
+        const char *v = std::getenv("FASTLLM_DISABLE_GGUF_DEQUANT_IQ4XS_Q5_0");
+        if (v == nullptr || v[0] == '\0') return false;
+        char c = (char)std::tolower((unsigned char)v[0]);
+        return c == '1' || c == 't' || c == 'y' || c == 'o';
+    }
+
+    // Build a GGUF quantized weight with synthetic blocks, dequant CPU reference,
+    // run CUDA Linear across batch sizes, verify, and assert the dispatched branch.
+    template <typename BlockT>
+    static void RunGgufDequantRegressionOne(ggml_type quantType, int inputDim,
+                                             int outputDim, const char *typeName,
+                                             void (*fillBlock)(BlockT &, uint32_t),
+                                             void (*cpuDequant)(const BlockT *, int64_t,
+                                                                std::vector<float> &)) {
+        const int blockSize = (int)ggml_blck_size(quantType);
+        Expect(inputDim % blockSize == 0,
+               std::string("input dim must be aligned to ") + typeName + " block size.");
+        int blocksPerRow = inputDim / blockSize;
+
+        // Uninitialized Data via the GGUF constructor, then fill raw blocks.
+        fastllm::Data weight(fastllm::DataType::DATA_GGUF_FORMAT, (int)quantType,
+                             {outputDim, inputDim});
+        weight.isGGUFData = true;
+        weight.disableGGUFRepack = true; // keep IQ4_XS/Q5_0 type stable for the CUDA dequant path
+        weight.Allocate();
+        size_t bytesPerRow = ggml_row_size(quantType, inputDim);
+
+        // Build the CPU reference dequantized weights.
+        std::vector<float> refWeightFp32((size_t)outputDim * inputDim);
+        for (int row = 0; row < outputDim; row++) {
+            std::vector<BlockT> rowBlocks(blocksPerRow);
+            for (int b = 0; b < blocksPerRow; b++) {
+                std::memset(&rowBlocks[b], 0, sizeof(BlockT));
+                fillBlock(rowBlocks[b], (uint32_t)((row * 1000 + b) * 7 + 3));
+            }
+            // Write blocks into the weight's CPU buffer.
+            std::memcpy(weight.cpuData + (size_t)row * bytesPerRow,
+                        rowBlocks.data(), (size_t)blocksPerRow * sizeof(BlockT));
+            // Dequant this row for the CPU reference.
+            std::vector<float> dequantRow;
+            cpuDequant(rowBlocks.data(), blocksPerRow, dequantRow);
+            std::memcpy(refWeightFp32.data() + (size_t)row * inputDim,
+                        dequantRow.data(), (size_t)inputDim * sizeof(float));
+        }
+        // Identity-input dequant check: feed a square identity matrix as the
+        // activation so the Linear output equals the dequantized weight rows
+        // directly. This isolates the CUDA dequantizer + row/column layout from
+        // any matmul accumulation noise. Bypassed when outputDim != inputDim.
+        if (outputDim == inputDim) {
+            std::vector<float> identity((size_t)inputDim * inputDim, 0.0f);
+            for (int i = 0; i < inputDim; i++) {
+                identity[(size_t)i * inputDim + i] = 1.0f;
+            }
+            fastllm::Data idInput(fastllm::DataType::FLOAT16, {inputDim, inputDim}, identity);
+            idInput.ToDevice(fastllm::DataDevice::CUDA, std::vector<int>{0}, true);
+            fastllm::Data idWeight = weight;
+            idWeight.name = std::string("regression.gguf_dequant.identity.") + typeName;
+            idWeight.ToDevice(fastllm::DataDevice::CUDA, std::vector<int>{0}, true);
+            fastllm::Data idActual;
+            {
+                ScopedFirstDevice guard("cuda");
+                fastllm::Data emptyBias;
+                fastllm::Linear(idInput, idWeight, emptyBias, idActual);
+            }
+            std::vector<float> idRef = refWeightFp32;
+            RoundOutputToFp16(idRef);
+            float idAtol = (quantType == GGML_TYPE_IQ4_XS) ? 1.5f : 0.5f;
+            float idRtol = (quantType == GGML_TYPE_IQ4_XS) ? 0.15f : 0.08f;
+            ExpectFloatNear(idRef, ToFloatVector(idActual), idAtol, idRtol,
+                            std::string("CUDA GGUF ") + typeName +
+                            " identity dequant (weight rows exact)");
+        }
+
+        // Batches spanning the MMVQ (n<=7) / SM70 MMQ trial (8<=n<=64) /
+        // dequant+GEMM (n>7, or n>64 fallback) boundaries.
+        const std::vector<int> batches = {1, 7, 8, 16, 33};
+
+        for (int batch : batches) {
+            // Deterministic synthetic activation.
+            std::vector<float> inputFp32((size_t)batch * inputDim);
+            for (int ni = 0; ni < batch; ni++) {
+                for (int mi = 0; mi < inputDim; mi++) {
+                    inputFp32[(size_t)ni * inputDim + mi] =
+                        (float)((ni * 17 + mi * 13 + 5) % 101 - 50) / 47.0f;
+                }
+            }
+
+            bool dequantDisabled = GgufDequantIq4xsQ50EnvDisabled();
+            bool expectDequantGemm = (batch > 7) && !dequantDisabled;
+            std::vector<float> refInput = inputFp32;
+            RoundInputToFp16(refInput);
+            if (!expectDequantGemm) {
+                QuantizeQ8_1DequantizeInPlace(refInput, inputDim);
+            }
+            std::vector<float> refWeight = refWeightFp32;
+            if (expectDequantGemm) {
+                RoundWeightToFp16(refWeight);
+            }
+            std::vector<float> refOutput;
+            CpuDenseMatmul(refInput, batch, inputDim, outputDim, refWeight, refOutput);
+            RoundOutputToFp16(refOutput);
+
+            // CUDA path: FP16 activation + GGUF quantized weight.
+            fastllm::Data inputHalf(fastllm::DataType::FLOAT16, {batch, inputDim}, inputFp32);
+            inputHalf.ToDevice(fastllm::DataDevice::CUDA, std::vector<int>{0}, true);
+            fastllm::Data quantWeight = weight; // copy to get a fresh device placement
+            quantWeight.name = std::string("regression.gguf_dequant.") + typeName;
+            quantWeight.ToDevice(fastllm::DataDevice::CUDA, std::vector<int>{0}, true);
+            fastllm::Data actual;
+            {
+                ScopedFirstDevice guard("cuda");
+                fastllm::Data emptyBias;
+                fastllm::Linear(inputHalf, quantWeight, emptyBias, actual);
+            }
+
+            bool expectedMmvq = !expectDequantGemm;
+
+            // Verify the GPU still owns the raw quantized buffer (dequant path
+            // borrows scratch; MMVQ reads weight.cudaData in chunks). Both branches
+            // keep cudaData non-null, so we assert the branch via the env + batch.
+            std::string route = expectDequantGemm ? "dequant+GEMM" : "DP4A-MMVQ";
+            std::string label = std::string("CUDA GGUF ") + typeName +
+                                " dequant linear batch " + std::to_string(batch) +
+                                " [" + route + "]";
+            if (dequantDisabled && batch > 7) {
+                std::cout << "  (env-disabled: n=" << batch
+                          << " forced to MMVQ fallback for " << typeName << ")\n";
+            }
+
+            // Tolerance: FP16 accumulation in the GEMM branch and DP4A in the
+            // MMVQ branch both produce float32 outputs. Tight enough to catch
+            // nibble/scale/high-bit decode errors (which would be O(1) or larger)
+            // but permissive for FP16 rounding of large dot-products.
+            float atol = (quantType == GGML_TYPE_IQ4_XS) ? 1.5f : 0.5f;
+            float rtol = (quantType == GGML_TYPE_IQ4_XS) ? 0.15f : 0.08f;
+            ExpectFloatNear(refOutput, ToFloatVector(actual), atol, rtol, label);
+
+            // Route logic consistency: this basic test uses a small batch set
+            // ({1,7,8,16,33}) and checks that the expected branch flag is
+            // internally consistent. For IQ4_XS on SM70, the SM70 MMQ trial
+            // (8<=n<=64) runs first when dequant is enabled; if it rejects,
+            // it falls through to dequant+GEMM. Both produce numerically
+            // correct output within the tolerance above, so this assertion
+            // only verifies the dispatch logic, not the actual route selected.
+            // The comprehensive MMQ test below exercises all boundary cases.
+            Expect(expectDequantGemm == (batch > 7 && !dequantDisabled),
+                   std::string("route selection inconsistent for ") + typeName +
+                   " batch " + std::to_string(batch) + ": expected " +
+                   (expectDequantGemm ? "dequant+GEMM" : "DP4A-MMVQ"));
+        }
+    }
+
+    // Forward declaration: defined after RunCudaGgufIq4xsQ5DequantRegression.
+    void RunCudaGgufIq4XsSm70MmqRegression();
+
+    void RunCudaGgufIq4xsQ5DequantRegression() {
+        // Minimum aligned shapes: IQ4_XS block = 256, Q5_0 block = 32.
+        // Use dims that are multiples of the block sizes and that match the
+        // existing test conventions (small but realistic).
+        RunGgufDequantRegressionOne<block_iq4_xs>(
+            GGML_TYPE_IQ4_XS, 256, 256, "iq4_xs",
+            FillIq4XsBlock, CpuDequantIq4Xs);
+        // Realistic shape for IQ4_XS (256-aligned).
+        RunGgufDequantRegressionOne<block_iq4_xs>(
+            GGML_TYPE_IQ4_XS, 512, 256, "iq4_xs",
+            FillIq4XsBlock, CpuDequantIq4Xs);
+        // Q5_0 minimum and realistic shapes (32-aligned).
+        RunGgufDequantRegressionOne<block_q5_0>(
+            GGML_TYPE_Q5_0, 256, 256, "q5_0",
+            FillQ5_0Block, CpuDequantQ5_0);
+        RunGgufDequantRegressionOne<block_q5_0>(
+            GGML_TYPE_Q5_0, 512, 256, "q5_0",
+            FillQ5_0Block, CpuDequantQ5_0);
+        // Comprehensive SM70 IQ4_XS MMQ sweep (boundary batches, 3 dtypes,
+        // non-%128 output dims for tail coverage).
+        RunCudaGgufIq4XsSm70MmqRegression();
+    }
+
+    // ---------------------------------------------------------------------------
+    // SM70 IQ4_XS MMQ comprehensive correctness regression.
+    //
+    // Sweeps batches across all dispatch boundaries (MMVQ n<=7, MMQ trial
+    // 8<=n<=64, dequant+GEMM fallback n>64), three activation dtypes
+    // (FLOAT16, FLOAT32, BFLOAT16), and non-%128 output dims (129/257) that
+    // exercise tile-Y tail-row handling. m (inputDim) is %256 for IQ4_XS
+    // block alignment.
+    //
+    // Without a production route introspection helper, each case is checked
+    // against BOTH the Q8_1 reference (models MMVQ + MMQ) and the dequant+GEMM
+    // reference. The actual output must match at least one within tolerance.
+    // A nibble/scale/row/column/tail bug produces O(1)+ errors that exceed
+    // the tolerance for every valid reference.
+    // ---------------------------------------------------------------------------
+
+    static const char *MmqDtypeName(fastllm::DataType dtype) {
+        switch (dtype) {
+            case fastllm::DataType::FLOAT16:  return "FP16";
+            case fastllm::DataType::FLOAT32:  return "FP32";
+            case fastllm::DataType::BFLOAT16: return "BF16";
+            default:                          return "UNKNOWN";
+        }
+    }
+
+    // Check actual against a reference, returning max-error context on failure.
+    // Returns true if within tolerance.
+    static bool MmqCheckRef(const std::vector<float> &actual,
+                            const std::vector<float> &ref,
+                            float atol, float rtol,
+                            float &maxErr, size_t &maxErrIdx) {
+        maxErr = 0.0f;
+        maxErrIdx = 0;
+        for (size_t i = 0; i < actual.size(); i++) {
+            if (!std::isfinite(actual[i]) || !std::isfinite(ref[i])) return false;
+            float diff = std::fabs(ref[i] - actual[i]);
+            if (diff > maxErr) { maxErr = diff; maxErrIdx = i; }
+            float limit = atol + rtol * std::fabs(ref[i]);
+            if (diff > limit) return false;
+        }
+        return true;
+    }
+
+    static void RunGgufIq4XsMmqShape(int inputDim, int outputDim) {
+        const int blockSize = (int)ggml_blck_size(GGML_TYPE_IQ4_XS);
+        Expect(inputDim % blockSize == 0,
+               "IQ4_XS MMQ regression: inputDim must be 256-aligned.");
+        int blocksPerRow = inputDim / blockSize;
+
+        // Build GGUF IQ4_XS weight and CPU reference dequant (reuses the same
+        // deterministic fill + dequant as the basic regression above).
+        fastllm::Data weightBase(fastllm::DataType::DATA_GGUF_FORMAT,
+                                 (int)GGML_TYPE_IQ4_XS,
+                                 {outputDim, inputDim});
+        weightBase.isGGUFData = true;
+        weightBase.disableGGUFRepack = true;
+        weightBase.Allocate();
+        size_t bytesPerRow = ggml_row_size(GGML_TYPE_IQ4_XS, inputDim);
+
+        std::vector<float> refWeightFp32((size_t)outputDim * inputDim);
+        for (int row = 0; row < outputDim; row++) {
+            std::vector<block_iq4_xs> rowBlocks(blocksPerRow);
+            for (int b = 0; b < blocksPerRow; b++) {
+                std::memset(&rowBlocks[b], 0, sizeof(block_iq4_xs));
+                FillIq4XsBlock(rowBlocks[b],
+                               (uint32_t)((row * 1000 + b) * 7 + 3));
+            }
+            std::memcpy(weightBase.cpuData + (size_t)row * bytesPerRow,
+                        rowBlocks.data(),
+                        (size_t)blocksPerRow * sizeof(block_iq4_xs));
+            std::vector<float> dequantRow;
+            CpuDequantIq4Xs(rowBlocks.data(), blocksPerRow, dequantRow);
+            std::memcpy(refWeightFp32.data() + (size_t)row * inputDim,
+                        dequantRow.data(), (size_t)inputDim * sizeof(float));
+        }
+
+        // Batches spanning MMVQ (n<=7), MMQ trial (8<=n<=64), and
+        // dequant+GEMM fallback (n>64). n=65 is the canonical fallback case.
+        const std::vector<int> batches = {
+            1, 7,      // MMVQ boundary
+            8, 9,      // MMQ trial entry + tile-X tail (tile=8)
+            15, 16, 17, // tile=16 boundary
+            31, 32, 33, // tile=32 boundary
+            63, 64,    // MMQ trial exit (tile=64)
+            65,        // dequant+GEMM fallback (outside [8,64])
+        };
+        const std::vector<fastllm::DataType> dtypes = {
+            fastllm::DataType::FLOAT16,
+            fastllm::DataType::FLOAT32,
+            fastllm::DataType::BFLOAT16,
+        };
+
+        bool dequantDisabled = GgufDequantIq4xsQ50EnvDisabled();
+        // IQ4_XS MMQ tolerance: catches nibble/scale/row/column/tail errors
+        // (O(1)+ per corrupted element) while accommodating Q8_1 input
+        // quantization noise and FP16/BF16 output rounding.
+        const float atol = 1.5f;
+        const float rtol = 0.15f;
+
+        for (int batch : batches) {
+            // Deterministic synthetic activation. Token zero is entirely zero
+            // to exercise the D4 quantizer's amax==0 path in every shape.
+            std::vector<float> inputFp32((size_t)batch * inputDim);
+            for (int ni = 0; ni < batch; ni++) {
+                for (int mi = 0; mi < inputDim; mi++) {
+                    inputFp32[(size_t)ni * inputDim + mi] = ni == 0
+                        ? 0.0f
+                        : (float)((ni * 17 + mi * 13 + 5) % 101 - 50) / 47.0f;
+                }
+            }
+
+            for (fastllm::DataType actDtype : dtypes) {
+                std::string dname = MmqDtypeName(actDtype);
+
+                // --- Q8_1 reference (models MMVQ + MMQ trial) ---
+                // Input rounded to activation dtype, then Q8_1 quant/dequant
+                // (32-element blocks, FP16 scale), FP32 accumulate against
+                // exact dequantized weights, output rounded to output dtype.
+                std::vector<float> q8Input = inputFp32;
+                RoundInputToDtype(q8Input, actDtype);
+                QuantizeQ8_1DequantizeInPlace(q8Input, inputDim);
+                std::vector<float> q8Ref;
+                CpuDenseMatmul(q8Input, batch, inputDim, outputDim,
+                               refWeightFp32, q8Ref);
+                RoundOutputToDtype(q8Ref, actDtype);
+
+                // The SM70 MMQ path uses the llama D4 layout: four FP32
+                // scales per 128 activation values. This is intentionally
+                // distinct from block_q8_1 MMVQ's FP16 scale reference.
+                std::vector<float> d4Input = inputFp32;
+                RoundInputToDtype(d4Input, actDtype);
+                QuantizeQ8D4DequantizeInPlace(d4Input, inputDim);
+                std::vector<float> d4Ref;
+                CpuDenseMatmul(d4Input, batch, inputDim, outputDim,
+                               refWeightFp32, d4Ref);
+                RoundOutputToDtype(d4Ref, actDtype);
+
+                // --- dequant+GEMM reference ---
+                // Input rounded to activation dtype; weights rounded to the
+                // dequant kernel's output type (FP16 for FP16/FP32 input,
+                // BF16 for BF16 input); FP32 accumulate; output rounded.
+                std::vector<float> gemmInput = inputFp32;
+                RoundInputToDtype(gemmInput, actDtype);
+                std::vector<float> gemmWeight = refWeightFp32;
+                RoundWeightForGemm(gemmWeight, actDtype);
+                std::vector<float> gemmRef;
+                CpuDenseMatmul(gemmInput, batch, inputDim, outputDim,
+                               gemmWeight, gemmRef);
+                RoundOutputToDtype(gemmRef, actDtype);
+
+                // --- Route label for diagnostics ---
+                std::string route;
+                if (batch <= 7) {
+                    route = "DP4A-MMVQ";
+                } else if (batch <= 64) {
+                    route = dequantDisabled ? "DP4A-MMVQ(env-disabled)"
+                                           : "SM70-IQ4XS-MMQ(trial)";
+                } else {
+                    route = dequantDisabled ? "DP4A-MMVQ(env-disabled)"
+                                           : "dequant+GEMM";
+                }
+
+                std::string label = std::string("IQ4_XS MMQ ") + dname +
+                                    " n=" + std::to_string(batch) +
+                                    " m=" + std::to_string(inputDim) +
+                                    " k=" + std::to_string(outputDim) +
+                                    " [" + route + "]";
+
+
+                // --- Run CUDA Linear ---
+                fastllm::Data inputData(actDtype, {batch, inputDim}, inputFp32);
+                inputData.ToDevice(fastllm::DataDevice::CUDA,
+                                   std::vector<int>{0}, true);
+                fastllm::Data quantWeight = weightBase;
+                quantWeight.name = "regression.iq4xs_mmq." + dname +
+                                   ".n" + std::to_string(batch);
+                quantWeight.ToDevice(fastllm::DataDevice::CUDA,
+                                     std::vector<int>{0}, true);
+
+                // Prove route selection separately from public-API fallback.
+                // A successful direct wrapper call must return true and match
+                // the independent D4 CPU reference; a no-op false return can
+                // no longer make this regression pass through GEMM.
+                if (batch >= 8 && batch <= 64 &&
+                    FastllmCudaSm70Iq4XsMmqSupported()) {
+                    fastllm::Data directOutput(actDtype);
+                    directOutput.Resize({batch, outputDim});
+                    directOutput.ToDevice(fastllm::DataDevice::CUDA,
+                                          std::vector<int>{0}, false);
+                    directOutput.Allocate(false);
+                    bool selected = FastllmCudaTrySm70Iq4XsMmq(
+                        quantWeight.cudaData, inputData.cudaData,
+                        directOutput.cudaData, actDtype,
+                        batch, inputDim, outputDim, nullptr);
+                    Expect(selected, label + " direct wrapper was not selected.");
+                    std::vector<float> directVec = ToFloatVector(directOutput);
+                    float directMaxErr = 0.0f;
+                    size_t directMaxIdx = 0;
+                    Expect(MmqCheckRef(directVec, d4Ref, 2e-2f, 2e-2f,
+                                       directMaxErr, directMaxIdx),
+                           label + " direct D4 mismatch: maxErr=" +
+                           std::to_string(directMaxErr) + " at out[" +
+                           std::to_string(directMaxIdx / outputDim) + "," +
+                           std::to_string(directMaxIdx % outputDim) + "]");
+                }
+                fastllm::Data actual;
+                {
+                    ScopedFirstDevice guard("cuda");
+                    fastllm::Data emptyBias;
+                    fastllm::Linear(inputData, quantWeight, emptyBias, actual);
+                }
+                std::vector<float> actualVec = ToFloatVector(actual);
+
+                Expect(actualVec.size() == q8Ref.size(),
+                       label + " output size mismatch: actual " +
+                       std::to_string(actualVec.size()) + " vs ref " +
+                       std::to_string(q8Ref.size()));
+
+                // --- Check against the route-specific references ---
+                float q8MaxErr = 0, d4MaxErr = 0, gemmMaxErr = 0;
+                size_t q8MaxIdx = 0, d4MaxIdx = 0, gemmMaxIdx = 0;
+
+                if (batch >= 8 && batch <= 64 &&
+                    FastllmCudaSm70Iq4XsMmqSupported() &&
+                    MmqCheckRef(actualVec, d4Ref, 2e-2f, 2e-2f,
+                                d4MaxErr, d4MaxIdx)) {
+                    continue;
+                }
+                if (MmqCheckRef(actualVec, q8Ref, atol, rtol,
+                                q8MaxErr, q8MaxIdx)) {
+                    continue;
+                }
+
+                if (MmqCheckRef(actualVec, gemmRef, atol, rtol,
+                                gemmMaxErr, gemmMaxIdx)) {
+                    continue;
+                }
+
+                // Neither reference matched — report full context.
+                throw std::runtime_error(
+                    label + " FAILED: no reference matched.\n"
+                    "  Q8_1 ref: maxErr=" + std::to_string(q8MaxErr) +
+                    " at out[" + std::to_string(q8MaxIdx / outputDim) +
+                    "," + std::to_string(q8MaxIdx % outputDim) + "]" +
+                    " ref=" + std::to_string(q8Ref[q8MaxIdx]) +
+                    " act=" + std::to_string(actualVec[q8MaxIdx]) + "\n"
+                    "  GEMM ref: maxErr=" + std::to_string(gemmMaxErr) +
+                    " at out[" + std::to_string(gemmMaxIdx / outputDim) +
+                    "," + std::to_string(gemmMaxIdx % outputDim) + "]" +
+                    " ref=" + std::to_string(gemmRef[gemmMaxIdx]) +
+                    " act=" + std::to_string(actualVec[gemmMaxIdx]));
+            }
+        }
+    }
+
+    void RunCudaGgufIq4XsSm70MmqRegression() {
+        FastllmCudaClearThreadError();
+        // Note on m%256 negative test: IQ4_XS has block size 256, so m must
+        // be %256 for a valid weight. The Data constructor and GGUF dequant
+        // kernel assert on block alignment, so an invalid m%256 cannot be
+        // expressed through the public Linear API without triggering an
+        // upstream assertion. This is by design (block-level quantization
+        // requires aligned dimensions). The n=65 case below covers the
+        // MMQ-eligibility fallback boundary instead.
+        // Small output projections (for example Qwen3.5 alpha/beta k=48)
+        // are intentionally rejected because the 128-row MMQ tile is slower
+        // than the legacy MMVQ path there.
+        if (FastllmCudaSm70Iq4XsMmqSupported()) {
+            Expect(!FastllmCudaTrySm70Iq4XsMmq(
+                       (const void *)1, (const void *)1, (void *)1,
+                       fastllm::DataType::FLOAT16, 8, 256, 127, nullptr),
+                   "IQ4_XS MMQ accepted a k<128 projection.");
+        }
+
+        // Small shapes with non-%128 output dims (129/257) to exercise
+        // tile-Y tail-row handling. m (inputDim) is %256 for IQ4_XS.
+        RunGgufIq4XsMmqShape(256, 129);
+        RunGgufIq4XsMmqShape(256, 257);
+        RunGgufIq4XsMmqShape(512, 129);
+        RunGgufIq4XsMmqShape(512, 257);
+
+#if !defined(USE_ROCM)
+        cudaError_t syncState = cudaDeviceSynchronize();
+        Expect(syncState == cudaSuccess,
+               std::string("IQ4_XS MMQ asynchronous CUDA failure: ") +
+               cudaGetErrorString(syncState));
+        cudaError_t stickyState = cudaGetLastError();
+        Expect(stickyState == cudaSuccess,
+               std::string("IQ4_XS MMQ left a sticky CUDA error: ") +
+               cudaGetErrorString(stickyState));
+#endif
+        Expect(!FastllmCudaGetThreadError(),
+               "IQ4_XS MMQ set the FastLLM CUDA thread-error flag.");
+    }
+
+    void RunCudaGgufIq4XsSm70MmqBenchmark() {
+        struct BenchShape {
+            const char *name;
+            int inputDim;
+            int outputDim;
+        };
+        const std::vector<BenchShape> shapes = {
+            {"qwen35_z", 5120, 6144},
+            {"qwen35_out", 6144, 5120},
+            {"qwen35_ab", 5120, 48},
+        };
+        const std::vector<int> batches = {8, 16, 32, 64};
+        constexpr int warmup = 5;
+        constexpr int iterations = 30;
+
+        std::cout << "route,dtype,shape,n,m,k,avg_ms,tokens_per_second\n";
+        for (const BenchShape &shape : shapes) {
+            const int blocksPerRow = shape.inputDim /
+                (int)ggml_blck_size(GGML_TYPE_IQ4_XS);
+            fastllm::Data weight(fastllm::DataType::DATA_GGUF_FORMAT,
+                                 (int)GGML_TYPE_IQ4_XS,
+                                 {shape.outputDim, shape.inputDim});
+            weight.isGGUFData = true;
+            weight.disableGGUFRepack = true;
+            weight.name = std::string("benchmark.") + shape.name;
+            weight.Allocate();
+            const size_t bytesPerRow =
+                ggml_row_size(GGML_TYPE_IQ4_XS, shape.inputDim);
+            for (int row = 0; row < shape.outputDim; row++) {
+                std::vector<block_iq4_xs> blocks(blocksPerRow);
+                for (int block = 0; block < blocksPerRow; block++) {
+                    std::memset(&blocks[block], 0, sizeof(block_iq4_xs));
+                    FillIq4XsBlock(
+                        blocks[block],
+                        (uint32_t)((row * 1000 + block) * 7 + 3));
+                }
+                std::memcpy(weight.cpuData + (size_t)row * bytesPerRow,
+                            blocks.data(),
+                            (size_t)blocksPerRow * sizeof(block_iq4_xs));
+            }
+            weight.ToDevice(fastllm::DataDevice::CUDA,
+                            std::vector<int>{0}, true);
+
+            for (int batch : batches) {
+                std::vector<float> inputFp32((size_t)batch * shape.inputDim);
+                for (int token = 0; token < batch; token++) {
+                    for (int col = 0; col < shape.inputDim; col++) {
+                        inputFp32[(size_t)token * shape.inputDim + col] =
+                            (float)((token * 17 + col * 13 + 5) % 101 - 50) /
+                            47.0f;
+                    }
+                }
+                for (fastllm::DataType dtype : {
+                         fastllm::DataType::FLOAT16,
+                         fastllm::DataType::FLOAT32}) {
+                    fastllm::Data input(dtype, {batch, shape.inputDim}, inputFp32);
+                    input.ToDevice(fastllm::DataDevice::CUDA,
+                                   std::vector<int>{0}, true);
+                    fastllm::Data output;
+                    fastllm::Data emptyBias;
+                    ScopedFirstDevice guard("cuda");
+                    for (int i = 0; i < warmup; i++) {
+                        fastllm::Linear(input, weight, emptyBias, output);
+                    }
+                    ForceDeviceSync();
+                    const auto begin = std::chrono::steady_clock::now();
+                    for (int i = 0; i < iterations; i++) {
+                        fastllm::Linear(input, weight, emptyBias, output);
+                    }
+                    ForceDeviceSync();
+                    const auto end = std::chrono::steady_clock::now();
+                    const double elapsedMs =
+                        std::chrono::duration<double, std::milli>(end - begin).count();
+                    const double avgMs = elapsedMs / iterations;
+                    const double tokensPerSecond = 1000.0 * batch / avgMs;
+                    std::cout
+                        << (batch >= 8 && batch <= 64 && shape.outputDim >= 128 &&
+                            FastllmCudaSm70Iq4XsMmqSupported() ? "mmq" : "fallback")
+                        << ',' << (dtype == fastllm::DataType::FLOAT16 ? "f16" : "f32")
+                        << ',' << shape.name
+                        << ',' << batch
+                        << ',' << shape.inputDim
+                        << ',' << shape.outputDim
+                        << ',' << avgMs
+                        << ',' << tokensPerSecond
+                        << '\n';
+                }
+            }
+        }
     }
 #endif
 
@@ -3254,12 +4691,82 @@ namespace {
 
 int main() {
     try {
+        const char *only = std::getenv("FASTLLM_REGRESSION_ONLY");
+        if (only != nullptr && std::string(only) == "gguf_dequant") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("gguf_dequant regression requires CUDA.");
+            }
+            RunCudaGgufIq4xsQ5DequantRegression();
+            std::cout << "cuda GGUF IQ4_XS/Q5_0 dequant regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error("gguf_dequant regression requires a CUDA build.");
+#endif
+        }
+        if (only != nullptr && std::string(only) == "qwen35_gguf") {
+            RunQwen35GGUFConfigRegression();
+            RunQwen35GGUFWeightMappingRegression();
+            RunQwen35GGUFFailFastRegression();
+            RunQwen35GGUFWorkerExceptionRegression();
+            RunQwen35MixedQuantGGUFProjectionRegression();
+#ifdef USE_CUDA
+            RunQwen35OutProjTpLayoutRegression();
+#endif
+            std::cout << "qwen35 GGUF alias, V-head layout, and grouped override regression: PASS\n";
+            return 0;
+        }
+        if (only != nullptr && std::string(only) == "iq4xs_mmq_bench") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("iq4xs_mmq_bench requires CUDA.");
+            }
+            RunCudaGgufIq4XsSm70MmqBenchmark();
+            return 0;
+#else
+            throw std::runtime_error("iq4xs_mmq_bench requires a CUDA build.");
+#endif
+        }
         bool ranAny = false;
+        if (only != nullptr && std::string(only) == "mtp9_snapshots") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("mtp9_snapshots regression requires CUDA.");
+            }
+            RunCudaConvMultiTokenSnapshotsRegression();
+            RunCudaRecurrentSnapshotsRegression();
+            std::cout << "cuda MTP9 conv/recurrent snapshot regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error("mtp9_snapshots regression requires a CUDA build.");
+#endif
+        }
+        if (only != nullptr && std::string(only) == "mtp9_greedy") {
+#ifdef USE_CUDA
+            if (!fastllm::HasDeviceType("cuda")) {
+                throw std::runtime_error("mtp9_greedy regression requires CUDA.");
+            }
+            RunCudaGreedyTieBreakRegression();
+            std::cout << "cuda MTP9 greedy tie-break regression: PASS\n";
+            return 0;
+#else
+            throw std::runtime_error("mtp9_greedy regression requires a CUDA build.");
+#endif
+        }
         bool ranCrossDeviceViewRegression = false;
 #ifndef USE_ROCM
         bool ranLargeWeightOffsetRegression = false;
 #endif
-
+        RunQwen35GGUFConfigRegression();
+        RunQwen35GGUFWeightMappingRegression();
+        RunQwen35MixedQuantGGUFProjectionRegression();
+        RunCpuEmbeddingDirectInMemoryLowMemRegression();
+        RunQwen35SplitGdnProjectionLayoutRegression();
+        RunQwen35SplitAttentionProjectionLayoutRegression();
+#ifdef USE_CUDA
+        RunQwen35OutProjTpLayoutRegression();
+#endif
+        std::cout << "qwen35 GGUF config, weight mapping, and embedding regression: PASS\n";
         RunMoeAtypeConfigRegression();
         std::cout << "moe_atype auto/explicit configuration regression: PASS\n";
         ranAny = true;
@@ -3272,6 +4779,7 @@ int main() {
 
         RunPerRequestMinOutputLengthRegression();
         std::cout << "per-request minimum output length regression: PASS\n";
+
 
         if (fastllm::HasDeviceType("cpu")) {
             RunCpuInt4GroupAwqLinearRegression();
@@ -3298,6 +4806,7 @@ int main() {
             RunCudaInt4GroupHalfWeightRoundingRegression();
             RunCudaInt4GroupBatch1MoeRegression();
             RunCudaInt8Batch1MoeRegression();
+            RunCudaGgufIq4xsQ5DequantRegression();
             RunCudaConvMultiTokenSnapshotsRegression();
             ranCrossDeviceViewRegression = RunCudaCrossDeviceViewRejectionRegression();
             RunMultiCudaReplicatedExpansionRegression();

--- a/test/ops/regressionOps.cpp
+++ b/test/ops/regressionOps.cpp
@@ -230,6 +230,17 @@ namespace {
         }
     }
 
+    void WriteGGUFStringArrayKV(std::ofstream &out, const std::string &key,
+                                const std::vector<std::string> &values) {
+        WriteGGUFString(out, key);
+        WritePod<int32_t>(out, 9);
+        WritePod<int32_t>(out, 8);
+        WritePod<uint64_t>(out, values.size());
+        for (const std::string &value : values) {
+            WriteGGUFString(out, value);
+        }
+    }
+
     uint64_t Pad32(uint64_t value) {
         return (value + 31) / 32 * 32;
     }
@@ -286,14 +297,16 @@ namespace {
     void WriteSyntheticQwen35GGUF(const std::string &path,
                                   const std::vector<SyntheticGGUFTensor> &tensors,
                                   const std::string &arch = "qwen35",
-                                  uint32_t nextnPredictLayers = 1) {
+                                  uint32_t nextnPredictLayers = 1,
+                                  const std::vector<std::string> &tokens = {},
+                                  int eosTokenId = -1) {
         std::ofstream out(path, std::ios::binary);
         Expect(out.good(), "failed to create synthetic GGUF file.");
 
         WritePod<uint32_t>(out, 0x46554747u);
         WritePod<uint32_t>(out, 3u);
         WritePod<uint64_t>(out, tensors.size());
-        WritePod<uint64_t>(out, 18u);
+        WritePod<uint64_t>(out, 18u + (tokens.empty() ? 0u : 2u));
 
         WriteGGUFStringKV(out, "general.architecture", arch);
         WriteGGUFStringKV(out, "general.name", "synthetic qwen35");
@@ -313,6 +326,12 @@ namespace {
         WriteGGUFUInt32KV(out, arch + ".ssm.state_size", 128);
         WriteGGUFUInt32KV(out, arch + ".ssm.time_step_rank", 48);
         WriteGGUFUInt32KV(out, arch + ".ssm.inner_size", 6144);
+        if (!tokens.empty()) {
+            Expect(eosTokenId >= 0 && eosTokenId < (int)tokens.size(),
+                   "synthetic GGUF eos token must index the tokenizer vocabulary.");
+            WriteGGUFStringArrayKV(out, "tokenizer.ggml.tokens", tokens);
+            WriteGGUFUInt32KV(out, "tokenizer.ggml.eos_token_id", (uint32_t)eosTokenId);
+        }
 
         uint64_t offset = 0;
         for (const auto &tensor : tensors) {
@@ -367,7 +386,8 @@ namespace {
     void RunQwen35GGUFConfigRegression() {
         for (const std::string &arch : {std::string("qwen35"), std::string("qwen3_5")}) {
             std::string path = MakeTempGGUFPath("fastllm-" + arch + "-config");
-            WriteSyntheticQwen35GGUF(path, {}, arch);
+            WriteSyntheticQwen35GGUF(path, {}, arch, 1,
+                                     {"ordinary", "<|endoftext|>", "<|im_end|>"}, 2);
             auto model = fastllm::CreateLLMModelFromFile(path);
             std::remove(path.c_str());
 
@@ -378,6 +398,10 @@ namespace {
             Expect(model->num_key_value_heads == 4, arch + " KV heads were not imported.");
             Expect(model->head_dim == 256, arch + " full-attention head_dim was not imported.");
             Expect(model->max_positions == 262144, arch + " context length was not imported.");
+            Expect(model->eos_token_id == 2,
+                   arch + " GGUF scalar eos token was not imported.");
+            Expect(model->eos_token_ids.count(1) == 1 && model->eos_token_ids.count(2) == 1,
+                   arch + " GGUF must stop on both <|endoftext|> and <|im_end|>.");
             Expect(model->weight.dicts["num_hidden_layers"] == "64",
                    arch + " num_hidden_layers dict must use the main trunk layer count.");
             Expect(model->weight.dicts["mtp_num_hidden_layers"] == "1",
@@ -817,6 +841,124 @@ namespace {
                    10, requestedShort, singleShort) == 0,
                "qwen35 page budget hid a true single-token cache shortage.");
     }
+
+    void RunQwen35LongPrefillStateRegression() {
+        constexpr int chunk = 2048;
+        fastllm::ResponseContext context;
+        context.currentTokens.resize(chunk * 2 + 17, 7);
+        auto *managerA = reinterpret_cast<fastllm::PagedCacheManager*>(uintptr_t(0x10));
+        auto *managerB = reinterpret_cast<fastllm::PagedCacheManager*>(uintptr_t(0x20));
+        Expect(fastllm::ClassifyQwen35RequestPhase(context) ==
+                   fastllm::Qwen35RequestPhase::NewPrefill,
+               "fresh qwen35 request was not classified as prefill.");
+        Expect(fastllm::BeginQwen35LongPrefill(
+                   context, (int)context.currentTokens.size(), 11,
+                   {{managerA, 4}, {managerB, 2}}),
+               "qwen35 long prefill state did not start.");
+        Expect(context.longPrefill.reservedPages.size() == 2,
+               "qwen35 long prefill reservations were not retained.");
+
+        auto first = fastllm::PlanQwen35LongPrefillQuantum(context, chunk);
+        Expect(first.cursor == 0 && first.length == chunk && first.baseTokens == 0 &&
+                   !first.isLast && !first.producesOutput,
+               "qwen35 first prefill quantum was planned incorrectly.");
+        Expect(fastllm::CommitQwen35LongPrefillQuantum(context, first, true),
+               "qwen35 first prefill quantum did not commit.");
+        Expect(context.preTokens == chunk && context.longPrefill.cursor == chunk &&
+                   context.longPrefill.inProgress,
+               "qwen35 first prefill quantum broke cursor invariants.");
+        Expect(!fastllm::CommitQwen35LongPrefillQuantum(context, first, true),
+               "qwen35 stale prefill quantum committed twice.");
+
+        auto second = fastllm::PlanQwen35LongPrefillQuantum(context, chunk);
+        Expect(second.cursor == chunk && second.length == chunk &&
+                   !second.producesOutput,
+               "qwen35 second prefill quantum was planned incorrectly.");
+        Expect(fastllm::CommitQwen35LongPrefillQuantum(context, second, false),
+               "qwen35 second prefill quantum did not commit.");
+        Expect(!context.longPrefill.mtpViable,
+               "qwen35 MTP append failure was not made sticky.");
+
+        auto last = fastllm::PlanQwen35LongPrefillQuantum(context, chunk);
+        Expect(last.cursor == chunk * 2 && last.length == 17 &&
+                   last.isLast && last.producesOutput,
+               "qwen35 final prefill quantum was planned incorrectly.");
+        Expect(fastllm::CommitQwen35LongPrefillQuantum(context, last, true),
+               "qwen35 final prefill quantum did not commit.");
+        Expect(context.preTokens == chunk * 2 + 17 &&
+                   context.longPrefill.cursor == chunk * 2 + 17 &&
+                   !context.longPrefill.inProgress &&
+                   context.longPrefill.reservedPages.empty(),
+               "qwen35 final prefill quantum did not release state.");
+        Expect(fastllm::ClassifyQwen35RequestPhase(context) ==
+                   fastllm::Qwen35RequestPhase::Decode,
+               "completed qwen35 prefill was not classified as decode.");
+
+        fastllm::ResponseContext prefixHit;
+        prefixHit.cacheLen = 128;
+        prefixHit.currentTokens.resize(33, 9);
+        Expect(fastllm::BeginQwen35LongPrefill(prefixHit, 33, 12),
+               "prefix-hit qwen35 prefill did not start.");
+        auto prefixQuantum = fastllm::PlanQwen35LongPrefillQuantum(prefixHit, 64);
+        Expect(prefixQuantum.baseTokens == 128 && prefixQuantum.isLast,
+               "prefix-hit qwen35 prefill used the wrong physical base.");
+        Expect(fastllm::CommitQwen35LongPrefillQuantum(prefixHit, prefixQuantum, true) &&
+                   prefixHit.cacheLen == 128 && prefixHit.preTokens == 33,
+               "qwen35 prefill cursor polluted cached-input accounting.");
+
+        std::vector<std::tuple<int, uint64_t> > candidates = {
+            {30, 3}, {10, 1}, {20, 2}
+        };
+        Expect(fastllm::SelectQwen35LongPrefillHandle(candidates, 0) == 10 &&
+                   fastllm::SelectQwen35LongPrefillHandle(candidates, 1) == 20 &&
+                   fastllm::SelectQwen35LongPrefillHandle(candidates, 2) == 30 &&
+                   fastllm::SelectQwen35LongPrefillHandle(candidates, 3) == 10,
+               "qwen35 long prefill ticket selection is not round-robin.");
+        Expect(fastllm::CanAdmitQwen35LongPrefill(3, 4) &&
+                   !fastllm::CanAdmitQwen35LongPrefill(4, 4),
+               "qwen35 long prefill lane capacity was not enforced.");
+        Expect(fastllm::CanReserveQwen35LongPrefillPages({{2, 3, 5}, {1, 2, 4}}) &&
+                   !fastllm::CanReserveQwen35LongPrefillPages({{2, 4, 5}}) &&
+                   fastllm::CanReserveQwen35LongPrefillPages({{0, 0, 0}}),
+               "qwen35 long prefill page reservation accounting is incorrect.");
+
+        {
+            ScopedEnvVar disabled("FASTLLM_QWEN35_INTERLEAVE_LONG_PREFILL", nullptr);
+            Expect(!fastllm::Qwen35InterleaveLongPrefillEnabled(),
+                   "qwen35 long prefill interleave should default off.");
+        }
+        {
+            ScopedEnvVar enabled("FASTLLM_QWEN35_INTERLEAVE_LONG_PREFILL", "1");
+            Expect(fastllm::Qwen35InterleaveLongPrefillEnabled(),
+                   "qwen35 long prefill interleave did not accept 1.");
+        }
+        {
+            ScopedEnvVar disabled("FASTLLM_QWEN35_INTERLEAVE_LONG_PREFILL", "false");
+            Expect(!fastllm::Qwen35InterleaveLongPrefillEnabled(),
+                   "qwen35 long prefill interleave did not reject false.");
+        }
+        {
+            ScopedEnvVar enabled("FASTLLM_QWEN35_BATCHED_MTP", nullptr);
+            Expect(fastllm::Qwen35BatchedMtpEnabled(),
+                   "qwen35 batched MTP should default on.");
+        }
+        {
+            ScopedEnvVar disabled("FASTLLM_QWEN35_BATCHED_MTP", "0");
+            Expect(!fastllm::Qwen35BatchedMtpEnabled(),
+                   "qwen35 batched MTP did not accept 0 as disabled.");
+        }
+        {
+            ScopedEnvVar disabled("FASTLLM_QWEN35_BATCHED_MTP", "false");
+            Expect(!fastllm::Qwen35BatchedMtpEnabled(),
+                   "qwen35 batched MTP did not reject false.");
+        }
+        {
+            ScopedEnvVar enabled("FASTLLM_QWEN35_BATCHED_MTP", "1");
+            Expect(fastllm::Qwen35BatchedMtpEnabled(),
+                   "qwen35 batched MTP did not accept 1.");
+        }
+    }
+
 
     void RunMoeAtypeConfigRegression() {
         MoeAtypeConfigTestModel model;
@@ -5686,6 +5828,11 @@ int main() {
             std::cout << "qwen35 GGUF alias, V-head layout, and grouped override regression: PASS\n";
             return 0;
         }
+        if (only != nullptr && std::string(only) == "qwen35_long_prefill_state") {
+            RunQwen35LongPrefillStateRegression();
+            std::cout << "qwen35 long prefill state regression: PASS\n";
+            return 0;
+        }
         if (only != nullptr && std::string(only) == "iq4xs_mmq_bench") {
 #ifdef USE_CUDA
             if (!fastllm::HasDeviceType("cuda")) {
@@ -5796,6 +5943,8 @@ int main() {
         std::cout << "KV cache dtype configuration regression: PASS\n";
         RunQwen35DecodePageBudgetRegression();
         std::cout << "qwen35 exact-window decode page budget regression: PASS\n";
+        RunQwen35LongPrefillStateRegression();
+        std::cout << "qwen35 long prefill state regression: PASS\n";
         RunMoeAtypeConfigRegression();
         std::cout << "moe_atype auto/explicit configuration regression: PASS\n";
         ranAny = true;

--- a/third_party/gguf/gguf-adapter.cpp
+++ b/third_party/gguf/gguf-adapter.cpp
@@ -109,6 +109,108 @@ namespace fastllm {
                 }
             },
             {
+                "qwen3_5",
+                {
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.nextn\.eh_proj\.weight)"),
+                        "mtp.fc.weight"
+                    ), // MTP eh_proj (only present on the nextn block)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.nextn\.enorm\.weight)"),
+                        "mtp.pre_fc_norm_embedding.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.nextn\.hnorm\.weight)"),
+                        "mtp.pre_fc_norm_hidden.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.nextn\.shared_head_norm\.weight)"),
+                        "mtp.norm.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_alpha\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.in_proj_a.weight",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // linear_attn in_proj_a (untile V-heads; must precede ssm_a)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_beta\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.in_proj_b.weight",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // linear_attn in_proj_b
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_a)"),
+                        "model.language_model.layers.$1.linear_attn.A_log",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads,
+                        true // untile V-heads then compose log(-x)
+                    ), // A_log (untile V-heads, then invert -exp(A_log) baked into GGUF ssm_a)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_conv1d\.(weight|bias))"),
+                        "model.language_model.layers.$1.linear_attn.conv1d.$2",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // conv1d (untile V channels)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_dt\.bias)"),
+                        "model.language_model.layers.$1.linear_attn.dt_bias",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // dt_bias (untile V-head scalars)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_norm\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.norm.weight"
+                    ), // linear_attn norm
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ssm_out\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.out_proj.weight"
+                    ), // out_proj (stays Direct/tiled; runtime activation reorder before matmul)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_qkv\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.in_proj_qkv.weight",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // in_proj_qkv (untile V-segment rows only)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_gate\.weight)"),
+                        "model.language_model.layers.$1.linear_attn.in_proj_z.weight",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads
+                    ), // in_proj_z (gate; untile V rows)
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_(q|k|v)\.(weight|bias))"),
+                        "model.language_model.layers.$1.self_attn.$2_proj.$3"
+                    ), // full-attention qkv
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_(q|k)_norm\.weight)"),
+                        "model.language_model.layers.$1.self_attn.$2_norm.weight"
+                    ), // qk norm
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_output\.(weight|bias))"),
+                        "model.language_model.layers.$1.self_attn.o_proj.$2"
+                    ), // o
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.ffn_(gate|up|down)\.(weight|bias))"),
+                        "model.language_model.layers.$1.mlp.$2_proj.$3"
+                    ), // mlp
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.attn_norm\.weight)"),
+                        "model.language_model.layers.$1.input_layernorm.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(blk\.(\d+)\.post_attention_norm\.weight)"),
+                        "model.language_model.layers.$1.post_attention_layernorm.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(token_embd\.weight)"),
+                        "model.language_model.embed_tokens.weight",
+                        GGUFWeightReplaceRule::GGUFWeightReplaceForceFP32
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(output\.weight)"),
+                        "lm_head.weight"
+                    ),
+                    GGUFWeightReplaceRule (
+                        std::regex(R"(output_norm\.weight)"),
+                        "model.language_model.norm.weight"
+                    )
+                }
+            },
+            {
                 "deepseek_v2", 
                 {
                     GGUFWeightReplaceRule (

--- a/third_party/gguf/gguf.cpp
+++ b/third_party/gguf/gguf.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <stdexcept>
 
 #include <assert.h>
 #include "gguf.h"
@@ -205,7 +206,7 @@ std::map <ggml_type, ggml_type_traits> type_traits = {
         }},
         {GGML_TYPE_IQ4_XS, {/* type_name */"iq4_xs", /* blck_size */QK_K,
             /* type_size */ sizeof(block_iq4_xs),/* is_quantized */  true,
-            // .to_float                 = (ggml_to_float_t) dequantize_row_iq4_xs,
+            /* to_float */ (ggml_to_float_t) dequantize_row_iq4_xs,
             // .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_xs_ref,
         }},
         {GGML_TYPE_Q8_K, {/* type_name */"q8_K", /* blck_size */QK_K,
@@ -545,7 +546,7 @@ std::map <ggml_type, ggml_type_traits> type_traits = {
             .blck_size                = QK_K,
             .type_size                = sizeof(block_iq4_xs),
             .is_quantized             = true,
-            // .to_float                 = (ggml_to_float_t) dequantize_row_iq4_xs,
+            .to_float                 = (ggml_to_float_t) dequantize_row_iq4_xs,
             // .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_xs_ref,
         }},
         {GGML_TYPE_Q8_K, {
@@ -711,8 +712,10 @@ namespace fastllm {
 
     extern void Float32ToFloat16(float *float32, uint16_t *float16, int len);
 
-    void WeightImportGGUFTensor(Data* weight, ggml_tensor *tensor, std::string &fileName, uint64_t offset, 
-                                GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType) {
+    void WeightImportGGUFTensor(Data* weight, ggml_tensor *tensor, std::string &fileName, uint64_t offset,
+                                GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType,
+                                int untileNumKHeads, int untileNumVHeads,
+                                int untileVRowStart, bool untileComposeNegLog) {
         if (tensor->type == ggml_type::GGML_TYPE_F32) {
             weight->dataType = DataType::FLOAT32;    
         } else if (tensor->type == ggml_type::GGML_TYPE_F16) {
@@ -810,6 +813,154 @@ namespace fastllm {
                 ggml_type_name(tensor->type) + ") can't convert to fp32.");
             toFloat(oriData.data(), floatData.data(), weight->Count(0));
             Float32ToFloat16(floatData.data(), (uint16_t*)weight->cpuData, weight->Count(0));
+        } else if (replaceType == GGUFWeightReplaceRule::GGUFWeightReplaceNegLogFP32) {
+            weight->dataType = DataType::FLOAT32;
+            weight->Resize(tensor->dims);
+            weight->Allocate();
+
+            auto len = ggml_nbytes(tensor);
+            std::vector <uint8_t> oriData;
+            oriData.resize(len);
+
+            FILE *fi = fopen(fileName.c_str(), "rb");
+#if defined(_WIN32) || defined(_WIN64)
+            _fseeki64(fi, offset, 0);
+#else
+            fseek(fi, offset, 0);
+#endif
+            int ret = fread(oriData.data(), 1, ggml_nbytes(tensor), fi);
+            fclose(fi);
+
+            if (tensor->type == ggml_type::GGML_TYPE_F32) {
+                memcpy((float*)weight->cpuData, oriData.data(), ggml_nbytes(tensor));
+            } else {
+                auto toFloat = ggml_type_to_float(tensor->type);
+                AssertInFastLLM(toFloat != nullptr, "WeightImportGGUFTensor: weight " + tensor->name + "(type " +
+                    ggml_type_name(tensor->type) + ") can't convert to fp32.");
+                toFloat(oriData.data(), (float*)weight->cpuData, weight->Count(0));
+            }
+            // GGUF stores ssm_a as -exp(A_log); FastLLM's GDN kernel applies -exp(A_log) again,
+            // so invert to recover raw A_log = log(-ssm_a).
+            float *data = (float*)weight->cpuData;
+            for (size_t i = 0; i < (size_t)weight->Count(0); i++) {
+                AssertInFastLLM(data[i] < 0.0f, "WeightImportGGUFTensor: ssm_a value >= 0, cannot take log(-x).");
+                data[i] = logf(-data[i]);
+            }
+        } else if (replaceType == GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads) {
+            // Qwen3.5/3.6 GGUF converter tiles V-heads at export:
+            //   T[((r*H+h)*W)+d] = G[((h*R+r)*W)+d]
+            // Inverse (load-time, tiled→grouped) so all internal tensors use
+            // grouped layout. Quantized rows are moved byte-exactly.
+            auto requireLayout = [&](bool condition, const std::string &message) {
+                if (!condition) {
+                    throw std::runtime_error("WeightImportGGUFTensor: " + message +
+                                             " for " + tensor->name + ".");
+                }
+            };
+            requireLayout(untileNumKHeads > 0 &&
+                          untileNumVHeads >= untileNumKHeads &&
+                          untileNumVHeads % untileNumKHeads == 0,
+                          "invalid V-head counts");
+            requireLayout(tensor->dims.size() == 1 || tensor->dims.size() == 2,
+                          "V-head untile expects a 1D or 2D tensor");
+            const int H = untileNumKHeads;
+            const int R = untileNumVHeads / H;
+            const bool isMultiDim = tensor->dims.size() == 2;
+            const int totalUnits = isMultiDim
+                ? (int)tensor->ne[1]
+                : (int)tensor->ne[0];
+            requireLayout(untileVRowStart >= 0 && untileVRowStart < totalUnits,
+                          "invalid V-row start");
+            const int vRowCount = totalUnits - untileVRowStart;
+            requireLayout(vRowCount > 0 &&
+                          vRowCount % untileNumVHeads == 0,
+                          "V rows do not divide into heads");
+            const int D = vRowCount / untileNumVHeads;
+
+            auto untileBytes = [&](uint8_t *storage, size_t storageBytes,
+                                   size_t unitStride) {
+                const size_t baseOffset =
+                    (size_t)untileVRowStart * unitStride;
+                const size_t groupStride = (size_t)D * unitStride;
+                const size_t totalVBytes = (size_t)vRowCount * unitStride;
+                requireLayout(unitStride > 0 &&
+                              baseOffset + totalVBytes <= storageBytes,
+                              "V-head byte range exceeds tensor storage");
+                uint8_t *vSeg = storage + baseOffset;
+                std::vector<uint8_t> temp(totalVBytes);
+                for (int h = 0; h < H; h++) {
+                    for (int r = 0; r < R; r++) {
+                        memcpy(temp.data() + (size_t)(h * R + r) * groupStride,
+                               vSeg + (size_t)(r * H + h) * groupStride,
+                               groupStride);
+                    }
+                }
+                memcpy(vSeg, temp.data(), totalVBytes);
+            };
+
+            if (untileComposeNegLog) {
+                weight->dataType = DataType::FLOAT32;
+                weight->Resize(tensor->dims);
+                weight->Allocate();
+                const size_t len = ggml_nbytes(tensor);
+                std::vector<uint8_t> oriData(len);
+                FILE *fi = fopen(fileName.c_str(), "rb");
+        #if defined(_WIN32) || defined(_WIN64)
+                _fseeki64(fi, offset, 0);
+        #else
+                fseek(fi, offset, 0);
+        #endif
+                const size_t ret = fread(oriData.data(), 1, len, fi);
+                fclose(fi);
+                requireLayout(ret == len, "short read");
+                if (tensor->type == ggml_type::GGML_TYPE_F32) {
+                    memcpy(weight->cpuData, oriData.data(), len);
+                } else {
+                    auto toFloat = ggml_type_to_float(tensor->type);
+                    requireLayout(toFloat != nullptr,
+                                  "type " + std::string(ggml_type_name(tensor->type)) +
+                                  " cannot convert to fp32");
+                    toFloat(oriData.data(), (float*)weight->cpuData,
+                            weight->Count(0));
+                }
+                const size_t unitStride = isMultiDim
+                    ? (size_t)tensor->ne[0] * sizeof(float)
+                    : sizeof(float);
+                untileBytes((uint8_t*)weight->cpuData, weight->GetBytes(),
+                            unitStride);
+                float *data = (float*)weight->cpuData;
+                for (size_t i = 0; i < (size_t)weight->Count(0); i++) {
+                    requireLayout(data[i] < 0.0f,
+                                  "ssm_a value is outside the log(-x) domain");
+                    data[i] = logf(-data[i]);
+                }
+            } else {
+                if (weight->dataType != DataType::DATA_GGUF_FORMAT) {
+                    weight->Resize(tensor->dims);
+                    weight->Allocate();
+                } else {
+                    weight->dims = tensor->dims;
+                    weight->ggmlTensor = (void*)(new ggml_tensor());
+                    weight->ggmlType = tensor->type;
+                    weight->expansionBytes = ggml_nbytes(tensor);
+                    weight->cpuData = new uint8_t[weight->expansionBytes];
+                    (*(ggml_tensor*)weight->ggmlTensor) = *tensor;
+                }
+                const size_t len = ggml_nbytes(tensor);
+                FILE *fi = fopen(fileName.c_str(), "rb");
+        #if defined(_WIN32) || defined(_WIN64)
+                _fseeki64(fi, offset, 0);
+        #else
+                fseek(fi, offset, 0);
+        #endif
+                const size_t ret = fread(weight->cpuData, 1, len, fi);
+                fclose(fi);
+                requireLayout(ret == len, "short read");
+                const size_t unitStride = isMultiDim
+                    ? (size_t)tensor->nb[1]
+                    : (size_t)tensor->nb[0];
+                untileBytes((uint8_t*)weight->cpuData, len, unitStride);
+            }
         } else {
             ErrorInFastLLM("WeightImportGGUFTensor: Unsupport replace type.");
         }
@@ -1000,7 +1151,9 @@ namespace fastllm {
                                 )
                         );
                     } else if (it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP32 ||
-                                it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP16) {
+                                it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP16 ||
+                                it.type == GGUFWeightReplaceRule::GGUFWeightReplaceNegLogFP32 ||
+                                it.type == GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads) {
                         name = std::regex_replace(name, it.pattern, it.names[0]);
                         if (name == "ignore") {
                             break;
@@ -1011,6 +1164,7 @@ namespace fastllm {
                                 it.type
                             )
                         );
+                        tasks.back().untileComposeNegLog = it.untileComposeNegLog;
                     } else if (it.type == GGUFWeightReplaceRule::GGUFWeightReplacePacked) {
                         std::string prefix = std::regex_replace(name, it.pattern, it.names[0]);
                         std::string suffix = std::regex_replace(name, it.pattern, it.names[1]);
@@ -1193,7 +1347,10 @@ namespace fastllm {
                             );
                             // printf("replace %s\n", name.c_str());
                         }
-                    } else if (it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP32) {
+                    } else if (it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP32 ||
+                               it.type == GGUFWeightReplaceRule::GGUFWeightReplaceForceFP16 ||
+                               it.type == GGUFWeightReplaceRule::GGUFWeightReplaceNegLogFP32 ||
+                               it.type == GGUFWeightReplaceRule::GGUFWeightReplaceUntileVHeads) {
                         name = std::regex_replace(name, it.pattern, it.names[0]);
                         if (model->weight.weight.find(name) != model->weight.weight.end()) {
                             tasks.push_back (
@@ -1202,6 +1359,7 @@ namespace fastllm {
                                     it.type
                                 )
                             );
+                            tasks.back().untileComposeNegLog = it.untileComposeNegLog;
                             // printf("replace %s\n", name.c_str());
                         }
                     } else if (it.type == GGUFWeightReplaceRule::GGUFWeightReplacePacked) {

--- a/third_party/gguf/gguf.h
+++ b/third_party/gguf/gguf.h
@@ -2133,18 +2133,32 @@ namespace fastllm {
             GGUFWeightReplaceDirect = 0, // 直接替换
             GGUFWeightReplacePacked = 1, // 拆包替换，例如[128, 2048, 2048]的矩阵替换为128个 2048 * 2048，常见于moe
             GGUFWeightReplaceForceFP32 = 2, // 强行转为FP32, 主要是Embedding
-            GGUFWeightReplaceForceFP16 = 3 // 强行转为FP16
+            GGUFWeightReplaceForceFP16 = 3, // 强行转为FP16
+            GGUFWeightReplaceNegLogFP32 = 4, // 转为FP32并取log(-x)，用于Qwen3.5 ssm_a → A_log
+            // Qwen3.5/3.6 GGUF V-head tiled→grouped inverse permutation.
+            // Copies whole raw quant rows byte-exact; operates before merges.
+            // untileComposeNegLog additionally applies log(-x) after perm (for A_log).
+            GGUFWeightReplaceUntileVHeads = 5
         };
 
         GGUFWeightReplaceType type;
         std::regex pattern;
         std::vector <std::string> names;
 
+        // V-head untile params (used when type == GGUFWeightReplaceUntileVHeads).
+        // Filled from model config at load time; 0 means "not set / fall back to Direct".
+        int untileNumKHeads = 0;     // H = num_k_heads
+        int untileNumVHeads = 0;     // Hv = num_v_heads (R = Hv / H)
+        int untileVRowStart = 0;     // first V-indexed row in dim[0]
+        bool untileComposeNegLog = false; // apply log(-x) after perm (A_log)
+
         GGUFWeightReplaceRule (std::regex pattern, const std::string &name, 
-                                GGUFWeightReplaceType type = GGUFWeightReplaceDirect) {
+                                GGUFWeightReplaceType type = GGUFWeightReplaceDirect,
+                                bool untileComposeNegLog = false) {
             this->type = type;
             this->pattern = pattern;
             this->names = {name};
+            this->untileComposeNegLog = untileComposeNegLog;
         }
 
         GGUFWeightReplaceRule (std::regex pattern, const std::vector <std::string> &names, 
@@ -2166,6 +2180,13 @@ namespace fastllm {
 
         GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType;
 
+        // V-head untile params (forwarded from GGUFWeightReplaceRule; H/Hv/vRowStart
+        // are injected from model config after AppendGGUFTasks).
+        int untileNumKHeads = 0;
+        int untileNumVHeads = 0;
+        int untileVRowStart = 0;
+        bool untileComposeNegLog = false;
+
         ReadGGUFTask (std::string &name, Data *weight, ggml_tensor tensor, std::string fileName, uint64_t offset, 
                         GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType = GGUFWeightReplaceRule::GGUFWeightReplaceType::GGUFWeightReplaceDirect) {
             this->name = name;
@@ -2178,7 +2199,9 @@ namespace fastllm {
     };
 
     void WeightImportGGUFTensor(Data* weight, ggml_tensor *tensor, std::string &fileName, uint64_t offset, 
-                                GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType = GGUFWeightReplaceRule::GGUFWeightReplaceType::GGUFWeightReplaceDirect);
+                                GGUFWeightReplaceRule::GGUFWeightReplaceType replaceType = GGUFWeightReplaceRule::GGUFWeightReplaceType::GGUFWeightReplaceDirect,
+                                int untileNumKHeads = 0, int untileNumVHeads = 0,
+                                int untileVRowStart = 0, bool untileComposeNegLog = false);
 
     void ReadGGUFMetaData(const std::string &fileName, json11::Json &config);
 

--- a/tools/fastllm_pytools/benchmark.py
+++ b/tools/fastllm_pytools/benchmark.py
@@ -1,8 +1,11 @@
 import argparse
 import ctypes
+import json
+import os
 import statistics
 import time
 from typing import Dict, List, Optional
+from pathlib import Path
 
 from .util import make_normal_llm_model, make_normal_parser
 
@@ -28,6 +31,8 @@ def add_benchmark_args(parser: argparse.ArgumentParser):
     parser.add_argument("--repeat_penalty", "--repetition_penalty",
                         dest="repeat_penalty", type=float, default=None,
                         help="Generation repetition penalty")
+    parser.add_argument("--output-json", type=str, default="",
+                        help="Write the complete benchmark result as JSON")
 
 
 def args_parser():
@@ -135,6 +140,7 @@ def _run_batch(model, input_tokens: List[int], output_tokens: int,
             "end_time": None,
             "output_tokens": 0,
             "finish_code": None,
+            "response_statistics": None,
         })
 
     pending = set(range(batch))
@@ -144,6 +150,11 @@ def _run_batch(model, input_tokens: List[int], output_tokens: int,
             item = requests[request_index]
             if not fastllm_lib.can_fetch_response_llm_model(model.model, item["handle"]):
                 continue
+            get_statistics = getattr(model, "get_response_statistics", None)
+            if callable(get_statistics):
+                response_statistics = get_statistics(item["handle"])
+                if response_statistics is not None:
+                    item["response_statistics"] = response_statistics
             token = fastllm_lib.fetch_response_llm_model(model.model, item["handle"])
             now = time.perf_counter()
             progressed = True
@@ -183,6 +194,10 @@ def _run_batch(model, input_tokens: List[int], output_tokens: int,
         max(item["end_time"] for item in requests) - min(first_token_times)
         if first_token_times else 0.0
     )
+    available_statistics = [
+        item["response_statistics"] for item in requests
+        if item["response_statistics"] is not None
+    ]
     return {
         "label": label,
         "input_tokens": len(input_tokens),
@@ -190,6 +205,13 @@ def _run_batch(model, input_tokens: List[int], output_tokens: int,
         "batch": batch,
         "requests": requests,
         "total_output_tokens": total_output_tokens,
+        "response_statistics_available": len(available_statistics) == len(requests),
+        "cached_input_tokens": sum(
+            item.get("cached_input_tokens", 0) for item in available_statistics),
+        "missed_input_tokens": sum(
+            item.get("missed_input_tokens", 0) for item in available_statistics),
+        "native_output_tokens": sum(
+            item.get("output_tokens", 0) for item in available_statistics),
         "total_time": batch_end - batch_start,
         "ttft_avg": statistics.mean(ttfts) if ttfts else None,
         "ttft_min": min(ttfts) if ttfts else None,
@@ -317,6 +339,21 @@ def _print_result(result: Dict[str, object]):
     print("=" * 72)
 
 
+def _write_result_json(output_path, result: Dict[str, object]):
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_output = Path(str(output) + ".tmp")
+    try:
+        temp_output.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temp_output, output)
+    finally:
+        if temp_output.exists():
+            temp_output.unlink()
+
+
 def fastllm_benchmark(args):
     _validate_args(args)
     if getattr(args, "max_batch", -1) <= 0:
@@ -339,6 +376,8 @@ def fastllm_benchmark(args):
         result = _run_batch(model, input_tokens, args.output_tokens, args.batch,
                             generation_args)
         _print_result(result)
+        if args.output_json:
+            _write_result_json(args.output_json, result)
         return result
     finally:
         model.release_memory()

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -1190,6 +1190,10 @@ class model:
                 exit(0)
         if config_base_path is not None:
             self.model_path = config_base_path
+        config_path = os.path.join(config_base_path, "config.json") if config_base_path else ""
+        if config_path and os.path.isfile(config_path) and not hasattr(self, "config"):
+            with open(config_path, "r", encoding="utf-8") as config_file:
+                self.config = json.load(config_file)
 
         architecture = ""
         model_type = ""

--- a/tools/fastllm_pytools/openai_server/fastllm_completion.py
+++ b/tools/fastllm_pytools/openai_server/fastllm_completion.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
 import traceback
 import uuid
@@ -115,7 +116,82 @@ class FastLLmCompletion:
     self.hide_input = hide_input
     # Store mapping between conversation IDs and handles
     self.conversation_handles = {}
+    self._conversation_lock = threading.Lock()
+    self._handle_condition = threading.Condition(self._conversation_lock)
+    self._active_handle_launches = 0
+    self._handle_owners = {}
     
+  def _ensure_handle_tracking(self):
+    if not hasattr(self, "_conversation_lock"):
+      self._conversation_lock = threading.Lock()
+    if not hasattr(self, "_handle_condition"):
+      self._handle_condition = threading.Condition(self._conversation_lock)
+    if not hasattr(self, "_active_handle_launches"):
+      self._active_handle_launches = 0
+    if not hasattr(self, "_handle_owners"):
+      self._handle_owners = {}
+
+  def _launch_owned_handle(self, request_id: str, launch):
+    self._ensure_handle_tracking()
+    with self._handle_condition:
+      self._active_handle_launches += 1
+    try:
+      handle = launch()
+    except BaseException:
+      with self._handle_condition:
+        self._active_handle_launches -= 1
+        self._handle_condition.notify_all()
+      raise
+    with self._handle_condition:
+      try:
+        previous_request = self._handle_owners.get(handle)
+        if (previous_request is not None and
+                self.conversation_handles.get(previous_request) == handle):
+          del self.conversation_handles[previous_request]
+        previous_handle = self.conversation_handles.get(request_id)
+        if (previous_handle is not None and
+                self._handle_owners.get(previous_handle) == request_id):
+          del self._handle_owners[previous_handle]
+        self.conversation_handles[request_id] = handle
+        self._handle_owners[handle] = request_id
+      finally:
+        self._active_handle_launches -= 1
+        self._handle_condition.notify_all()
+    return handle
+
+  def _release_owned_handle(self, request_id: str,
+                            expected_handle: Optional[int] = None) -> bool:
+    self._ensure_handle_tracking()
+    with self._conversation_lock:
+      handle = self.conversation_handles.get(request_id)
+      if handle is None or (expected_handle is not None and
+                            handle != expected_handle):
+        return False
+      if self._handle_owners.get(handle) != request_id:
+        del self.conversation_handles[request_id]
+        return False
+      del self.conversation_handles[request_id]
+      del self._handle_owners[handle]
+      return True
+
+  def _abort_owned_handle(self, request_id: str,
+                          expected_handle: Optional[int] = None) -> bool:
+    self._ensure_handle_tracking()
+    with self._handle_condition:
+      while self._active_handle_launches:
+        self._handle_condition.wait()
+      handle = self.conversation_handles.get(request_id)
+      if handle is None or (expected_handle is not None and
+                            handle != expected_handle):
+        return False
+      if self._handle_owners.get(handle) != request_id:
+        del self.conversation_handles[request_id]
+        return False
+      self.model.abort_handle(handle)
+      del self.conversation_handles[request_id]
+      del self._handle_owners[handle]
+      return True
+
   def init_fast_llm_model(self):
     pass
   
@@ -2089,11 +2165,12 @@ class FastLLmCompletion:
           if parser_request is not None:
               self._attach_tool_call_constraint_if_supported(
                   launch_kwargs, parser_request)
-          handle = self.model.launch_stream_response(
-              messages, **launch_kwargs)
+          handle = self._launch_owned_handle(
+              request_id,
+              lambda: self.model.launch_stream_response(
+                  messages, **launch_kwargs))
       finally:
           self._cleanup_temp_paths(media.temp_paths)
-      self.conversation_handles[request_id] = handle
       response_statistics: Dict[str, int] = {}
       result_generator = self._stream_response_handle_with_statistics(
           handle, response_statistics)
@@ -2111,6 +2188,7 @@ class FastLLmCompletion:
                   input_token_len, parser_request,
                   response_statistics = response_statistics)
           except ValueError as e:
+              self._release_owned_handle(request_id, handle)
               return self.create_error_response(str(e))
 
   async def create_chat_completion(
@@ -2240,8 +2318,10 @@ class FastLLmCompletion:
               images = model_images,
               videos = model_videos,
               tools = tools)
-          launched_handle = self.model.launch_stream_response(
-              messages, **launch_kwargs)
+          launched_handle = self._launch_owned_handle(
+              request_id,
+              lambda: self.model.launch_stream_response(
+                  messages, **launch_kwargs))
           return input_len, launched_handle
 
       try:
@@ -2256,7 +2336,6 @@ class FastLLmCompletion:
       finally:
           self._cleanup_temp_paths(media.temp_paths)
       # Store the mapping between conversation ID and handle
-      self.conversation_handles[request_id] = handle
       # logging.info(f"Created conversation: {request_id}, handle: {handle}")
       response_statistics: Dict[str, int] = {}
       result_generator = self._stream_response_handle_with_statistics(
@@ -2281,20 +2360,15 @@ class FastLLmCompletion:
                   emit_reasoning_content = emit_reasoning_content,
                   response_statistics = response_statistics)
           except ValueError as e:
+              self._release_owned_handle(request_id, handle)
               return self.create_error_response(str(e))
 
   async def check_disconnect(self, raw_request: Request, request_id, handle: int):
-    # 进入BackgroundTask之后，说明流式请求已经断开了，那么这里直接abort
-    self.model.abort_handle(handle)
-    logging.info(f"Abort request: {request_id}")
-    return
-  
-    while True:
-      if await raw_request.is_disconnected():
-        self.model.abort_handle(handle)
-        logging.info(f"Abort request: {request_id}")
-        return
-      await asyncio.sleep(1)  # 检查间隔
+    # Starlette runs this task after a stream disconnects or completes. The
+    # integer handle may already have been recycled for another request, so
+    # abort only while this request still owns that exact handle.
+    if self._abort_owned_handle(request_id, handle):
+      logging.info(f"Abort request: {request_id}")
       
   async def chat_completion_full_generator(
               self, request: ChatCompletionRequest, raw_request: Request,
@@ -2316,7 +2390,7 @@ class FastLLmCompletion:
         completion_tokens += 1
         if await raw_request.is_disconnected():
            print("is_disconnected!!!")
-           self.model.abort_handle(handle)
+           self._abort_owned_handle(request_id, handle)
            logging.info(f"Abort request: {request_id}")
            return self.create_error_response("Client disconnected")
 
@@ -2330,8 +2404,7 @@ class FastLLmCompletion:
 
       tool_call_info = self._parse_non_stream_tool_calls(result, request)
       if isinstance(tool_call_info, ErrorResponse):
-          if request_id in self.conversation_handles:
-              del self.conversation_handles[request_id]
+          self._release_owned_handle(request_id, handle)
           return tool_call_info
 
       if tool_call_info.tools_called:
@@ -2368,9 +2441,7 @@ class FastLLmCompletion:
           usage = usage,
       )
 
-      # After completion, remove the conversation from tracking dictionary
-      if request_id in self.conversation_handles:
-          del self.conversation_handles[request_id]
+      self._release_owned_handle(request_id, handle)
           # logging.info(f"Removed completed conversation from tracking: {request_id}")
 
       return response
@@ -2694,9 +2765,7 @@ class FastLLmCompletion:
         yield f"data: {data}\n\n"
         await asyncio.sleep(0)
       
-      # After completion, remove the conversation from tracking dictionary
-      if request_id in self.conversation_handles:
-          del self.conversation_handles[request_id]
+      self._release_owned_handle(request_id, handle)
           # logging.info(f"Removed completed stream conversation from tracking: {request_id}")
       
       yield "data: [DONE]\n\n"
@@ -2723,7 +2792,7 @@ class FastLLmCompletion:
         completion_tokens += 1
         if await raw_request.is_disconnected():
            print("is_disconnected!!!")
-           self.model.abort_handle(handle)
+           self._abort_owned_handle(request_id, handle)
            logging.info(f"Abort request: {request_id}")
            return self.create_error_response("Client disconnected")
 
@@ -2747,8 +2816,7 @@ class FastLLmCompletion:
           usage = usage,
       )
 
-      if request_id in self.conversation_handles:
-          del self.conversation_handles[request_id]
+      self._release_owned_handle(request_id, handle)
 
       return response
 
@@ -2932,8 +3000,7 @@ class FastLLmCompletion:
           yield f"event: error\ndata: {error_data}\n\n"
           await asyncio.sleep(0)
 
-      if request_id in self.conversation_handles:
-          del self.conversation_handles[request_id]
+      self._release_owned_handle(request_id, handle)
 
       await asyncio.sleep(0)
       
@@ -2951,26 +3018,26 @@ class FastLLmCompletion:
       return json_str
 
   def abort_conversation(self, conversation_id: str) -> bool:
-    if conversation_id in self.conversation_handles:
-      handle = self.conversation_handles[conversation_id]
-      try:
-        self.model.abort_handle(handle)
-        logging.info(f"Aborted conversation: {conversation_id}, handle: {handle}")
-        # Remove the conversation from the mapping
-        del self.conversation_handles[conversation_id]
-        return True
-      except Exception as e:
-        logging.error(f"Error aborting conversation {conversation_id}: {e}")
-        return False
-    else:
+    self._ensure_handle_tracking()
+    handle = self.conversation_handles.get(conversation_id)
+    if handle is None:
       logging.warning(f"Conversation ID not found: {conversation_id}")
+      return False
+    try:
+      if not self._abort_owned_handle(conversation_id, handle):
+        logging.warning(f"Conversation no longer owns handle: {conversation_id}")
+        return False
+      logging.info(f"Aborted conversation: {conversation_id}, handle: {handle}")
+      return True
+    except Exception as e:
+      logging.error(f"Error aborting conversation {conversation_id}: {e}")
       return False
       
   def get_active_conversations(self) -> List[Dict[str, Any]]:
-    result = []
-    for conversation_id, handle in self.conversation_handles.items():
-      result.append({
-        "conversation_id": conversation_id,
-        "handle": handle
-      })
-    return result
+    self._ensure_handle_tracking()
+    with self._conversation_lock:
+      conversations = list(self.conversation_handles.items())
+    return [
+        {"conversation_id": conversation_id, "handle": handle}
+        for conversation_id, handle in conversations
+    ]

--- a/tools/fastllm_pytools/tui.py
+++ b/tools/fastllm_pytools/tui.py
@@ -194,6 +194,7 @@ KV_CACHE_DTYPE_CHOICES: Sequence[Choice] = (
     ("float16", "float16"),
     ("bfloat16", "bfloat16"),
     ("fp8_e4m3", "fp8"),
+    ("turbo3", "Turbo3 (Qwen3.5/3.6 experimental)"),
 )
 
 MOE_ATYPE_CHOICES: Sequence[Choice] = (
@@ -310,7 +311,7 @@ FIELDS: Sequence[FormField] = (
         "text",
         "分块 prefill 的切片大小；调小可以减少显存占用，auto 表示不指定。",
     ),
-    FormField("kv_cache_dtype", "缓存类型", "choice", "KV Cache 类型，可使用 auto、float16、bfloat16 或 fp8。", KV_CACHE_DTYPE_CHOICES),
+    FormField("kv_cache_dtype", "缓存类型", "choice", "KV Cache 类型；turbo3 仅用于 Qwen3.5/3.6，且需 FASTLLM_QWEN35_TURBO3_KV=1。", KV_CACHE_DTYPE_CHOICES),
     FormField("mtp", "MTP", "text", "Qwen3.5 MTP 每步生成的 draft token 数；0 表示关闭，1-9 开启，auto 表示不指定。"),
     FormField("max_batch", "最大Batch", "text", "每次最多同时推理的询问数量；auto 表示不指定。"),
     FormField(

--- a/tools/fastllm_pytools/tui.py
+++ b/tools/fastllm_pytools/tui.py
@@ -311,7 +311,7 @@ FIELDS: Sequence[FormField] = (
         "分块 prefill 的切片大小；调小可以减少显存占用，auto 表示不指定。",
     ),
     FormField("kv_cache_dtype", "缓存类型", "choice", "KV Cache 类型，可使用 auto、float16、bfloat16 或 fp8。", KV_CACHE_DTYPE_CHOICES),
-    FormField("mtp", "MTP", "text", "Qwen3.5 MTP 每步生成的 draft token 数；0 表示关闭，1-8 开启，auto 表示不指定。"),
+    FormField("mtp", "MTP", "text", "Qwen3.5 MTP 每步生成的 draft token 数；0 表示关闭，1-9 开启，auto 表示不指定。"),
     FormField("max_batch", "最大Batch", "text", "每次最多同时推理的询问数量；auto 表示不指定。"),
     FormField(
         "max_context_length",
@@ -549,7 +549,7 @@ def _is_mtp_value(value: str) -> bool:
         mtp = int(str(value).strip())
     except ValueError:
         return False
-    return 0 <= mtp <= 8
+    return 0 <= mtp <= 9
 
 
 def _is_positive_float_or_auto(value: str) -> bool:
@@ -1088,7 +1088,7 @@ def validate_config(config: DeployConfig) -> List[str]:
             errors.append(f"{label}必须是正整数或 auto。")
 
     if not _is_mtp_value(config.mtp):
-        errors.append("MTP 必须是 0-8 的整数或 auto。")
+        errors.append("MTP 必须是 0-9 的整数或 auto。")
 
     if not _is_ratio(config.gpu_mem_ratio):
         errors.append("显存利用率必须是 0 到 1 之间的数字，例如 0.9。")

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -29,7 +29,7 @@ def _normalize_mtp_arg(value) -> int:
         value = int(value)
     except Exception:
         value = 0
-    return max(0, value)
+    return min(9, max(0, value))
 
 def _total_memory_gib() -> float:
     try:
@@ -245,7 +245,7 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
                         help = "全局最多保留的前缀缓存快照数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_RECORDS")
     parser.add_argument("--gpu_mem_ratio", type = float, default = 0.9, help = "GPU显存使用比例，如0.9表示使用90%%的显存")
     parser.add_argument("--cuda_slab", type = int, default = 0, help = "CUDA模型权重slab大小（MB），0表示关闭")
-    parser.add_argument("--mtp", type = int, default = 0, help = "Qwen3.5 MTP每步生成的draft token数，0表示关闭（默认），当前最大8")
+    parser.add_argument("--mtp", type = int, default = 0, help = "Qwen3.5 MTP每步生成的draft token数，0表示关闭（默认），当前最大9")
     parser.add_argument("--triton", action = "store_true", help = "启用Triton CUDA算子")
     
     parser.add_argument('--custom', type = str, default = "", help = '指定描述自定义模型的python文件')

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -215,7 +215,7 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
     parser.add_argument('--moe_dtype', type = str, default = "", help = 'MOE层使用的权重类型（读取HF模型时有效）')
     parser.add_argument('--moe_atype', type = str, default = "", help = 'MOE层激活类型，可使用auto、float32、float16或bfloat16')
     parser.add_argument('--atype', type = str, default = "auto", help = '推理类型，可使用float32或float16')
-    parser.add_argument('--kv_cache_dtype', type = str, default = "auto", help = 'KV Cache类型，可使用auto、float16、bfloat16或fp8_e4m3')
+    parser.add_argument('--kv_cache_dtype', type = str, default = "auto", help = 'KV Cache类型，可使用auto、float16、bfloat16、fp8_e4m3或turbo3（Qwen3.5/3.6需FASTLLM_QWEN35_TURBO3_KV=1）')
     parser.add_argument('--cuda_embedding', action = 'store_true', help = '在cuda上进行embedding')
     parser.add_argument('--kv_cache_limit', type = str, default = "auto",  help = 'kv缓存最大使用量')
     parser.add_argument('--max_batch', type = int, default = -1,  help = '每次最多同时推理的询问数量')

--- a/tools/src/pytools.cpp
+++ b/tools/src/pytools.cpp
@@ -563,8 +563,10 @@ extern "C" {
             model->SetKVCacheDataType(fastllm::DataType::FLOAT32);
         } else if (dtypeStr == "fp8" || dtypeStr == "float8" || dtypeStr == "fp8_e4m3") {
             model->SetKVCacheDataType(fastllm::DataType::FP8_E4M3);
+        } else if (dtypeStr == "turbo3" || dtypeStr == "turbo3_kv") {
+            model->SetKVCacheDataType(fastllm::DataType::TURBO3_KV);
         } else {
-            fastllm::ErrorInFastLLM("set_model_kv_cache_dtype error: kv_cache_dtype should be auto, float32, float16, bfloat16 or fp8_e4m3.");
+            fastllm::ErrorInFastLLM("set_model_kv_cache_dtype error: kv_cache_dtype should be auto, float32, float16, bfloat16, fp8_e4m3 or turbo3.");
         }
         return;
     }


### PR DESCRIPTION
## 概述

在 CUDA 12 / Tesla V100 (SM70) 上支持 Qwen3.5/3.6 27B hybrid（full-attention + GDN linear-attention）GGUF 模型加载与推理，包括内置 MTP（Multi-Token Prediction）投机解码、长上下文容量配置、V100 IQ4_XS MMQ，以及 Qwen3.5 exact-shape 分页 XQA 解码优化。

## 主要变更

### GGUF 加载（`src/model.cpp`, `third_party/gguf/*`）
- 识别 `qwen35` / `qwen3_5` 架构并映射 linear-attention metadata
- 将 `block_count` 拆分为 trunk 层与 MTP 层，重映射 MTP tensor
- V-head tiled → grouped 加载时逆置换，保留 quantized out_proj tiled-column marker
- norm pre-offset 与 out_proj layout marker 独立控制
- worker 线程通过 `std::exception_ptr` 向调用方传播异常
- `qwen35moe` 与多层 MTP（`nextn_predict_layers > 1`）明确 fail-fast
- `originalPath` 分支保留 immutable GGUF 源架构
- 修复无 CUDA 构建中 Qwen3.5 GGUF layout override helper 不可见的问题

### Qwen3.5 运行时（`src/models/qwen3_5.cpp`, `include/models/qwen3_5.h`）
- 修复 KV-head 派生成员遮蔽，并初始化 GDN head metadata / inverse scale
- grouped/tiled out_proj TP 分片方案由 layout marker 决定
- MTP draft 容量扩展到每步 9 个（`FAST_SEQ_MAX=10`）
- CUDA graph、single-GPU 与 thread-TP 路径均支持 tiled out_proj activation reorder
- decode 页预算不足以验证整组 MTP draft 时降级为单 token；单 token 也不足才重建请求

### SM70 IQ4_XS DP4A MMQ（`src/devices/cuda/fastllm-iq4xs-sm70.cu`）
- 为 SM70 + IQ4_XS + `n∈[8,64]` + `k≥128` 增加 DP4A MMQ
- Q8_1 D4 activation 量化、IQ4_XS codebook lookup、按 `(device, stream)` 隔离的 thread-local scratch
- BF16 cuBLAS 路径增加 SM80 capability gate，V100 安全回退到 MMVQ
- `__CUDA_ARCH__ >= 610` 编译 guard 与 scalar fallback，兼容 sm60 / mixed-arch 编译
- ROCm 编译 stub 与 `FASTLLM_CUDA_SM70_IQ4XS_MMQ=0` 禁用开关

### SM70 分页 XQA 解码（`src/devices/cuda/attention/paged/*`）
- 为 V100 上 Qwen3.5/3.6 的 exact shape 增加 native split-KV XQA 解码：FP16、page 128、Q24/KV4、D256、GQA6、`qLen=1`
- 4-warp phase-1 每次只读取一份 K/V 并供 6 个 Q head 复用；phase-2 合并在线 softmax 的 split 状态
- scratch 按 host thread / `cudaStreamPerThread` 隔离并保持稳定地址，支持 CUDA graph capture/replay
- exact shape 默认启用；`FASTLLM_CUDA_SM70_PAGED_XQA=0` 可恢复原 native 路径
- 非 SM70、非连续 output、不同 dtype/layout/head shape 或 `qLen>1` 均在发射前安全拒绝并回退
- MTP9 target validation 的 `qLen=10` 有意继续走原 native causal prefill；普通 greedy/seed 的 `qLen=1` decode 可命中 XQA

### 容量与服务端
- `SetTokenLimit` 同步模型 token limit 与 paged-cache allocator 容量
- `apiserver` 新增 `--kv_cache_dtype auto|float32|float16|bfloat16|fp8_e4m3`
- 修复 tokenizer 输出生命周期、请求断连/边界处理和低显存 EmbeddingDirect 校验
- Python CLI 的 MTP 上界统一为 9

### 回归测试
- synthetic Qwen3.5 GGUF 覆盖真实 H=16 / V=48 / D=128 V-head 布局、mixed quant、fail-fast 与 worker exception
- GDN projection layout 四种状态和 merged-layout precedence 全覆盖
- 临时目录与环境变量 fixture 使用跨平台 RAII，异常路径不污染后续测试
- FP8 KV 配置测试在 CPU-only build 保留 parser/F16 契约，并仅在 CUDA build 调用 FP8 setter
- SM70 XQA 覆盖非顺序 physical pages、partial last page、batch=2/nonzero `pageStart`、非法 group、非连续 output、CUDA graph replay 与双 PTDS 并发

## 验证

- CUDA 12.9 toolchain（SM70）构建 `apiserver` 与 `regressionOps`：PASS
- `FASTLLM_REGRESSION_ONLY=qwen35_gguf ./regressionOps`：CUDA 12 / CPU-only 均 PASS
- `FASTLLM_REGRESSION_ONLY=gguf_dequant ./regressionOps`：V100 PASS
- `FASTLLM_REGRESSION_ONLY=sm70_paged_xqa ./regressionOps`：V100 PASS
- 完整 `./regressionOps`：CUDA 12 与 `USE_CUDA=OFF, UNIT_TEST=ON` 均 PASS（双 GPU、Triton/NUMA 等不可用环境按预期 SKIP）
- SM70 XQA 单层 decode attention（对比原 per-Q-head native）：8K `2.22x`、32K `3.37x`、128K `4.03x`
- XQA phase-1 cubin resource：136 registers、30,912 B shared、0 local memory / spill
- 真实 Qwen3.6 27B IQ4_XS greedy：HTTP 200、输出正确并观测到默认 `SM70 paged XQA enabled` production route
- 真实 Qwen3.6 27B IQ4_XS MTP9：HTTP 200、连续输出正确并观测到 speculative full/partial acceptance；`qLen=10` target validation 按设计保留原路径
- exact-window：128K / 160K 使用 FP16 KV 完成，256K 使用 FP8 E4M3 KV 完成
- 基于最新 `origin/master`，8 个中文意图拆分 commits；无本机路径、模型路径或 benchmark 产物进入上游代码
