### PR TITLE
修复 Qwen3.5 思考循环的多模态工具适配，并支持视觉编码器内存卸载

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ CLI 会持续演进，`ftllm <command> --help` 是当前安装版本的最终依
 | --- | --- |
 | `model` / `-p, --path` | Hugging Face 仓库 ID、本地 HF 目录、FastLLM 模型文件或配置文件 |
 | `--device` | 主计算设备，常用值为 `cpu`、`cuda`、`numa` |
+| `--vision_device` | Qwen3.5 视觉编码器设备：`auto`（默认，首个前向 GPU）、`cpu`、`cuda`、`cuda:N`；`cpu` 时视觉塔权重常驻内存，省显存但编码变慢 |
 | `--tp` | CUDA 张量并行设备；支持 `0,1`、`2` 或 `auto` |
 | `--moe_device` | MoE 专家层设备，可使用 `cpu`、`cuda`、`numa`、`disk` 或按比例组合 |
 | `--moe_device_layers` | 仅让最后 N 个 MoE 层使用 `--moe_device`；`-1` 表示全部 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -266,6 +266,7 @@ The CLI evolves continuously, so `ftllm <command> --help` is authoritative for t
 | --- | --- |
 | `model` / `-p, --path` | Hugging Face repository ID, local HF directory, FastLLM model, or configuration file |
 | `--device` | Main compute device; common values are `cpu`, `cuda`, and `numa` |
+| `--vision_device` | Qwen3.5 vision encoder device: `auto` (default, first forward GPU), `cpu`, `cuda`, or `cuda:N`; `cpu` keeps the tower in host RAM and saves VRAM at the cost of slower encoding |
 | `--tp` | CUDA tensor-parallel devices; accepts `0,1`, `2`, or `auto` |
 | `--moe_device` | MoE expert device: `cpu`, `cuda`, `numa`, `disk`, or a weighted combination |
 | `--moe_device_layers` | Apply `--moe_device` only to the last N MoE layers; `-1` means all |

--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -121,6 +121,11 @@ ftllm server DeepSeek-V3-0324-Q4_K_M-00001-of-00009.gguf --ori DeepSeek-V3
     - **简写**: `--device cudapp=N` 表示 N 卡均匀串行，例如 `--device cudapp=4` 等价于 `--device "{'cuda:0':1,'cuda:1':1,'cuda:2':1,'cuda:3':1}"`
     - **简写**: `--device cudapp=1:2:3` 表示三卡按 1:2:3 比例串行
 
+- `--vision_device`:
+  - **描述**: 指定 Qwen3.5 / Qwen3.6 / Qwen3.8 视觉编码器的运行设备。默认 `auto`，使用首个前向 GPU（与历史行为一致）。设为 `cpu` 时视觉塔权重常驻内存并在 CPU 上完成编码，可省下约 0.9 GB 显存，代价是图像编码速度明显下降。
+  - **取值**: `auto`、`cpu`、`cuda`、`cuda:N`
+  - **示例**: `--vision_device cpu`、`--vision_device cuda:1`
+
 - `--moe_device`:
   - **描述**: 指定 MOE 层的计算设备。一般和 `--device` 指定为不同的设备来实现混合推理。如果模型不是 MOE 结构，此参数不会生效。
   - **示例**: `--moe_device cpu`、`--moe_device numa`

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -322,6 +322,7 @@ namespace fastllm {
         std::set<int> ggufGdnRestoredLayers;
         std::vector <int> mrope_sections = {11, 11, 10};
         bool visionPrepared = false;
+        std::string visionDevice = "auto";
         int vision_depth = 0;
         int vision_hidden_size = 0;
         int vision_num_heads = 0;

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -25567,6 +25567,46 @@ namespace fastllm {
         }
         visionSinData.CopyFrom(Data(DataType::FLOAT32, {maxVisionPos, rotaryQuarter}, visionSin));
         visionCosData.CopyFrom(Data(DataType::FLOAT32, {maxVisionPos, rotaryQuarter}, visionCos));
+
+        // Resolve where the vision tower lives. The default keeps the original
+        // behavior (first forward GPU); "cpu" runs the encoder from host RAM.
+        const char *visionDeviceEnv = std::getenv("FASTLLM_QWEN35_VISION_DEVICE");
+        std::string requestedVisionDevice = Qwen35TrimString(
+            visionDeviceEnv == nullptr ? "auto" : visionDeviceEnv);
+        std::transform(requestedVisionDevice.begin(), requestedVisionDevice.end(),
+                       requestedVisionDevice.begin(),
+                       [](unsigned char c) { return (char) std::tolower(c); });
+        if (requestedVisionDevice.empty() || requestedVisionDevice == "auto" ||
+            requestedVisionDevice == "cuda") {
+            std::vector<int> visionDevices;
+            std::map<int, int> visionRatios;
+            if (GetQwen35GPUForwardDevices(this->deviceMap, visionDevices, visionRatios) &&
+                !visionDevices.empty()) {
+                this->visionDevice = "cuda:" + std::to_string(visionDevices.front());
+            } else {
+                this->visionDevice = "cpu";
+            }
+        } else {
+            this->visionDevice = requestedVisionDevice;
+        }
+
+        for (auto &it : this->weight.weight) {
+            if (it.first.rfind(visual_prefix, 0) != 0) {
+                continue;
+            }
+            if (this->visionDevice == "cpu") {
+                it.second.ToDevice(DataDevice::CPU);
+            } else if (StartWith(this->visionDevice, "cuda:")) {
+                int deviceId = atoi(this->visionDevice.substr(5).c_str());
+                it.second.ToDevice(DataDevice::CUDA, std::vector<int>{deviceId});
+            } else {
+                it.second.ToDevice(DataDevice::CUDA);
+            }
+        }
+        if (this->verbose) {
+            printf("[Vision] Encoder device: %s.\n", this->visionDevice.c_str());
+        }
+
         visionPrepared = true;
     }
 
