### PR TITLE
改进 Qwen3.5 前缀快照：解码阶段记录、间隔与保留数量、共享缓冲

### DIFF
--- a/include/models/basellm.h
+++ b/include/models/basellm.h
@@ -440,6 +440,11 @@ namespace fastllm {
         virtual bool TryRecordPagedPrefixCacheExtra(ResponseContext *context);
         virtual int QueryPagedPrefixCacheExtra(ResponseContext *context, int maxCachedLen) const;
         virtual bool RestorePagedPrefixCacheExtra(ResponseContext *context, int cachedLen) const;
+        // Models with non-paged recurrent state (for example Qwen3.5 linear
+        // attention) must snapshot while decoding too; otherwise the tokens
+        // generated in a turn can only be cached when the next turn re-prefills
+        // them.
+        virtual bool WantsPerStepPrefixSnapshot() const { return false; }
 
         virtual void PrepareToolCallConstraint(ResponseContext *context, GenerationConfig &generationConfig);
 

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -109,6 +109,7 @@ namespace fastllm {
         virtual bool TryRecordPagedPrefixCacheExtra(ResponseContext *context) override;
         virtual int QueryPagedPrefixCacheExtra(ResponseContext *context, int maxCachedLen) const override;
         virtual bool RestorePagedPrefixCacheExtra(ResponseContext *context, int cachedLen) const override;
+        virtual bool WantsPerStepPrefixSnapshot() const override;
         virtual int GetChunkedPrefillSize() override;
 
         virtual int GetBatchedPrefillTokenLimit() override;

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -2655,6 +2655,9 @@ namespace fastllm {
                         ctx->resultTokenQueue.push(curRet);
                         QueueGeneratedResultLogits(ctx, logits, i);
                         ctx->allTokens.push_back(curRet);
+                        if (model->WantsPerStepPrefixSnapshot()) {
+                            ctx->TryRecordPagedCache(model);
+                        }
                         if (NeedRepeatPenalty(ctx->generationConfig)) {
                             ctx->tokens.Push(curRet);
                         }

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -4756,7 +4756,7 @@ namespace fastllm {
         }
 
         static int Qwen35LinearPrefixSnapshotIntervalTokens() {
-            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 4);
+            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 2);
             pages = std::max(1, pages);
             return pages * fastllm::GetPageLen();
         }

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -4756,7 +4756,7 @@ namespace fastllm {
         }
 
         static int Qwen35LinearPrefixSnapshotIntervalTokens() {
-            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 16);
+            int pages = Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES", 4);
             pages = std::max(1, pages);
             return pages * fastllm::GetPageLen();
         }

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -4700,6 +4700,15 @@ namespace fastllm {
             Qwen35LinearPrefixSnapshotCache second;
         };
 
