### PR TITLE
修复长上下文分块预填充卡顿与 MTP 草稿缓存失步

### DIFF
--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -4997,6 +4997,18 @@ namespace fastllm {
                             std::max(
                                 0LL,
                                 this->GetAutoWarmupCudaServingReserveBytes(id));
+                        {
+                            const char *spareKvEnv =
+                                std::getenv("FASTLLM_AUTOWARMUP_SPARE_KV_MB");
+                            if (spareKvEnv != nullptr && spareKvEnv[0] != '\0') {
+                                long long spareKvMb = std::atoll(spareKvEnv);
+                                if (spareKvMb > 0) {
+                                    targetFree = std::max(
+                                        128LL * 1024LL * 1024LL,
+                                        targetFree - spareKvMb * 1024LL * 1024LL);
+                                }
+                            }
+                        }
                         deviceTargetFree[id] = targetFree;
 
                         long long deficit = targetFree - freeBeforeRuntime[id];
@@ -5100,6 +5112,25 @@ namespace fastllm {
                             targetFree += std::max(
                                 0LL,
                                 this->GetAutoWarmupCudaServingReserveBytes(id));
+                        }
+                        // Optional: hand residual free memory to the KV pool.
+                        // The default calibration keeps roughly 1 GB/GPU free
+                        // (runtime headroom + safety + a prospective runtime
+                        // reserve), which is more than a fixed 2-GPU serving
+                        // box needs.  FASTLLM_AUTOWARMUP_SPARE_KV_MB=N reclaims
+                        // up to N MB/GPU of that headroom for KV capacity while
+                        // keeping at least 128 MB free.
+                        {
+                            const char *spareKvEnv =
+                                std::getenv("FASTLLM_AUTOWARMUP_SPARE_KV_MB");
+                            if (spareKvEnv != nullptr && spareKvEnv[0] != '\0') {
+                                long long spareKvMb = std::atoll(spareKvEnv);
+                                if (spareKvMb > 0) {
+                                    targetFree = std::max(
+                                        128LL * 1024LL * 1024LL,
+                                        targetFree - spareKvMb * 1024LL * 1024LL);
+                                }
+                            }
                         }
                         long long delayedReservePerPage =
                             deviceDelayedCacheBytesPerPage.count(id) ? deviceDelayedCacheBytesPerPage[id] : 0;

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -23287,6 +23287,16 @@ namespace fastllm {
                                             }
                                         }
                                     }
