### PR TITLE
Fix GGUF tokenization: BPE merges are applied left-to-right instead of by merge rank

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -2852,6 +2852,41 @@ namespace fastllm {
                 printf("Load chatTemplate = %s\n", model->weight.tokenizer.chatTemplate.c_str());
             }
 
+            // Canonical BPE is defined by the rank of each rule in "tokenizer.ggml.merges"
+            // (rank 0 is applied first). Tokenizer::TryMergePairs however orders candidate
+            // merges by token score, and SymbolPairs::operator< falls back to comparing
+            // positions when the scores are equal, so giving every token the same score
+            // turns the merge order into a plain left-to-right greedy scan. That yields a
+            // valid but non-canonical split, e.g. "brutalist" -> "bru" + "talist" instead
+            // of "br" + "ut" + "alist". GPT-2 style vocabularies (tokenizer.ggml.model ==
+            // "gpt2") carry no "tokenizer.ggml.scores" field at all, so merges are the only
+            // ordering information available for them.
+            //
+            // Scoring the token produced by rule i with -i makes the existing max-heap pop
+            // the lowest rank first, which is exactly canonical BPE, without changing the
+            // tokenizer. Tokens that no merge rule can produce get a very low score, so
+            // they can still be merged as a last resort but never outrank a real merge.
+            // Files without merges (SentencePiece style vocabularies) keep the previous
+            // score of 1.0f and therefore behave exactly as before.
+            std::unordered_map <std::string, int> mergeRanks;
+            {
+                const auto &mergeItems = params["tokenizer.ggml.merges"].array_items();
+                mergeRanks.reserve(mergeItems.size() * 2);
+                for (int i = 0; i < (int)mergeItems.size(); i++) {
+                    // every rule looks like "<left> <right>" and produces "<left><right>"
+                    const std::string &rule = mergeItems[i].string_value();
+                    size_t sep = rule.find(' ');
+                    if (sep == std::string::npos || sep == 0 || sep + 1 >= rule.size()) {
+                        continue;
+                    }
+                    // keep the best (smallest) rank if a string is produced more than once
+                    mergeRanks.insert({rule.substr(0, sep) + rule.substr(sep + 1), i});
+                }
+                if (!mergeRanks.empty()) {
+                    printf("Load tokenizer merges = %d\n", (int)mergeRanks.size());
+                }
+            }
+
             const auto &tokenItems = params["tokenizer.ggml.tokens"].array_items();
             int tokenTotal = (int)tokenItems.size();
             ReportModelLoadProgress("tokenizer", 0, std::max(1, tokenTotal));
