### PR TITLE
fix: GGUF UD 混合量化类型导致 MTP 权重无法融合

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -3506,13 +3506,31 @@ namespace fastllm {
             return false;
         }
 
+        // UD dynamic quants mix GGML types inside one block (e.g. IQ4_XS
+        // ffn_gate next to Q4_K ffn_up).  Heterogeneous types make the
+        // gate/up and q/k/v merge rules skip, and the MTP forward needs the
+        // fused tensors to exist.  Dequantize the MTP block's matrices to
+        // FP16 so the merges always apply; the stack is a single layer, so
+        // the extra memory stays bounded.
+        auto forceMtpMatrixFP16 = [&task]() {
+            if (task.tensor.ne[1] > 1 && task.tensor.ne[2] <= 1 &&
+                task.tensor.ne[3] <= 1) {
+                task.replaceType =
+                    GGUFWeightReplaceRule::GGUFWeightReplaceForceFP16;
+            }
+        };
+
         // The four NextN-only tensors are already mapped to their canonical
         // mtp.* root names by the architecture rules above.  The rest of the
         // optional block follows the normal decoder-layer naming convention;
         // only its layer namespace has to become relative to the MTP stack.
         if (sourceName.compare(
                 separatorPos + 1, strlen("nextn."), "nextn.") == 0) {
-            return StartWith(task.name, "mtp.");
+            if (StartWith(task.name, "mtp.")) {
+                forceMtpMatrixFP16();
+                return true;
+            }
+            return false;
         }
 
         const std::string targetPrefix = "model.language_model.layers." +
@@ -3523,6 +3541,7 @@ namespace fastllm {
         const int mtpLayer = sourceLayer - mainLayerCount;
         task.name = "mtp.layers." + std::to_string(mtpLayer) + "." +
             task.name.substr(targetPrefix.size());
+        forceMtpMatrixFP16();
         return true;
     }
 

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -28636,6 +28636,24 @@ namespace fastllm {
     }
 
     bool Qwen3_5Model::HasMtpWeights() const {
+        if (std::getenv("FASTLLM_DEBUG_MTP") != nullptr) {
+            static std::once_flag debugOnce;
+            std::call_once(debugOnce, [&] {
+                printf("[MTP-debug] mtp_num_hidden_layers=%d\n", mtp_num_hidden_layers);
+                std::vector<std::string> mtpNames;
+                for (auto &it : weight.weight) {
+                    if (it.first.find("mtp.") != std::string::npos) {
+                        mtpNames.push_back(it.first);
+                    }
+                }
+                std::sort(mtpNames.begin(), mtpNames.end());
+                printf("[MTP-debug] %zu mtp.* weights loaded:\n", mtpNames.size());
+                for (auto &name : mtpNames) {
+                    printf("[MTP-debug]   %s\n", name.c_str());
+                }
+                fflush(stdout);
+            });
+        }
         if (mtp_num_hidden_layers <= 0) {
             return false;
         }


### PR DESCRIPTION
## 问题

UD 动态量化的 GGUF（如 `Qwen3.8-27B-UD-Q4_K_XL.gguf`）会在同一个 block 内混用 GGML 类型——实测该文件全部 65 层都是 `ffn_gate = IQ4_XS`、`ffn_up = Q4_K`。而加载期的权重合并规则（`model.cpp` 中 gate+up → gateup、q+k+v → mergeqkv）要求各输入 `ggmlType` 一致，类型混合时 `canMerge = false` **静默跳过**。

主层 forward 支持分离投影，模型照常运行；但 `HasMtpWeights()` 硬性要求融合的 `mtp.layers.N.mlp.gateup_proj.weight` 存在，于是 `--mtp` 静默失效：无报错、无 `[Qwen3.5 MTP]` 日志，任何混类型 UD 量化 GGUF 都无法使用 MTP。

## 修复

`RemapQwen35GGUFMtpTask`（`src/model.cpp`）对 2-D 的 MTP 张量改走 `GGUFWeightReplaceForceFP16`（复用现成的反量化通道），MTP 各矩阵类型统一为 FP16 后，合并机制即可正常产出 `gateup_proj` 与 `mergeqkv`。MTP 栈通常只有 1 层，FP16 约 850MB，显存增量可控。

另在 `HasMtpWeights()` 顶部加了 `FASTLLM_DEBUG_MTP` 环境变量门控的 `mtp.*` 权重清单打印，方便此类问题诊断（默认关闭，无开销）。

## 验证

Qwen3.8-27B-UD-Q4_K_XL.gguf + RTX 3090 24GB（`--device cuda --mtp 3`）：

- 修复前：`FASTLLM_DEBUG_MTP=1` 显示 15 个 mtp 权重，`gate_proj`/`up_proj` 分离存在、无 `gateup_proj`，`HasMtpWeights` false，无任何 MTP 日志
- 修复后：12 个 mtp 权重（gate/up 融合为 gateup_proj，q/k/v 融合为 mergeqkv），日志出现：

```
[Qwen3.5 MTP] enabled: layers=1, drafts_per_step=3, root_device=cuda:0, ...
[Qwen3.5 MTP] pos_accept_rate=[87.0%, 72.4%, 54.7%]
```

decode 约 3.1 token/次验证，实测 44 → 50-58 tok/s；17×23=391、代码/翻译等生成质量正常。

## 测试计划

- [x] UD-Q4_K_XL GGUF + `--mtp 3`：MTP enabled、接受率、生成质量
- [x] 无 MTP 的普通加载回归（`--mtp 0`）
- [ ] 非 UD 的同类型 GGUF（理论上无影响：同类型时本就走合并路径）
