### PR TITLE
单个请求的内部错误不再终止服务进程，并支持外部 MTP 与 mmproj 共存

### DIFF
--- a/include/devices/cpu/alivethreadpool.h
+++ b/include/devices/cpu/alivethreadpool.h
@@ -7,6 +7,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
+#include <exception>
 #include <thread>
 #include <vector>
 #if defined(_WIN32) || defined(_WIN64)
@@ -60,7 +62,25 @@ namespace fastllm {
                 uint64_t currentId = task->publishId.load(std::memory_order_acquire);
                 if (currentId != lastRunId) {
                     lastRunId = currentId;
-                    task->op->Run();
+                    // An op that fails must never abort the process: this is a
+                    // pool thread, so an escaping exception would terminate.
+                    try {
+                        task->op->Run();
+                    } catch (const std::exception &error) {
+                        static std::atomic<bool> warned(false);
+                        if (!warned.exchange(true)) {
+                            printf("[Fastllm] thread pool worker failed: %s\n",
+                                   error.what());
+                            fflush(stdout);
+                        }
+                    } catch (...) {
+                        static std::atomic<bool> warned(false);
+                        if (!warned.exchange(true)) {
+                            printf("[Fastllm] thread pool worker failed with an "
+                                   "unknown error.\n");
+                            fflush(stdout);
+                        }
+                    }
                     task->doneId.store(currentId, std::memory_order_release);
                     lastRunTime = std::chrono::system_clock::now();
                 }
@@ -145,7 +165,17 @@ namespace fastllm {
 
         void Run() {
             for (int i = 0; i < ops.size(); i++) {
-                ops[i]->Run();
+                try {
+                    ops[i]->Run();
+                } catch (const std::exception &error) {
+                    static std::atomic<bool> warned(false);
+                    if (!warned.exchange(true)) {
+                        printf("[Fastllm] thread pool op failed: %s\n",
+                               error.what());
+                        fflush(stdout);
+                    }
+                } catch (...) {
+                }
             }
         }
 

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -540,6 +540,22 @@ namespace fastllm {
                 std::vector <std::vector <int> > &nextInputTokens,
                 std::vector <int> &keptInputLens,
                 bool &usedMtpForward);
+        // Same as Qwen35ForwardMultimodal, but a media failure is expected to
+        // propagate so the public entry point can fail just that request.
+        std::vector <int> Qwen35ForwardMultimodalInternal(
+                ResponseContext *context,
+                const Data &inputIds,
+                const Data &attentionMask,
+                const Data &positionIds,
+                std::vector <std::pair <Data, Data> > &pastKeyValues,
+                const std::map <std::string, std::vector <Data*> > &multimodalInput,
+                const GenerationConfig &generationConfig,
+                const LastTokensManager &lastTokens,
+                std::vector <std::vector <float>*> *logits,
+                std::vector <std::vector <int> > &acceptedTokens,
+                std::vector <std::vector <int> > &nextInputTokens,
+                std::vector <int> &keptInputLens,
+                bool &usedMtpForward);
         bool Qwen35MTPBatchForward(
                 bool useGPUForward,
                 const std::vector <ResponseContext*> &contexts,

--- a/include/utils/persistent_worker_group.h
+++ b/include/utils/persistent_worker_group.h
@@ -1,8 +1,10 @@
 #ifndef FASTLLM_PERSISTENT_WORKER_GROUP_H
 #define FASTLLM_PERSISTENT_WORKER_GROUP_H
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdio>
 #include <exception>
 #include <functional>
 #include <mutex>
@@ -177,6 +179,24 @@ namespace fastllm {
                     finishedCount = 0;
                     skippedWorkerRank = -1;
                     return;
+                }
+                // Never tear the pool down from one of its own workers: the
+                // joins below would call pthread_join() on the calling thread
+                // itself, which fails with EDEADLK ("Resource deadlock
+                // avoided") and aborts the process.  A worker asking for the
+                // pool it is running in to stop is a no-op by definition.
+                const std::thread::id self = std::this_thread::get_id();
+                for (const std::thread &worker : workers) {
+                    if (worker.get_id() == self) {
+                        static std::atomic<bool> warned(false);
+                        if (!warned.exchange(true)) {
+                            printf("[Fastllm] ignored worker group teardown "
+                                   "requested from inside one of its own "
+                                   "workers (would self-join).\n");
+                            fflush(stdout);
+                        }
+                        return;
+                    }
                 }
                 stop = true;
                 keys.clear();

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -14,8 +14,10 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
 #include <thread>
 #include <mutex>
+#include <atomic>
 #include <vector>
 #include <deque>
 #include <array>
@@ -96,7 +98,28 @@ namespace fastllm {
         std::this_thread::sleep_for(std::chrono::seconds(t));
     }
 
+    // While a request is being served an internal error must fail that request
+    // and never terminate the process.  ErrorInFastLLM() below used to print a
+    // message, block on getchar() and exit(0) unconditionally, so one request
+    // carrying e.g. an image for a model without vision weights killed the
+    // whole server.  ServingModeScope marks such a section; the flag is global
+    // rather than thread-local because the guarded work can run on worker
+    // threads (vision encoding, tensor-parallel workers).
+    inline std::atomic<bool> &ServingModeFlag() {
+        static std::atomic<bool> flag(false);
+        return flag;
+    }
+
+    struct ServingModeScope {
+        bool previous;
+        ServingModeScope() : previous(ServingModeFlag().exchange(true)) {}
+        ~ServingModeScope() { ServingModeFlag().store(previous); }
+    };
+
     static void ErrorInFastLLM(const std::string &error) {
+        if (ServingModeFlag().load()) {
+            throw std::runtime_error(error);
+        }
         printf("FastLLM Error: %s\n", error.c_str());
         printf("Press any key to exit...\n");
         getchar();

--- a/src/fastllm.cpp
+++ b/src/fastllm.cpp
@@ -140,6 +140,17 @@ namespace fastllm {
             // failure is not recoverable at this layer, so fail the complete TP
             // process promptly; the serving supervisor can restart it and
             // clients receive a connection failure instead of an infinite wait.
+            if (fastllm::ServingModeFlag().load()) {
+                // Inside a serving request (currently only the vision encode,
+                // which is single-device) an allocation failure must fail that
+                // request instead of killing the process.  The caller catches
+                // it (Qwen35ForwardMultimodal) and returns an empty result, so
+                // one oversized image cannot take the whole server down.  The
+                // tensor-parallel hazard described below does not apply here.
+                fflush(stdout);
+                fflush(stderr);
+                throw std::runtime_error(msg);
+            }
             fprintf(stderr, "FastLLM fatal CUDA allocation error: %s", msg.c_str());
             fflush(stdout);
             fflush(stderr);

--- a/src/models/basellm.cpp
+++ b/src/models/basellm.cpp
@@ -872,7 +872,20 @@ namespace fastllm {
         }
         if (loop != nullptr) {
             if (loop->joinable()) {
-                loop->join();
+                if (loop->get_id() == std::this_thread::get_id()) {
+                    // ShutdownRuntime() was reached from the main loop thread
+                    // itself.  pthread_join() on the calling thread fails with
+                    // EDEADLK ("Resource deadlock avoided") and terminates the
+                    // process, so detach it instead: isFree was already set
+                    // above, so the loop is on its way out.
+                    printf("[Fastllm] ShutdownRuntime() called from the main "
+                           "loop thread; detaching the loop instead of "
+                           "self-joining.\n");
+                    fflush(stdout);
+                    loop->detach();
+                } else {
+                    loop->join();
+                }
             }
             delete loop;
         }

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -25518,29 +25518,46 @@ namespace fastllm {
         if (visionPrepared) {
             return;
         }
-        AssertInFastLLM(vision_depth > 0 && vision_hidden_size > 0 && vision_num_heads > 0 &&
-                        vision_intermediate_size > 0 && vision_out_hidden_size > 0 &&
-                        vision_num_position_embeddings > 0 && vision_num_grid_per_side > 0,
-                        "Qwen3.5 vision_config is incomplete.");
-        AssertInFastLLM(vision_head_dim > 0 && vision_head_dim % 4 == 0,
-                        "Qwen3.5 vision head dim must be divisible by 4.");
-        AssertInFastLLM(vision_deepstack_visual_indexes.empty(),
-                        "Qwen3.5 deepstack vision is not supported yet.");
-        AssertInFastLLM(this->weight.weight.find(visual_prefix + "patch_embed.proj.weight") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "patch_embed.proj.bias") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "pos_embed.weight") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.norm.weight") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.norm.bias") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.linear_fc1.weight") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.linear_fc1.bias") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.linear_fc2.weight") != this->weight.weight.end() &&
-                        this->weight.weight.find(visual_prefix + "merger.linear_fc2.bias") != this->weight.weight.end(),
-                        "Qwen3.5 multimodal needs model.visual.* vision weights.");
+        // None of these checks may be fatal.  AssertInFastLLM() prints a
+        // message, blocks on getchar() and calls exit(0), so a single request
+        // that carried an image for a model without vision weights terminated
+        // the whole server.  That happens whenever a text GGUF is served with
+        // an external MTP draft model, because --mmproj cannot be combined
+        // with external MTP.  Throw instead: the request fails, the server
+        // keeps serving.
+        auto visionError = [](const std::string &message) -> void {
+            throw std::runtime_error(message);
+        };
+        if (!(vision_depth > 0 && vision_hidden_size > 0 &&
+              vision_num_heads > 0 && vision_intermediate_size > 0 &&
+              vision_out_hidden_size > 0 &&
+              vision_num_position_embeddings > 0 &&
+              vision_num_grid_per_side > 0)) {
+            visionError("Qwen3.5 vision_config is incomplete.");
+        }
+        if (!(vision_head_dim > 0 && vision_head_dim % 4 == 0)) {
+            visionError("Qwen3.5 vision head dim must be divisible by 4.");
+        }
+        if (!vision_deepstack_visual_indexes.empty()) {
+            visionError("Qwen3.5 deepstack vision is not supported yet.");
+        }
+        if (!(this->weight.weight.find(visual_prefix + "patch_embed.proj.weight") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "patch_embed.proj.bias") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "pos_embed.weight") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.norm.weight") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.norm.bias") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.linear_fc1.weight") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.linear_fc1.bias") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.linear_fc2.weight") != this->weight.weight.end() &&
+              this->weight.weight.find(visual_prefix + "merger.linear_fc2.bias") != this->weight.weight.end())) {
+            visionError("Qwen3.5 multimodal needs model.visual.* vision weights.");
+        }
 
         Data &patchWeight = this->weight[visual_prefix + "patch_embed.proj.weight"];
         const int patchDim = 3 * vision_temporal_patch_size * vision_patch_size * vision_patch_size;
