### PR TITLE
Validate safetensors header fields before using them as sizes

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -873,6 +873,17 @@ namespace fastllm {
                                                       const std::string &tensorName);
     static bool IsPackedFP4Tensor(const SafeTensors &safeTensors, const std::string &name);
 
+    // Byte width of a safetensors dtype string. Returns 0 for dtypes fastllm does
+    // not size directly, so callers can skip the size check rather than guess.
+    static uint64_t SafeTensorDtypeBytes(const std::string &dtype) {
+        if (dtype == "F64" || dtype == "I64" || dtype == "U64") return 8;
+        if (dtype == "F32" || dtype == "I32" || dtype == "U32") return 4;
+        if (dtype == "F16" || dtype == "BF16" || dtype == "I16" || dtype == "U16") return 2;
+        if (dtype == "F8_E4M3" || dtype == "F8_E5M2" || dtype == "F8_E8M0" ||
+            dtype == "I8" || dtype == "U8" || dtype == "BOOL") return 1;
+        return 0;
+    }
+
     struct SafeTensorItem {
         std::string tensorName;
         std::string fileName;
@@ -907,9 +918,27 @@ namespace fastllm {
 
             len = 1;
             for (auto &it : shape) {
+                AssertInFastLLM(it == 0 || len <= UINT64_MAX / it,
+                                "SafeTensorItem: shape product overflows.");
                 len *= it;
             }
+
+            // data_offsets, shape and dtype are three independent fields of the same
+            // untrusted header. Reconcile them here, once, before any of them is used
+            // to size an allocation or a read length.
+            AssertInFastLLM(this->data_offsets.size() == 2,
+                            "SafeTensorItem: data_offsets must have exactly 2 elements.");
+            AssertInFastLLM(this->data_offsets[1] >= this->data_offsets[0],
+                            "SafeTensorItem: data_offsets end is before begin.");
             bytes = this->data_offsets[1] - this->data_offsets[0];
+
+            uint64_t elemBytes = SafeTensorDtypeBytes(this->dtype);
+            if (elemBytes > 0) {
+                AssertInFastLLM(len == 0 || len <= UINT64_MAX / elemBytes,
+                                "SafeTensorItem: shape times dtype size overflows.");
+                AssertInFastLLM(bytes == len * elemBytes,
+                                "SafeTensorItem: data_offsets span does not match shape and dtype.");
+            }
         }
 
         struct FP8E4M3ToFP32Manager fp8e4m3tofp32;
@@ -1428,8 +1457,20 @@ namespace fastllm {
             this->fileNames = fileNames;
             for (auto &fileName : fileNames) {
                 FILE *f = fopen(fileName.c_str(), "rb");
+                AssertInFastLLM(f != nullptr, "SafeTensors: cannot open " + fileName);
+                // The header length is the first attacker-controlled value in the file.
+                // Bound it against the real file size before it is used as an allocation
+                // size or a read length: configBytes + 5 wraps for values near UINT64_MAX,
+                // which produced a tiny allocation and an unbounded fread into it.
+                fseek(f, 0, SEEK_END);
+                long long fileSize = ftell(f);
+                fseek(f, 0, SEEK_SET);
+                AssertInFastLLM(fileSize >= 8, "SafeTensors: " + fileName + " is too short to hold a header length.");
                 uint64_t configBytes;
                 int ret = fread(&configBytes, 8, 1, f);
+                AssertInFastLLM(ret == 1, "SafeTensors: cannot read the header length of " + fileName);
+                AssertInFastLLM(configBytes <= (uint64_t)fileSize - 8,
+                                "SafeTensors: header length exceeds the file size of " + fileName);
                 char *configString = new char[configBytes + 5];
                 ret = fread(configString, 1, configBytes, f);
                 configString[configBytes] = 0;


### PR DESCRIPTION
Fixes #712.

Three values from the `.safetensors` header were used as allocation sizes or read lengths without being checked against anything else. Loading a crafted file writes past the end of heap allocations.

**`SafeTensors` (src/model.cpp:1430-1435).** The 8-byte header length went straight into `new char[configBytes + 5]`. That addition wraps for values near `UINT64_MAX`, so the allocation becomes 0-4 bytes while the following `fread` still asks for `configBytes`. Now bounded against the real file size. The `fopen` result and the first `fread` return were also unchecked, so a short or unreadable file left `configBytes` uninitialised.

**`SafeTensorItem` (src/model.cpp:900-912).** `data_offsets[1]` was indexed without checking that two elements were parsed, and there was no check that the end offset is not before the beginning.

**`SafeTensorItem::CreateBuffer` (src/model.cpp:1383-1385).** The tensor buffer is allocated from the shape product and then filled by `fread` with the `data_offsets` span. Those are independent header fields and can disagree. The `else` branch has the mirror problem, where `ConvertDataType` copies `len * unitSize` out of a buffer allocated with `bytes`.

All three are now checked at parse time, where the fields are first read, rather than at each point of use.

## Testing

Against the crafted files from #712, on a build with `-fsanitize=address` and `_FORTIFY_SOURCE` disabled so the writes are visible rather than caught by glibc:

| input | before | after |
|---|---|---|
| valid model | loads | loads, unchanged |
| shape `[32,8]`, `data_offsets` span 65536 | heap overflow, WRITE of size 65536 | rejected, "data_offsets span does not match shape and dtype" |
| `data_offsets: [0]` | heap overflow, READ of size 8 | rejected, "data_offsets must have exactly 2 elements" |
| `data_offsets: []` | SEGV | rejected, same |
| header length `2^64-1`, 4 KB body | heap overflow, WRITE of size 4088 | rejected, "header length exceeds the file size" |
| header length `2^64-1`, no body | heap overflow, WRITE of size 1 | rejected, same |

Seven crafted inputs in total are rejected, each by the specific check intended for it. A model directory whose header fields agree still loads to inference.

I have the crafted files if they would be useful for a regression test.