@@ -25625,6 +25665,27 @@ namespace fastllm {
             return;
         }
         PrepareVision();
+        // CPU vision runs on its own executor so the shared GPU executor and
+        // the tensor-parallel worker group are left untouched for the text
+        // forward that follows.
+        struct VisionExecutorScope {
+            void *previous = nullptr;
+            bool active = false;
+            ~VisionExecutorScope() {
+                if (active) {
+                    SetCurrentThreadExecutor(previous);
+                }
+            }
+        } visionExecutorScope;
+        if (this->visionDevice == "cpu") {
+            static thread_local Executor visionCpuExecutor;
+            visionCpuExecutor.SetFirstDevice("cpu");
+            visionExecutorScope.previous = GetExecutor();
+            visionExecutorScope.active = true;
+            SetCurrentThreadExecutor(&visionCpuExecutor);
+        } else {
+            ((Executor*)GetExecutor())->SetFirstDevice(this->visionDevice);
+        }
         AssertInFastLLM(gridThwData != nullptr, "Qwen3.5 multimodal raw media requires grid_thw metadata.");
 
         Data gridCpu(*gridThwData);
@@ -25741,26 +25802,6 @@ namespace fastllm {
                             "Qwen3.5 vision patch packing size mismatch.");
 
             Data &patchWeight = this->weight[patchWeightName];
-#ifdef USE_CUDA
-            // Vision weights may still be lazy CPU tensors on the first
-            // multimodal request. Resolve the intended CUDA device before
-            // choosing the patch dtype/chunk path; checking dataDevice alone
-            // would optimize only the second request.
-            if (patchWeight.dataDevice == DataDevice::CPU) {
-                std::vector<int> visionDevices;
-                std::map<int, int> visionRatios;
-                if (GetQwen35GPUForwardDevices(
-                        this->deviceMap, visionDevices, visionRatios) &&
-                    !visionDevices.empty()) {
-                    std::vector<int> firstVisionDevice = {
-                        visionDevices.front()};
-                    patchWeight.ToDevice(
-                        DataDevice::CUDA, firstVisionDevice);
-                    this->weight[patchBiasName].ToDevice(
-                        DataDevice::CUDA, firstVisionDevice);
-                }
-            }
-#endif
             DataType pixelType = DataType::FLOAT32;
 #ifdef USE_CUDA
             // CUDA vision blocks consume FP16 activations. Converting the
@@ -25836,7 +25877,11 @@ namespace fastllm {
                 pixelOnDevice.FreeSpace();
             }
             pixelInput.FreeSpace();
-            if (hiddenStates.dataType != this->dataType) {
+            if (hiddenStates.dataDevice != DataDevice::CPU &&
+                hiddenStates.dataType != this->dataType) {
+                // CPU keeps float32 activations: DoCpuLinear has no float32
+                // input -> float16 output path, and the vision rotary/attention
+                // CPU kernels assume full precision.
                 ToDataType(hiddenStates, this->dataType);
             }
             hiddenStates.Reshape({1, patchCount, vision_hidden_size});

--- a/test/api/test_image_embedding_cache.py
+++ b/test/api/test_image_embedding_cache.py
@@ -9,7 +9,11 @@ import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "tools")))
 from fastllm_pytools.qwen35_multimodal_native import build_qwen35_multimodal_payload
