### PR TITLE
fix: qwen3.5 稠密模型的 cpu/cuda 分层设备字典被融合单卡路径忽略

### DIFF
--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -2249,6 +2249,16 @@ namespace fastllm {
         static bool Qwen35CanUseGPUForward(const std::map<std::string, int> &deviceMap,
                                            const std::map<std::string, int> &moeDeviceMap) {
             (void)moeDeviceMap;
+            // The fused single-GPU runner keeps every touched weight resident on
+            // one GPU (requireLocal migrates unconditionally).  A device map that
+            // mixes CUDA with a positive-weight non-CUDA entry (e.g. {'cpu':4,'cuda':6})
+            // requests layer-wise offload instead, which only the generic
+            // per-layer forward honors, so fall back to it.
+            for (auto &it : deviceMap) {
+                if (it.second > 0 && !Qwen35DeviceSpecIsCuda(it.first)) {
+                    return false;
+                }
+            }
             std::vector<int> devices;
             std::map<int, int> ratios;
             return GetQwen35GPUForwardDevices(deviceMap, devices, ratios);


### PR DESCRIPTION
## 问题

qwen3_5 稠密模型的设备字典里含正权重的非 cuda 条目时（如 `--device "{'cpu':4,'cuda':6}"`），本意是 CPU/CUDA 逐层 offload，但 `Qwen35CanUseGPUForward` 只收集 map 里的 cuda 条目、忽略其余条目，仍然返回 true 进入 `ForwardSingleGPU` 融合单卡路径。该路径的 `requireLocal` 会把触碰到的全部权重无条件 `ToDevice(CUDA)`，模型大于单卡显存时 warmup 期直接 OOM 退出（`CudaMallocForData → _Exit`）。

## 修复

`Qwen35CanUseGPUForward` 中：设备字典任一正权重条目不是 cuda 时返回 false，回落通用 `ForwardV2` 逐层 `ApplyDeviceMap` 路径（该路径本来就支持 cpu/cuda 混合）。

## 验证

- Qwen3.8-27B-FP8（29GB 稠密）+ RTX 3090 24GB + `{'cpu':4,'cuda':6}`：
  - 修复前：warmup 期显存 6 秒冲满，`_Exit(EXIT_FAILURE)`
  - 修复后：显存 ~21.4GB / RSS ~15.5GB，正常出 token，decode ~4.6 tok/s（CPU 段带宽瓶颈），生成质量正常

## 测试计划

- [x] 混合字典 `{'cpu':4,'cuda':6}` 分层加载 + 生成
- [x] 纯 cuda 字典回归（融合单卡路径不受影响）