+        // MTP draft KV for one request. Snapshots of the same request share
+        // this buffer and record only their length, so growing a request does
+        // not duplicate the full draft KV for every snapshot.
+        struct Qwen35MtpSnapshotBuffer {
+            Data key;
+            Data value;
+            int tokens = 0;
+        };
+
         struct Qwen35LinearPrefixSnapshot {
             int cachedLen = 0;
             int requestId = 0;
@@ -4708,8 +4717,7 @@ namespace fastllm {
             std::vector<Qwen35LinearPrefixSnapshotLayer> layers;
             bool mtpValid = false;
             int mtpTokens = 0;
-            Data mtpKey;
-            Data mtpValue;
+            std::shared_ptr<Qwen35MtpSnapshotBuffer> mtpBuffer;
             bool dflashValid = false;
             int dflashTokens = 0;
             std::vector<std::pair<Data, Data> > dflashKeyValues;
@@ -5193,10 +5201,10 @@ namespace fastllm {
                 }
                 if (requireMtp &&
                     (!snapshot->mtpValid || snapshot->mtpTokens != snapshot->cachedLen ||
-                     snapshot->mtpKey.dims.size() < 2 ||
-                     snapshot->mtpValue.dims.size() < 2 ||
-                     snapshot->mtpKey.dims[1] != snapshot->cachedLen ||
-                     snapshot->mtpValue.dims[1] != snapshot->cachedLen)) {
+                     snapshot->mtpBuffer == nullptr ||
+                     snapshot->mtpBuffer->key.dims.size() < 2 ||
+                     snapshot->mtpBuffer->value.dims.size() < 2 ||
+                     snapshot->mtpBuffer->tokens < snapshot->cachedLen)) {
                     continue;
                 }
                 if (requireDFlash &&
@@ -5211,6 +5219,32 @@ namespace fastllm {
                     (snapshot->cachedLen == best->cachedLen &&
                      snapshot->timestamp > best->timestamp)) {
                     best = snapshot;
+                }
+            }
+            return best;
+        }
+
+        // The caller holds Qwen35LinearPrefixSnapshotsMutex. Reuse the MTP
+        // buffer of the newest snapshot from the same request so snapshots of
+        // one conversation do not each keep a full copy of the draft KV.
+        static std::shared_ptr<Qwen35MtpSnapshotBuffer> Qwen35FindReusableMtpSnapshotBufferLocked(
+                const Qwen3_5Model *model, int requestId) {
+            auto &all = Qwen35LinearPrefixSnapshots();
+            auto it = all.find(model);
+            if (it == all.end()) {
+                return nullptr;
+            }
+            std::shared_ptr<Qwen35MtpSnapshotBuffer> best;
+            long long bestTimestamp = -1;
+            for (auto &snapshotPtr : it->second) {
+                Qwen35LinearPrefixSnapshot *snapshot = snapshotPtr.get();
+                if (snapshot == nullptr || snapshot->requestId != requestId ||
+                    snapshot->mtpBuffer == nullptr) {
+                    continue;
+                }
+                if (snapshot->timestamp > bestTimestamp) {
+                    bestTimestamp = snapshot->timestamp;
+                    best = snapshot->mtpBuffer;
                 }
             }
             return best;
@@ -7884,6 +7918,12 @@ namespace fastllm {
             Qwen35LinearPrefixSnapshotCache second;
         };
 
+        struct Qwen35MtpSnapshotBuffer {
+            Data key;
+            Data value;
+            int tokens = 0;
+        };
+
         struct Qwen35LinearPrefixSnapshot {
             int cachedLen = 0;
             int requestId = 0;
@@ -7892,8 +7932,7 @@ namespace fastllm {
             std::vector<Qwen35LinearPrefixSnapshotLayer> layers;
             bool mtpValid = false;
             int mtpTokens = 0;
-            Data mtpKey;
-            Data mtpValue;
+            std::shared_ptr<Qwen35MtpSnapshotBuffer> mtpBuffer;
             bool dflashValid = false;
             int dflashTokens = 0;
             std::vector<std::pair<Data, Data> > dflashKeyValues;
@@ -9871,10 +9910,22 @@ namespace fastllm {
                     mtpIt->second.key.dims.size() < 2 ||
                     mtpIt->second.value.dims.size() < 2 ||
                     mtpIt->second.key.dims[1] != currentLen ||
-                    mtpIt->second.value.dims[1] != currentLen ||
-                    !SnapshotMtpPagedCache(mtpIt->second, snapshot->mtpKey, snapshot->mtpValue)) {
+                    mtpIt->second.value.dims[1] != currentLen) {
                     return false;
                 }
+                std::shared_ptr<Qwen35MtpSnapshotBuffer> mtpBuffer;
+                {
+                    std::lock_guard<std::mutex> guard(Qwen35LinearPrefixSnapshotsMutex());
+                    mtpBuffer = Qwen35FindReusableMtpSnapshotBufferLocked(this, requestId);
+                }
+                if (mtpBuffer == nullptr) {
+                    mtpBuffer = std::make_shared<Qwen35MtpSnapshotBuffer>();
+                }
+                if (!SnapshotMtpPagedCache(mtpIt->second, mtpBuffer->key, mtpBuffer->value)) {
+                    return false;
+                }
+                mtpBuffer->tokens = currentLen;
+                snapshot->mtpBuffer = mtpBuffer;
                 snapshot->mtpValid = true;
                 snapshot->mtpTokens = currentLen;
             }
@@ -10038,12 +10089,22 @@ namespace fastllm {
                         dflashCache.draftKeyValues[0].first.dims[1];
                 } else {
                     if (!snapshot->mtpValid ||
-                        snapshot->mtpTokens != cachedLen) {
+                        snapshot->mtpTokens != cachedLen ||
+                        snapshot->mtpBuffer == nullptr ||
+                        snapshot->mtpBuffer->tokens < cachedLen) {
                         return false;
                     }
+                    Data mtpKeyView, mtpValueView;
+                    auto makeMtpView = [&](const Data &buffer, Data &view) {
+                        view.FakeFrom(buffer, 0);
+                        view.dims = {buffer.dims[0], cachedLen, buffer.dims[2]};
+                        view.strides = buffer.strides;
+                    };
+                    makeMtpView(snapshot->mtpBuffer->key, mtpKeyView);
+                    makeMtpView(snapshot->mtpBuffer->value, mtpValueView);
                     MtpKvCache &mtpCache = mtpCaches[context];
-                    if (!RestoreMtpPagedSnapshot(mtpCache, snapshot->mtpKey,
-                                                snapshot->mtpValue, devices[0])) {
+                    if (!RestoreMtpPagedSnapshot(mtpCache, mtpKeyView,
+                                                mtpValueView, devices[0])) {
                         mtpCaches.erase(context);
                         return false;
                     }

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -4762,11 +4762,11 @@ namespace fastllm {
         }
 
         static int Qwen35LinearPrefixSnapshotMaxPerRequest() {
-            return std::max(1, Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST", 4));
+            return std::max(1, Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST", 32));
         }
 
         static int Qwen35LinearPrefixSnapshotMaxRecords() {
-            return std::max(1, Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_RECORDS", 8));
+            return std::max(1, Qwen35EnvInt("FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_RECORDS", 64));
         }
 
         static bool Qwen35LayerIsLinearAttention(const Qwen3_5Model *model, int layer) {

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -9774,6 +9774,11 @@ namespace fastllm {
                Qwen35MtpSupportsGenerationConfig(context->generationConfig);
     }
 
+    bool Qwen3_5Model::WantsPerStepPrefixSnapshot() const {
+        return Qwen35LinearPrefixCacheEnabled() &&
+               Qwen35HasLinearAttentionLayers(this, this->block_cnt);
+    }
+
     bool Qwen3_5Model::TryRecordPagedPrefixCacheExtra(ResponseContext *context) {
         if (context == nullptr ||
             !Qwen35LinearPrefixCacheEnabled() ||

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -804,7 +804,7 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
                         help = "是否启用前缀缓存（true/false），对应 FASTLLM_PREFIX_CACHE")
     parser.add_argument("--prefix_cache_snapshot_interval_pages", "--prefix-cache-snapshot-interval-pages",
                         dest = "prefix_cache_snapshot_interval_pages", type = int, default = -1,
-                        help = "前缀缓存快照间隔页数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES")
+                        help = "前缀缓存快照间隔页数，默认 4，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES")
     parser.add_argument("--prefix_cache_snapshot_max_per_request", "--prefix-cache-snapshot-max-per-request",
                         dest = "prefix_cache_snapshot_max_per_request", type = int, default = -1,
                         help = "单请求最多保留的前缀缓存快照数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST")

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -804,7 +804,7 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
                         help = "是否启用前缀缓存（true/false），对应 FASTLLM_PREFIX_CACHE")
     parser.add_argument("--prefix_cache_snapshot_interval_pages", "--prefix-cache-snapshot-interval-pages",
                         dest = "prefix_cache_snapshot_interval_pages", type = int, default = -1,
-                        help = "前缀缓存快照间隔页数，默认 4，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES")
+                        help = "前缀缓存快照间隔页数，默认 2，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES")
     parser.add_argument("--prefix_cache_snapshot_max_per_request", "--prefix-cache-snapshot-max-per-request",
                         dest = "prefix_cache_snapshot_max_per_request", type = int, default = -1,
                         help = "单请求最多保留的前缀缓存快照数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST")

--- a/tools/fastllm_pytools/util.py
+++ b/tools/fastllm_pytools/util.py
@@ -807,10 +807,10 @@ def make_normal_parser(des: str, add_help = True) -> argparse.ArgumentParser:
                         help = "前缀缓存快照间隔页数，默认 2，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_INTERVAL_PAGES")
     parser.add_argument("--prefix_cache_snapshot_max_per_request", "--prefix-cache-snapshot-max-per-request",
                         dest = "prefix_cache_snapshot_max_per_request", type = int, default = -1,
-                        help = "单请求最多保留的前缀缓存快照数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST")
+                        help = "单请求最多保留的前缀缓存快照数，默认 32，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_PER_REQUEST")
     parser.add_argument("--prefix_cache_snapshot_max_records", "--prefix-cache-snapshot-max-records",
                         dest = "prefix_cache_snapshot_max_records", type = int, default = -1,
-                        help = "全局最多保留的前缀缓存快照数，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_RECORDS")
+                        help = "全局最多保留的前缀缓存快照数，默认 64，对应 FASTLLM_PREFIX_CACHE_SNAPSHOT_MAX_RECORDS")
     parser.add_argument("--gpu_mem_ratio", type = float, default = 0.9, help = "GPU显存使用比例，如0.9表示使用90%%的显存")
     parser.add_argument("--cuda_slab", type = int, default = 0, help = "CUDA模型权重slab大小（MB），0表示关闭")
     parser.add_argument("--mtp", type = int, default = 0, help = "支持MTP的模型每步生成的draft token数，0表示关闭（默认），当前最大8")


### PR DESCRIPTION
## 问题
Qwen3.5 的线性注意力循环状态无法由分页 KV 重建，因此前缀复用是“全有全无”的：命中与否完全取决于快照网格，而快照网格直接决定最坏情况下的重算量。

## 修改
- 解码阶段也记录前缀快照，使本轮输出成为可复用的前缀。
- 前缀快照间隔默认值降低并统一为 2 页（256 token）。
- 提高单请求的快照保留数量。
- MTP 前缀快照缓冲区改为共享（原先每请求一份）。

## 证据
实测命中后仅需重算尾部 ≤256 token（日志形如 `prefix cache hit: tokens=34560`），长会话每轮不再全量重算；未命中时的重算上限由快照间隔决定。