@@ -2860,7 +2895,12 @@ namespace fastllm {
                 if (idx < 10) {
                     // printf("%s: %d\n", it.string_value().c_str(), idx);
                 }
-                model->weight.AddTokenizerWord(it.string_value(), idx, 1.0f);
+                float score = 1.0f;
+                if (!mergeRanks.empty()) {
+                    auto rankIt = mergeRanks.find(it.string_value());
+                    score = (rankIt == mergeRanks.end()) ? -1e9f : -(float)rankIt->second;
+                }
+                model->weight.AddTokenizerWord(it.string_value(), idx, score);
                 idx++;
                 if (idx == tokenTotal ||
                     idx * 100 / std::max(1, tokenTotal) != (idx - 1) * 100 / std::max(1, tokenTotal)) {


### PR DESCRIPTION
## Symptom

Models loaded from GGUF are tokenized with a valid but **non-canonical** BPE split. Measured against a reference BPE implementation (HuggingFace `tokenizers` 0.22.2) built from the vocabulary and merge table read out of the *same* GGUF file, **more than half of ordinary English words come out split differently**:

| GGUF vocabulary (`llama.cpp/models/*.gguf`) | vocab / merges | words split non-canonically, before | after |
| --- | --- | --- | --- |
| `ggml-vocab-qwen2` | 151936 / 151387 | 23291 / 40014 (58.2%) | **0** |
| `ggml-vocab-qwen35` | 151936 / 151387 | 23291 / 40014 (58.2%) | **0** |
| `ggml-vocab-gpt-2` | 50257 / 50000 | 21876 / 40014 (54.7%) | **0** |
| `ggml-vocab-llama-bpe` | 128256 / 280147 | 23355 / 40014 (58.4%) | **0** |
| `ggml-vocab-starcoder` | 49152 / 48872 | 24926 / 40014 (62.3%) | **0** |
| `ggml-vocab-falcon` | 65024 / 64784 | 21996 / 40014 (55.0%) | **0** |
| `ggml-vocab-deepseek-coder` | 32256 / 31757 | 23635 / 40014 (59.1%) | **0** |

(40014 probe words: a 20000-word sample of `/usr/share/dict/words`, each tested with and without a leading space.)

Concrete examples:

| input | canonical BPE | fastllm before this PR |
| --- | --- | --- |
| `brutalist` (qwen2) | `['br', 'ut', 'alist']` | `['bru', 'tal', 'ist']` |
| `brutalist` (gpt-2) | `['br', 'ut', 'alist']` | `['br', 'uta', 'list']` |
| `prototypes` (qwen2) | `['prot', 'otypes']` | `['prototype', 's']` |
| `Proto-UI` (qwen2) | `['Proto', '-', 'UI']` | `['Proto', '-U', 'I']` |

The model is fed a token sequence that differs from the one it was trained on, which shows up as degraded output quality — most visibly when the model is asked to reproduce a word or a path verbatim.

## Root cause

Two pieces interact.

`src/model.cpp`, GGUF vocabulary loading, gives **every** token the same score:

```cpp
model->weight.AddTokenizerWord(it.string_value(), idx, 1.0f);
```

`src/tokenizer.cpp` picks the next merge by that score:

```cpp
q.push(SymbolPairs(now->score, l, r, symbols[l].len + symbols[r].len));
```

and `include/fastllm.h` falls back to comparing positions when the scores are equal:

```cpp
friend bool operator < (const SymbolPairs &a, const SymbolPairs &b) {
    return a.score < b.score || (a.score == b.score && a.l > b.l);
}
```

So with a constant score the first comparison is always false, the ordering degenerates into the positional tie-break, and merges are applied strictly **left to right** — the merge ranking is never consulted at all. That is not BPE.

## Why this is not just "the score was not filled in"

Canonical BPE is defined solely by the **rank** of each rule in `tokenizer.ggml.merges`: rank 0 is applied first, and the merge point may be anywhere in the word. GPT-2 family vocabularies (`tokenizer.ggml.model == "gpt2"`) have **no `tokenizer.ggml.scores` field at all** — there is no per-token score to load, the merge table is the only source of ordering information. Checked on the vocab-only GGUF files shipped with llama.cpp:

| file | `tokenizer.ggml.model` | has `tokenizer.ggml.scores` | merges |
| --- | --- | --- | --- |
| `ggml-vocab-qwen2` | `gpt2` | no | 151387 |
| `ggml-vocab-qwen35` | `gpt2` | no | 151387 |
| `ggml-vocab-gpt-2` | `gpt2` | no | 50000 |
| `ggml-vocab-llama-bpe` | `gpt2` | no | 280147 |
| `ggml-vocab-starcoder` | `gpt2` | no | 48872 |
| `ggml-vocab-falcon` | `gpt2` | no | 64784 |
| `ggml-vocab-deepseek-coder` | `gpt2` | no | 31757 |
| `ggml-vocab-llama-spm` | `llama` | yes | 0 |
| `ggml-vocab-phi-3` | `llama` | yes | 0 |
| `ggml-vocab-baichuan` | `llama` | yes | 0 |

`tokenizer.ggml.merges` is currently not read anywhere in the tree.

## Fix

Build a "merged string -> rank" table from `tokenizer.ggml.merges`, and give the token produced by rule `i` the score `-i`. The existing max-heap then pops the lowest rank first, which is exactly canonical BPE — the merge loop itself is untouched. Tokens that no merge rule can produce (single bytes, added tokens) get a very low score, so they can still be merged as a last resort but never outrank a real merge.

Only `src/model.cpp` is touched, 41 added lines and 1 changed line.

## Backward compatibility

When the file carries no `tokenizer.ggml.merges`, the previous score of `1.0f` is kept, so SentencePiece-style vocabularies behave exactly as before.

Verified rather than assumed: for `ggml-vocab-llama-spm`, `ggml-vocab-phi-3` and `ggml-vocab-baichuan` (all `tokenizer.ggml.model == "llama"`, 0 merges), the tokenizer output before and after this patch is **byte-identical** over the same 40014 probe words.

## How this was verified

- Configured with `USE_CUDA=OFF`; `src/model.cpp` compiles clean (only the pre-existing `wstring_convert` deprecation warning).
- A small standalone harness links the **unmodified** `src/tokenizer.cpp` and drives it with the vocabulary and merges read straight out of the GGUF files listed above, so the real merge loop is what gets measured. Reference splits come from HuggingFace `tokenizers` 0.22.2 constructed from that same vocabulary and merge table.

## Known limitation (out of scope for this PR)

`tokenizer.ggml.pre` is also never read, so no GPT-2 pre-tokenizer regex is applied and BPE can merge across word/line boundaries. This PR does not address that.

Measured on whole sentences, exact match against the HF pipeline goes from 0/5 to 2/5 with this patch; the 3 remaining mismatches are purely pre-tokenization (e.g. cross-boundary tokens like `():\n`, `/local`).

On single words — where pre-tokenization is a no-op — this patch takes the error rate from 54.7%–62.3% to 0 across every GPT-2-family vocabulary tested.