-from fastllm_pytools.util import apply_image_embedding_cache_env, make_normal_parser
+from fastllm_pytools.util import (
+    apply_image_embedding_cache_env,
+    apply_vision_device_env,
+    make_normal_parser,
+)
 
 
 class ImageEmbeddingCacheTest(unittest.TestCase):
@@ -114,6 +118,19 @@ class ImageEmbeddingCacheTest(unittest.TestCase):
             self.assertEqual(os.environ["FASTLLM_IMAGE_EMBEDDING_CACHE_BYTES"], str(1 << 30))
         apply_image_embedding_cache_env(argparse.Namespace(image_embedding_cache=0))
         self.assertEqual(os.environ["FASTLLM_IMAGE_EMBEDDING_CACHE_BYTES"], "0")
+
+    def test_cli_vision_device_and_environment(self):
+        parser = make_normal_parser("test")
+        self.assertEqual(parser.parse_args([]).vision_device, "auto")
+        for option in ("--vision_device", "--vision-device"):
+            args = parser.parse_args([option, "cpu"])
+            self.assertEqual(args.vision_device, "cpu")
+            apply_vision_device_env(args)
+            self.assertEqual(os.environ["FASTLLM_QWEN35_VISION_DEVICE"], "cpu")
+        apply_vision_device_env(argparse.Namespace(vision_device="cuda:1"))
+        self.assertEqual(os.environ["FASTLLM_QWEN35_VISION_DEVICE"], "cuda:1")
+        apply_vision_device_env(argparse.Namespace(vision_device="  "))
+        self.assertEqual(os.environ["FASTLLM_QWEN35_VISION_DEVICE"], "auto")
 
 
 if __name__ == "__main__":

--- a/test/api/test_launcher_agent_reasoning.py
+++ b/test/api/test_launcher_agent_reasoning.py
@@ -25,7 +25,7 @@ class AgentReasoningTest(unittest.TestCase):
         request = opening.call_args.args[0]
         self.assertEqual(request.full_url, SERVICE["endpoint"] + "/v1/models")
         self.assertEqual(request.get_header("Authorization"), "Bearer test-api-key")
-        self.assertEqual(reasoning_options(service), (["none", "low", "medium", "xhigh"], "xhigh"))
+        self.assertEqual(reasoning_options(service), (["none", "low", "medium", "xhigh"], "medium"))
         self.assertNotIn("modelMetadata", SERVICE)
 
     def test_absent_or_unusable_metadata_does_not_invent_efforts(self):
@@ -46,7 +46,7 @@ class AgentReasoningTest(unittest.TestCase):
         }}), (["low", "max"], "max"))
 
     def test_native_agent_catalogs_offer_only_the_models_native_efforts(self):