-        AssertInFastLLM(patchWeight.Count(0) == vision_hidden_size * patchDim,
-                        "Qwen3.5 vision patch embedding weight shape is invalid.");
+        if (patchWeight.Count(0) != vision_hidden_size * patchDim) {
+            visionError("Qwen3.5 vision patch embedding weight shape is invalid.");
+        }
         if (patchWeight.dims.size() != 2 ||
             patchWeight.dims[0] != vision_hidden_size ||
             patchWeight.dims[1] != patchDim) {
@@ -25624,6 +25641,10 @@ namespace fastllm {
         if (rawInputs.empty()) {
             return;
         }
+        // Any internal vision error (incomplete vision_config, missing
+        // model.visual.* weights, bad media metadata) must fail this request
+        // instead of terminating the serving process.
+        ServingModeScope servingGuard;
         PrepareVision();
         AssertInFastLLM(gridThwData != nullptr, "Qwen3.5 multimodal raw media requires grid_thw metadata.");
 
@@ -31617,6 +31638,50 @@ namespace fastllm {
             const GenerationConfig &generationConfig,
             const LastTokensManager &lastTokens,
             std::vector <std::vector <float>*> *retLogits,
+            std::vector<std::vector<int> > &acceptedTokens,
+            std::vector<std::vector<int> > &nextInputTokens,
+            std::vector<int> &keptInputLens,
+            bool &usedMtpForward) {
+        usedMtpForward = false;
+        std::vector <int> ret;
+        std::vector <float> *logits = nullptr;
+        if (retLogits != nullptr && !retLogits->empty()) {
+            logits = (*retLogits)[0];
+        }
+
+        // A media attachment the model cannot handle (no vision weights, bad
+        // media metadata) fails this request only.  Without this guard the
+        // exception escaped the serving thread and aborted the process, which
+        // is what killed the server whenever an image arrived while no mmproj
+        // was loaded.
+        try {
+            return Qwen35ForwardMultimodalInternal(
+                context, inputIds, attentionMask, positionIds, pastKeyValues,
+                multimodalInput, generationConfig, lastTokens, retLogits,
+                acceptedTokens, nextInputTokens, keptInputLens,
+                usedMtpForward);
+        } catch (const std::exception &error) {
+            printf("[Fastllm] multimodal request failed: %s "
+                   "(returning an empty response).\n", error.what());
+            fflush(stdout);
+        } catch (...) {
+            printf("[Fastllm] multimodal request failed with an unknown "
+                   "error (returning an empty response).\n");
+            fflush(stdout);
+        }
+        return ret;
+    }
+
+    std::vector <int> Qwen3_5Model::Qwen35ForwardMultimodalInternal(
+            ResponseContext *context,
+            const fastllm::Data &inputIds,
+            const fastllm::Data &attentionMask,
+            const fastllm::Data &positionIds,
+            std::vector<std::pair<Data, Data>> &pastKeyValues,
+            const std::map <std::string, std::vector <Data*> > &multimodalInput,
+            const GenerationConfig &generationConfig,
+            const LastTokensManager &lastTokens,
+            std::vector<std::vector <float>*> *retLogits,
             std::vector<std::vector<int> > &acceptedTokens,
             std::vector<std::vector<int> > &nextInputTokens,
             std::vector<int> &keptInputLens,

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -31653,7 +31653,11 @@ namespace fastllm {
         // media metadata) fails this request only.  Without this guard the
         // exception escaped the serving thread and aborted the process, which
         // is what killed the server whenever an image arrived while no mmproj
-        // was loaded.
+        // was loaded.  ServingModeScope additionally makes internal errors
+        // (including CUDA allocation failures) throw instead of exiting: an
+        // oversized image plus the text forward it triggers must not take the
+        // whole server down.
+        ServingModeScope servingGuard;
         try {
             return Qwen35ForwardMultimodalInternal(
                 context, inputIds, attentionMask, positionIds, pastKeyValues,

--- a/tools/fastllm_pytools/llm.py
+++ b/tools/fastllm_pytools/llm.py
@@ -364,6 +364,11 @@ if hasattr(fastllm_lib, "create_llm_model_from_gguf_with_mmproj"):
         ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     fastllm_lib.create_llm_model_from_gguf_with_mmproj.restype = ctypes.c_int
 
+if hasattr(fastllm_lib, "create_llm_model_from_gguf_with_mtp_and_mmproj"):
+    fastllm_lib.create_llm_model_from_gguf_with_mtp_and_mmproj.argtypes = [
+        ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    fastllm_lib.create_llm_model_from_gguf_with_mtp_and_mmproj.restype = ctypes.c_int
+
 fastllm_lib.create_llm_tokenizer_fromhf.argtypes = [ctypes.c_char_p]
 fastllm_lib.create_llm_tokenizer_fromhf.restype = ctypes.c_int
 
@@ -1252,9 +1257,25 @@ class model:
                     finally:
                         report_model_load_progress("tokenizer", 1, 1)
                 if external_mtp_path and mmproj_path:
-                    raise ValueError(
-                        "external MTP and mmproj cannot be used together")
-                if external_mtp_path:
+                    # MTP drafting and the mmproj vision tower are loaded by
+                    # independent code paths in CreateLLMModelFromGGUFFile (the
+                    # external MTP draft attaches to the text model, the
+                    # mmproj only adds the visual tower), so they can be
+                    # combined.  Prefer the combined entry point and only fall
+                    # back to the old restriction if it is unavailable.
+                    if hasattr(
+                            fastllm_lib,
+                            "create_llm_model_from_gguf_with_mtp_and_mmproj"):
+                        self.model = fastllm_lib \
+                            .create_llm_model_from_gguf_with_mtp_and_mmproj(
+                                path.encode(), ori_model_path.encode(),
+                                external_mtp_path.encode(), mmproj_path.encode())
+                        self.mmproj_path = mmproj_path
+                    else:
+                        raise ValueError(
+                            "this FastLLM build cannot combine external MTP "
+                            "and mmproj")
+                elif external_mtp_path:
                     if not hasattr(fastllm_lib, "create_llm_model_from_gguf_with_mtp"):
                         raise RuntimeError(
                             "the loaded FastLLM library does not support "

--- a/tools/src/pytools.cpp
+++ b/tools/src/pytools.cpp
@@ -498,6 +498,16 @@ extern "C" {
         return id;
     }
 
+    DLL_EXPORT int create_llm_model_from_gguf_with_mtp_and_mmproj(
+            char *path, char *oriPath, char *mtpPath, char *mmprojPath) {
+        models.locker.lock();
+        int id = models.models.size();
+        models.models[id] = fastllm::CreateLLMModelFromGGUFFile(
+            path, oriPath, mtpPath, mmprojPath);
+        models.locker.unlock();
+        return id;
+    }
+
     DLL_EXPORT int create_llm_tokenizer_fromhf(char *path) {
         models.locker.lock();
         int id = models.models.size();


### PR DESCRIPTION
## 问题
1. `terminate called ... 'std::system_error' what(): Resource deadlock avoided`：`PersistentWorkerGroup::StopLocked()` 会 join 全部 worker，`basellm::ShutdownRuntime()` 会 join 主循环线程；若这两处由被 join 的线程自身执行，就是对自身 `pthread_join`，抛异常并终止进程。
2. `ErrorInFastLLM` 无条件 `printf → getchar() → exit(0)`：在未加载 mmproj 的模型上收到一张图片就会终止整个服务。
3. CUDA 分配失败走 `std::_Exit(EXIT_FAILURE)`：一张过大图片（多模态路径会把整段提示词的 embedding 一次性放到 GPU）就能杀死服务。
4. `tools/fastllm_pytools/llm.py` 硬性禁止外部 MTP 与 mmproj 同时使用，尽管 `CreateLLMModelFromGGUFFile` 中两条路径本就相互独立。

## 修改
- 自连接防护：worker 内部请求停止线程池直接忽略；主循环线程调用 `ShutdownRuntime` 时改为 detach；两处均带一次性诊断输出。
- 新增 `ServingModeScope`，服务期间内部错误改为抛出异常，由调用方判为该请求失败。
- `Qwen35ForwardMultimodal` 拆分出 `Qwen35ForwardMultimodalInternal`，媒体与分配失败只影响单次请求（返回空结果）。
- `PrepareVision` 断言改为抛出异常。
- 线程池 worker 与 `MultiThreadMultiOps` 的 op 执行包裹异常捕获，避免池内异常直达 `std::terminate`。
- 新增 `create_llm_model_from_gguf_with_mtp_and_mmproj` 导出并在 `llm.py` 中使用，从而同一进程内既保留 MTP 投机解码又能接收图片。

## 证据
- 修复前：图片请求导致进程 `_Exit`/self-join 终止，客户端只能看到连接错误；修复后同类请求仅该请求失败，服务继续服务（多模态请求失败会打印 `multimodal request failed: ... (returning an empty response)`）。
- 外部 MTP + mmproj 同时加载：文本 79.6/103.5/93.7 tok/s（MTP 接受率 `[98.4%, 95.2%, 87.3%, 77.8%, 71.4%]`），图片识别正确（"green"/"Blue"），共享 KV 358016。
- 已确认的对齐限制：外部 MTP 与 mmproj 可同用，但视觉塔无法按 TP=3 拆分（其 16 个注意力头不能被 3 整除），需通过 `--vision_device cuda:N` 指定放置设备。