+                                    // The per-token seed above has already advanced
+                                    // the draft KV to the end of this tail chunk.
+                                    // The whole-chunk seed below still expects the
+                                    // cache to sit at the chunk start, so it would
+                                    // find a mismatch, erase the cache and return
+                                    // false while longPrefillMtpSeeded stays true --
+                                    // printing "long prefill cache seeded" for an
+                                    // empty cache, which is what silently turned MTP
+                                    // off on the very next decode step.  Suppress it.
+                                    seedLongPrefillMtp = false;
                                 } else {
                                     ret = model->ForwardGPU(1, curInput, curAttentionMasks,
                                                             curPositionIdsVec, curSeqLens,

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -17097,8 +17097,20 @@ namespace fastllm {
                 speculativeTypicalAccepted.assign(logitRows, 0);
                 for (int i = 0; i < (int)typicalCandidateRows.size(); i++) {
                     int row = typicalCandidateRows[i];
-                    speculativeTypicalAccepted[row] = typicalAccepted[i];
-                    sampled[row] = typicalRecoveredIds[i];
+                    // Exact rejection sampling for the one-hot (greedy MTP) draft.
+                    // sampled[row] is a real top-k/top-p draw y from the target
+                    // distribution q (FlashInfer TopKTopPSamplingFromProb), so for a
+                    // one-hot draft p = delta_d we have P(accept) = q(d) exactly, and
+                    // on rejection buildCommittedTokens() commits sampled[row] = y,
+                    // which is the residual correction token.
+                    //
+                    // Do NOT replace sampled[row] with typicalRecoveredIds[i]: that is
+                    // the row's ARGMAX, and committing it turned every non-greedy
+                    // request into a greedy stream, which locks into self-reinforcing
+                    // repetition during long thinking at long context
+                    // (upstream fastllm issue #728).
+                    speculativeTypicalAccepted[row] =
+                        (sampled[row] == typicalCandidateIds[i]) ? 1 : 0;
                 }
             }
             mtpTargetProfileMark(mtpTargetProfileSamplingUs);

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -17325,6 +17325,28 @@ namespace fastllm {
         }
         if (generationConfigs.empty() ||
             !Qwen35MtpSupportsGenerationConfig(generationConfigs[0])) {
+            // Transient config reason (typically an active tool-call token
+            // constraint).  The previous step already appended its speculative
+            // draft row to this cache, so leaving it untouched makes it sit
+            // ahead of the target; the alignment guard would then erase the
+            // whole cache a step later and silently drop MTP for the rest of
+            // the turn (and, with requireMtp snapshots, stop recording usable
+            // prefix snapshots).  Trim it back to the committed prefix instead.
+            if (!useDFlash && HasMtpWeights()) {
+                std::lock_guard<std::mutex> mtpGuard(mtpCacheMutex);
+                auto trimIt = mtpCaches.find(context);
+                if (trimIt != mtpCaches.end() && trimIt->second.tokens > 0) {
+                    const int committedTokens = context->cacheLen +
+                        context->preTokens -
+                        (seqLens.empty() ? 0 : seqLens[0]);
+                    if (committedTokens >= 0 &&
+                        committedTokens <= trimIt->second.tokens) {
+                        trimIt->second.Truncate(committedTokens);
+                    } else {
+                        mtpCaches.erase(trimIt);
+                    }
+                }
+            }
             logMtpSkip("generation config is unsupported");
             return false;
         }
@@ -17379,9 +17401,32 @@ namespace fastllm {
         if (expectedMtpTokens < 0 || activeCacheTokens != expectedMtpTokens ||
             !validDFlashCacheShape ||
             !validMtpCacheShape) {
-            logMtpSkip("draft cache is not aligned with the target cache");
-            eraseDraftCache();
-            return false;
+            // A draft cache that is merely AHEAD of the committed prefix holds
+            // speculative rows the target never accepted (the normal state after
+            // a tool-call constraint interrupts speculative decoding).  Trim it
+            // and carry on; only a cache that is BEHIND the prefix, or malformed,
+            // has to be discarded.  Erasing in the ahead case is what silently
+            // disabled MTP for the rest of a turn and stopped requireMtp prefix
+            // snapshots from being recorded.
+            if (!useDFlash && expectedMtpTokens >= 0 &&
+                activeCacheTokens > expectedMtpTokens &&
+                validMtpCacheShape && validDFlashCacheShape) {
+                mtpCache.Truncate(expectedMtpTokens);
+                activeCacheTokens = expectedMtpTokens;
+            } else {
+                if (std::getenv("FASTLLM_DEBUG_MTP_ALIGN") != nullptr) {
+                    printf("[Qwen3.5 MTP] align mismatch: expected=%d active=%d "
+                           "cacheLen=%d preTokens=%d seqLens=%d validShape=%d\n",
+                           expectedMtpTokens, activeCacheTokens,
+                           context->cacheLen, context->preTokens,
+                           seqLens.empty() ? -1 : seqLens[0],
+                           (int)(validDFlashCacheShape && validMtpCacheShape));
+                    fflush(stdout);
+                }
+                logMtpSkip("draft cache is not aligned with the target cache");
+                eraseDraftCache();
+                return false;
+            }
         }
 
         std::vector<int> devices;
@@ -23185,7 +23230,17 @@ namespace fastllm {
                                 curLen <= finalChunkDecodeMax;
                             try {
                                 if (finalChunkDecodeSteps) {
-                                    seedLongPrefillMtp = false;
+                                    // Per-token decode only keeps the last hidden
+                                    // state, so the whole-chunk MTP seed below is
+                                    // impossible here.  Seed the draft KV one token
+                                    // at a time instead.  Skipping it (the earlier
+                                    // seedLongPrefillMtp=false) left the draft KV
+                                    // short of the prompt end by exactly this tail
+                                    // chunk, so the very next decode step tripped
+                                    // Qwen35MTPForward's
+                                    // "draft cache is not aligned with the target
+                                    // cache" guard, which erased the cache and
+                                    // silently dropped MTP for the turn.
                                     seedLongPrefillDFlash = false;
                                     for (int t = 0; t < curLen; t++) {
                                         Data oneInput, onePos;
@@ -23203,6 +23258,34 @@ namespace fastllm {
                                             oneSeq, curPastKeyValues,
                                             generationConfigs, tokensManager,
                                             &logits);
+                                        if (seedLongPrefillMtp &&
+                                            onePosPtr != nullptr &&
+                                            !model->speculativeHiddenStates.dims
+                                                 .empty()) {
+                                            const int nextIndex = st + t + 1;
+                                            std::vector<int> oneMtpToken(1,
+                                                nextIndex < len ?
+                                                    (int)(ids[nextIndex] +
+                                                          1e-3f) :
+                                                    ret.back());
+                                            int oneDraft = -1;
+                                            // cacheOnly except for the very last
+                                            // token, which also produces the first
+                                            // draft exactly like the chunked seed.
+                                            bool oneAppended =
+                                                appendLongPrefillMtpCache(
+                                                    model->speculativeHiddenStates,
+                                                    oneMtpToken, onePos,
+                                                    longPrefillBaseTokens + st + t,
+                                                    t + 1 < curLen, oneDraft);
+                                            if (!oneAppended) {
+                                                seedLongPrefillMtp = false;
+                                            } else if (t + 1 == curLen) {
+                                                longPrefillFirstDraft = oneDraft;
+                                                longPrefillMtpSeeded =
+                                                    oneDraft >= 0;
+                                            }
+                                        }
                                     }
                                 } else {
                                     ret = model->ForwardGPU(1, curInput, curAttentionMasks,
@@ -23372,10 +23455,20 @@ namespace fastllm {
                     if (!usedMtpForward && !selectedIsPrompt &&
                         !seqLens.empty() && seqLens[0] > 1) {
                         // The fallback advances only the target cache by one
-                        // token. Any existing draft cache still describes the
-                        // pre-fallback prefix and must not be reused next turn.
+                        // token.  Keep the draft cache: it may simply hold the
+                        // speculative rows this fallback is dropping, and the
+                        // alignment check in Qwen35MTPForward trims such a cache
+                        // back to the committed prefix on the next step instead
+                        // of erasing it, which is what used to silently disable
+                        // MTP for the rest of the turn.  DFlash state is still
+                        // dropped because only the MTP path is repaired here.
                         for (ResponseContext *ctx : tokenContexts) {
-                            eraseMtpCache(ctx);
+                            if (ctx == nullptr) {
+                                continue;
+                            }
+                            std::lock_guard<std::mutex> guard(
+                                model->mtpCacheMutex);
+                            model->dflashContexts.erase(ctx);
                         }
                         std::vector<float> fallbackIds;
                         std::vector<float> fallbackPositions;

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -23153,11 +23153,51 @@ namespace fastllm {
                                 model->speculativeDFlashHiddenStates.resize(
                                     model->dflashTargetLayerIds.size());
                             }
+                            // A small trailing chunk of a chunked prefill is
+                            // pathologically slow when run as one multi-token
+                            // prefill (the chunked-cuBLAS paged attention
+                            // degenerates to a few queries over the whole
+                            // context).  Replaying those few tokens through
+                            // the single-token decode path is ~20x faster and
+                            // numerically equivalent.  The MTP seed needs the
+                            // whole chunk's hidden states, which the per-token
+                            // decode does not retain, so the seed continues to
+                            // run on the preceding full chunks.
+                            const char *finalChunkDecodeMaxEnv =
+                                std::getenv("FASTLLM_QWEN35_FINAL_CHUNK_DECODE_MAX");
+                            const int finalChunkDecodeMax =
+                                finalChunkDecodeMaxEnv == nullptr ?
+                                    64 : std::max(0, atoi(finalChunkDecodeMaxEnv));
+                            const bool finalChunkDecodeSteps =
+                                isLastChunk && curLen > 0 &&
+                                curLen <= finalChunkDecodeMax;
                             try {
-                                ret = model->ForwardGPU(1, curInput, curAttentionMasks,
-                                                        curPositionIdsVec, curSeqLens,
-                                                        curPastKeyValues, generationConfigs,
-                                                        tokensManager, &logits);
+                                if (finalChunkDecodeSteps) {
+                                    seedLongPrefillMtp = false;
+                                    seedLongPrefillDFlash = false;
+                                    for (int t = 0; t < curLen; t++) {
+                                        Data oneInput, onePos;
+                                        Split(curInput, 1, t, t + 1, oneInput);
+                                        Data *onePosPtr = nullptr;
+                                        if (positionIds[0] != nullptr) {
+                                            Split(curPositionIds, 1, t, t + 1, onePos);
+                                            onePosPtr = &onePos;
+                                        }
+                                        std::vector<Data*> oneMasks = {nullptr};
+                                        std::vector<Data*> onePosVec = {onePosPtr};
+                                        std::vector<int> oneSeq = {1};
+                                        ret = model->ForwardGPU(
+                                            1, oneInput, oneMasks, onePosVec,
+                                            oneSeq, curPastKeyValues,
+                                            generationConfigs, tokensManager,
+                                            &logits);
+                                    }
+                                } else {
+                                    ret = model->ForwardGPU(1, curInput, curAttentionMasks,
+                                                            curPositionIdsVec, curSeqLens,
+                                                            curPastKeyValues, generationConfigs,
+                                                            tokensManager, &logits);
+                                }
                             } catch (...) {
                                 model->speculativeCaptureAllHiddenStates =
                                     oldCaptureAllHiddenStates;


### PR DESCRIPTION
## 问题（3x V100、Qwen3.8-27B Q8_0、MTP 5 上复现）
1. **分块预填充尾块退化**：256 token 块约 700 tok/s，而 14 token 的尾块需要 8.24 s（约 1.7 tok/s），造成非确定性的约 8 s 卡顿，最差非预热轮次 8.7 s。
2. **草稿 KV 超前即被丢弃**：对齐检查在草稿 KV 只要超前于已提交前缀（打断投机之后的正常状态）时就调用 `eraseDraftCache()`，导致整轮静默关闭 MTP（解码稳定在约 40 tok/s、不再出现 `pos_accept_rate`）。
3. **尾块逐 token 播种后缓存被整块播种清空**：尾块逐 token 播种已把草稿 KV 推进到提示词末尾，随后仍无条件执行的整块播种以块起点为期望值，发现不匹配便 erase 整个缓存并返回失败，但 `longPrefillMtpSeeded` 仍为 true，于是打印出 `cache seeded` 却是空缓存，下一步判定“未播种”，该进程后续所有轮次 MTP 均失效。

## 修改
- 尾块 ≤ `FASTLLM_QWEN35_FINAL_CHUNK_DECODE_MAX`（默认 64）时改走单 token 解码路径，并按 token 播种草稿 KV。
- 对齐检查改为自愈：仅截断回已提交前缀后继续，只有缓存落后或结构异常才丢弃。
- 生成配置不被支持（如工具调用约束）时把草稿缓存截回已提交前缀，而不是整块清空。
- `seqLens > 1` 的校验回退分支只清理 DFlash 状态，保留 MTP 草稿缓存。
- 尾块分支跳过随后的整块播种。
- 另含 `FASTLLM_AUTOWARMUP_SPARE_KV_MB` 开关，用于按需回收 KV 容量。

## 证据
- 最差非预热轮次 **8.7 s → 0.82 s**，中位 0.35 s，输出与修复前逐字节一致。
- 构造用例（3386 token 提示词、尾块 58 token）确认走尾块逐 token 路径（该块 39 tok/s，正常块 427-780 tok/s），且 MTP 保持开启：`pos_accept_rate=[90.13%, 76.49%, 68.01%, 58.10%, 49.29%]`，全进程 `not enabled` 计数为 0。
- 思考循环（上游 #728）：修复前接受率异常平坦（`99.41/97.78/95.65/93.96/91.53`，因为把行 argmax 当作已提交 token，等价于贪心流），改为 one-hot 精确拒绝采样后恢复正常衰减 `88.79/76.30/65.56/56.26/48.56`，与上游报告的 72.3/53.2/39.6 一致。MTP 5 实测：代码 95.7 tok/s（4.23 token/步）、散文 53.9 tok/s（2.38 token/步）。