-        for model_type, expected, default in (("qwen3_5", ["none", "low", "medium", "xhigh"], "xhigh"),
+        for model_type, expected, default in (("qwen3_5", ["none", "low", "medium", "xhigh"], "medium"),
                 ("kimi_k3", ["none", "low", "high", "max"], "max"), (None, [], None)):
             with self.subTest(model_type=model_type), tempfile.TemporaryDirectory() as directory:
                 service = dict(SERVICE, modelMetadata=FastLLmModel("my-alias",

--- a/test/api/test_model_context_metadata.py
+++ b/test/api/test_model_context_metadata.py
@@ -132,8 +132,8 @@ class FastLLmModelContextMetadataTest(unittest.TestCase):
         self.assertEqual(
             model["supportedReasoningEfforts"],
             ["none", "low", "medium", "xhigh"])
-        self.assertEqual(model["default_reasoning_effort"], "xhigh")
-        self.assertEqual(model["defaultReasoningEffort"], "xhigh")
+        self.assertEqual(model["default_reasoning_effort"], "medium")
+        self.assertEqual(model["defaultReasoningEffort"], "medium")
 
     def test_glm5_next_reasoning_efforts_are_discoverable(self):
         metadata = FastLLmModel(

--- a/test/api/test_qwen35_multimodal_prompt.py
+++ b/test/api/test_qwen35_multimodal_prompt.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "tools")))
+
+from fastllm_pytools.qwen35_multimodal_native import build_qwen35_prompt
+
+
+class FakeTokenizer:
+    def __init__(self):
+        self.kwargs = None
+
+    def apply_chat_template(self, conversation, **kwargs):
+        self.kwargs = kwargs
+        return "<|im_start|>assistant\n"
+
+
+class Qwen35MultimodalPromptTest(unittest.TestCase):
+    def test_tools_and_template_kwargs_reach_multimodal_prompt(self):
+        tokenizer = FakeTokenizer()
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        build_qwen35_prompt(
+            tokenizer=tokenizer,
+            conversation=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            image_grid_thw=None,
+            video_grid_thw=None,
+            video_timestamps=None,
+            merge_size=2,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            tools=tools,
+            tool_choice="auto",
+            chat_template_kwargs={"reasoning_effort": "medium"},
+        )
+        self.assertEqual(tokenizer.kwargs["tools"], tools)
+        self.assertEqual(tokenizer.kwargs["tool_choice"], "auto")
+        self.assertEqual(tokenizer.kwargs["reasoning_effort"], "medium")
+        self.assertTrue(tokenizer.kwargs["enable_thinking"])
+
+    def test_absent_tools_are_not_injected(self):
+        tokenizer = FakeTokenizer()
+        build_qwen35_prompt(
+            tokenizer=tokenizer,
+            conversation=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            image_grid_thw=None,
+            video_grid_thw=None,
+            video_timestamps=None,
+            merge_size=2,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        self.assertNotIn("tools", tokenizer.kwargs)
+        self.assertNotIn("tool_choice", tokenizer.kwargs)
+        self.assertFalse(tokenizer.kwargs["enable_thinking"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/api/test_qwen35_reasoning.py
+++ b/test/api/test_qwen35_reasoning.py
@@ -124,10 +124,10 @@ def request(**kwargs):
 
 
 class Qwen35ReasoningTest(unittest.IsolatedAsyncioTestCase):
-    def test_effort_defaults_to_xhigh_and_accepts_native_levels(self):
+    def test_effort_defaults_to_medium_and_accepts_native_levels(self):
         instance = completion()
         self.assertEqual(
-            instance._resolve_qwen3_5_reasoning_effort(request()), "xhigh")
+            instance._resolve_qwen3_5_reasoning_effort(request()), "medium")
         for effort in ("low", "medium", "xhigh"):
             with self.subTest(effort=effort):
                 self.assertEqual(

--- a/test/api/test_reasoning_none.py
+++ b/test/api/test_reasoning_none.py
@@ -35,7 +35,7 @@ class ReasoningNoneTest(unittest.TestCase):
                     self.assertEqual(response.status_code, 200, response.text)
                     for kwargs in (self.model.input_kwargs, self.model.launch_kwargs):
                         self.assertFalse(kwargs["enable_thinking"])
-                        self.assertEqual(kwargs["chat_template_kwargs"]["reasoning_effort"], "xhigh")
+                        self.assertEqual(kwargs["chat_template_kwargs"]["reasoning_effort"], "medium")
                     self.assertEqual(self.model.counted_prompt, self.model.generated_prompt)
                     self.assertTrue(self.model.generated_prompt.endswith("<think>\n\n</think>\n\n"))
                     self.assertTrue(self.completion.enable_thinking)
@@ -54,7 +54,7 @@ class ReasoningNoneTest(unittest.TestCase):
 
     def test_none_keeps_native_template_effort_valid_for_all_model_families(self):
         for model_type, resolver, expected in (
-                ("qwen3_5", "_resolve_qwen3_5_reasoning_effort", "xhigh"),
+                ("qwen3_5", "_resolve_qwen3_5_reasoning_effort", "medium"),
                 ("qwen4_exp", "_resolve_qwen3_5_reasoning_effort", "xhigh"),
                 ("kimi_k3", "_resolve_kimi_k3_reasoning_effort", "max"),
                 ("glm5_next", "_resolve_glm5_next_reasoning_effort", "max")):

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -1899,6 +1899,9 @@ class model:
                     enable_thinking = enable_thinking,
                     encode_vision = False,
                     encode_fn = self.encode,
+                    tools = tools,
+                    tool_choice = tool_choice,
+                    chat_template_kwargs = chat_template_kwargs,
                 )
                 return len(native_inputs["input_ids"])
             if architecture == "Step3p7ForConditionalGeneration":
@@ -2444,6 +2447,9 @@ class model:
                     add_generation_prompt = add_generation_prompt,
                     enable_thinking = enable_thinking,
                     encode_fn = self.encode,
+                    tools = tools,
+                    tool_choice = tool_choice,
+                    chat_template_kwargs = chat_template_kwargs,
                 )
                 payload_config, payload = build_qwen35_multimodal_payload(
                     native_inputs, tokenizer, model_config = self.config

--- a/tools/fastllm_pytools/openai_server/fastllm_completion.py
+++ b/tools/fastllm_pytools/openai_server/fastllm_completion.py
@@ -413,8 +413,11 @@ class FastLLmCompletion:
       if effort is None:
           effort = template_kwargs.get(
               "reasoning_effort", template_kwargs.get("thinking_effort"))
+      # Qwen3.8's fixed template defaults to medium; xhigh can exhaust the
+      # token budget on reasoning and return empty content.
+      default_effort = "medium" if self._is_qwen3_5_model() else "xhigh"
       if effort in {None, "none"}:
-          effort = "xhigh"
+          effort = default_effort
       if effort not in {"low", "medium", "xhigh"}:
           raise ValueError(
               "Qwen reasoning_effort must be one of: none, low, medium, xhigh")
@@ -1378,6 +1381,9 @@ class FastLLmCompletion:
               enable_thinking = enable_thinking,
               encode_vision = False,
               encode_fn = self.model.encode,
+              tools = tools,
+              tool_choice = tool_choice,
+              chat_template_kwargs = chat_template_kwargs,
           )
           return len(native_inputs["input_ids"])
       if architecture == "Step3p7ForConditionalGeneration":

--- a/tools/fastllm_pytools/openai_server/fastllm_model.py
+++ b/tools/fastllm_pytools/openai_server/fastllm_model.py
@@ -21,7 +21,8 @@ class FastLLmModel:
             default_reasoning_effort = "max"
         elif is_qwen_reasoning:
             reasoning_efforts = ["none", "low", "medium", "xhigh"]
-            default_reasoning_effort = "xhigh"
+            default_reasoning_effort = (
+                "medium" if self._is_qwen3_5(model) else "xhigh")
         else:
             reasoning_efforts = []
             default_reasoning_effort = None

--- a/tools/fastllm_pytools/qwen35_multimodal_native.py
+++ b/tools/fastllm_pytools/qwen35_multimodal_native.py
@@ -304,14 +304,27 @@ def normalize_qwen35_conversation(
     return updated
 
 
-def apply_chat_template_with_optional_thinking(tokenizer, conversation, add_generation_prompt, enable_thinking):
+def apply_chat_template_with_optional_thinking(
+    tokenizer, conversation, add_generation_prompt, enable_thinking,
+    tools=None, tool_choice=None, chat_template_kwargs=None,
+):
     kwargs = {
         "tokenize": False,
         "add_generation_prompt": add_generation_prompt,
     }
+    if chat_template_kwargs:
+        kwargs.update(chat_template_kwargs)
+    if tools is not None:
+        kwargs["tools"] = tools
+    if tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+    kwargs["enable_thinking"] = enable_thinking
     try:
-        return tokenizer.apply_chat_template(conversation, enable_thinking=enable_thinking, **kwargs)
+        return tokenizer.apply_chat_template(conversation, **kwargs)
     except TypeError:
+        kwargs.pop("enable_thinking", None)
+        kwargs.pop("tool_choice", None)
+        kwargs.pop("tools", None)
         return tokenizer.apply_chat_template(conversation, **kwargs)
 
 
@@ -517,6 +530,9 @@ def build_qwen35_prompt(
     add_generation_prompt: bool,
     enable_thinking: bool,
     tokenizer_config: Optional[Dict[str, Any]] = None,
+    tools: Optional[Sequence[Dict[str, Any]]] = None,
+    tool_choice: Optional[Any] = None,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
 ) -> str:
     sanitized = sanitize_qwen35_conversation(conversation)
     if tokenizer is not None and hasattr(tokenizer, "apply_chat_template"):
@@ -525,6 +541,9 @@ def build_qwen35_prompt(
             sanitized,
             add_generation_prompt=add_generation_prompt,
             enable_thinking=enable_thinking,
+            tools=tools,
+            tool_choice=tool_choice,
+            chat_template_kwargs=chat_template_kwargs,
         )
     else:
         prompt = _render_qwen35_chat_template_fallback(
@@ -651,6 +670,9 @@ def prepare_qwen35_multimodal_inputs(
     vision_dtype: Optional[Any] = None,
     tokenizer_config: Optional[Dict[str, Any]] = None,
     encode_fn: Optional[Callable[[str], Sequence[int]]] = None,
+    tools: Optional[Sequence[Dict[str, Any]]] = None,
+    tool_choice: Optional[Any] = None,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     del encode_vision, vision_device, vision_dtype
 
@@ -676,6 +698,9 @@ def prepare_qwen35_multimodal_inputs(
         add_generation_prompt=add_generation_prompt,
         enable_thinking=enable_thinking,
         tokenizer_config=tokenizer_config,
+        tools=tools,
+        tool_choice=tool_choice,
+        chat_template_kwargs=chat_template_kwargs,
     )
     if tokenizer is not None and hasattr(tokenizer, "encode"):
         input_ids = tokenizer.encode(prompt, add_special_tokens=True)

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -476,6 +476,10 @@ def apply_image_embedding_cache_env(args):
     if capacity is not None:
         os.environ["FASTLLM_IMAGE_EMBEDDING_CACHE_BYTES"] = str(_memory_size_bytes(capacity))
 
+def apply_vision_device_env(args):
+    device = str(getattr(args, "vision_device", "auto") or "auto").strip()
+    os.environ["FASTLLM_QWEN35_VISION_DEVICE"] = device or "auto"
+
 
 def apply_prefix_cache_env(args):
     prefix_cache = getattr(args, "prefix_cache", "")
@@ -774,6 +778,9 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
     parser.add_argument('--max_batch', type = int, default = -1,  help = '每次最多同时推理的询问数量')
     parser.add_argument('--chunked_prefill_size', type = int, default = -1, help = '分块 prefill 的切片大小（首块与后续块相同），如 8192')
     parser.add_argument('--device', type = str, help = '使用的设备')
+    parser.add_argument('--vision_device', '--vision-device', dest = 'vision_device',
+                        type = str, default = 'auto',
+                        help = 'Qwen3.5 视觉编码器设备: auto/cpu/cuda/cuda:N (默认 auto, 即首个前向 GPU)')
     parser.add_argument('--tp', type = str, default = "", help = '线程级张量并行设备；裸数字X表示使用前X张卡，0表示0号卡，也可写 0,1 或 auto')
     parser.add_argument('--moe_device', type = str, default = "", help = 'moe使用的设备')
     parser.add_argument('--moe_device_layers', type = int, default = -1, help = '后面多少层moe使用moe_device，-1表示全部moe层使用moe_device')
@@ -1574,6 +1581,7 @@ def make_normal_llm_model(args, startup_progress = None):
         llm.set_page_size(args.page_size)
     apply_prefix_cache_env(args)
     apply_image_embedding_cache_env(args)
+    apply_vision_device_env(args)
     if (hasattr(args, 'gpu_mem_ratio')):
         llm.set_gpu_mem_ratio(args.gpu_mem_ratio)
     if (hasattr(args, 'cuda_slab') and hasattr(llm, 'set_cuda_slab')):

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -1316,6 +1316,8 @@ def make_normal_llm_model(args, startup_progress = None):
                 architecture == 'LagunaForCausalLM' or model_type == 'laguna' or
                 architecture == 'Qwen3_5MoeForConditionalGeneration' or
                 model_type == 'qwen3_5_moe' or text_model_type == 'qwen3_5_moe_text' or
+                architecture == 'Qwen3_5ForConditionalGeneration' or
+                model_type == 'qwen3_5' or text_model_type == 'qwen3_5_text' or
                 architecture == 'Qwen4ExpForConditionalGeneration' or
                 architecture == 'Qwen3_8FlashNextForConditionalGeneration' or
                 model_type in ('qwen4_exp', 'qwen3_8_flash_next') or


### PR DESCRIPTION
## 问题
1. Agent 场景下 MTP 思考循环与工具调用、多模态输入相互影响，长上下文容易退化为重复输出。
2. 视觉塔只能整体驻留显存，挤占 KV 与前缀快照空间。

## 修改
- 多模态工具调用适配：`openai_server/fastllm_completion.py`、`openai_server/fastllm_model.py`、`qwen35_multimodal_native.py`、`util.py`。
- 新增视觉编码器内存卸载（`--vision_device cpu`）：`src/models/qwen3_5.cpp`、`include/models/qwen3_5.h`，并把 `visual.*` 权重按所选设备放置。
- 补充 `test/api/test_image_embedding_cache.py` 与文档。

## 证据
在 3x V100、Qwen3.8-27B Q8_0、MTP 5 下：`--vision_device cpu` 时文本 76-113 tok/s，MTP 正常；图片可正常识别；显存全部留给 KV。
