### PR TITLE
Fix/mtp效率和稳定性优化

### DIFF
--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -1465,6 +1465,13 @@ bool FastllmCudaDFlashRejectionSampling(
                                   int *acceptedDraftTokens,
                                   int batch, int draftTokens,
                                   int selectorTopK, int vocabSize);
+bool FastllmCudaMtpDraftSpecSampling(
+                                  const float *logits,
+                                  float temperature, int topK, float topP,
+                                  uint64_t seed,
+                                  int *draftOut, int *candidateIdsOut,
+                                  float *candidateProbsOut,
+                                  int *candidateCountOut, int vocabSize);
 bool FastllmCudaDFlashDynamicConv(
                                   const fastllm::Data &source,
                                   const fastllm::Data &dynamicProjection,

--- a/include/devices/cuda/fastllm-cuda.cuh
+++ b/include/devices/cuda/fastllm-cuda.cuh
@@ -423,6 +423,17 @@ bool FastllmCudaPreparePagedBatchParamsSingle(
     int32_t *qSizes, int32_t *pageSizes, int32_t *pageIndexs,
     int32_t *lastPageLens, const int *pageIdxHost, int pageIndexCount,
     int totalPages, int qSize, int lastPageLen);
+// Upload the paged batch parameters via a kernel carrying the values in its
+// parameter space (upstream #722): no blocking pageable H2D copy, capturable
+// by a CUDA Graph.  Returns false when a size exceeds the kernel parameter
+// budget; callers keep the memcpy fallback.
+bool FastllmCudaUploadPagedIntParams(
+    int32_t *qSizes, int qSizesCount,
+    int32_t *pageSizes, int pageSizesCount,
+    int32_t *pageIndexs, int pageIndexsCount,
+    int32_t *lastPageLens, int lastPageLensCount,
+    const int *qSizesHost, const int *pageSizesHost,
+    const int *pageIndexsHost, const int *lastPageLensHost);
 void FastllmCudaPagedCacheCopyBatch(uint8_t *pagedData, int32_t *pageIdxArray, int32_t *pageOffsetArray,
                                     int pageLen, int batch, int numHeads, int headDim,
                                     fastllm::DataType dstType, uint8_t *inputData, fastllm::DataType srcType,

--- a/include/models/qwen3_5.h
+++ b/include/models/qwen3_5.h
@@ -263,6 +263,18 @@ namespace fastllm {
             std::vector <int> proposalCandidateIds;
             std::vector <float> proposalCandidateProbs;
         };
+        struct MtpSpecDraftParams {
+            bool active = false;
+            float temperature = 1.0f;
+            int topK = 1;
+            float topP = 1.0f;
+            unsigned long long seed = 0;
+        };
+        struct MtpSpecDraftSample {
+            int token = -1;
+            std::vector <int> candidateIds;
+            std::vector <float> candidateProbs;
+        };
         bool mtpWeightsPrepared = false;
         bool mtpSharedWeightsPrepared = false;
         int mtpWeightsPreparedDevice = -1;
@@ -283,6 +295,10 @@ namespace fastllm {
         DFlashContext *speculativeDFlashSamplingContext = nullptr;
         std::vector<DFlashContext*> speculativeDFlashSamplingContexts;
         std::vector<unsigned char> speculativeDFlashAccepted;
+        MtpSpecDraftParams mtpSpecDraftParams;
+        MtpSpecDraftSample mtpSpecDraftLast;
+        unsigned long long mtpSpecDraftSeedBase = 0;
+        unsigned long long mtpSpecDraftSeedCounter = 0;
         bool speculativeCaptureFirstTokenLinearState = false;
         int speculativeLinearStateCaptureSlots = 0;
         std::vector<std::vector<std::pair<Data, Data> > > speculativeLinearStates;

--- a/src/devices/cuda/attention/fastllm-attention.cu
+++ b/src/devices/cuda/attention/fastllm-attention.cu
@@ -2888,6 +2888,140 @@ bool FastllmCudaPreparePagedBatchParamsSingle(
     return true;
 }
 
+// Upstream #722: the pageable H2D copies of the paged batch parameters hold
+// the CUDA driver lock while the DMA completes; past the 256-page boundary
+// that window overlaps the peer rank's allocation/collective submission and
+// can deadlock a long-context prefill.  Carry the values in kernel parameters
+// instead: no blocking copy, and the launch is capturable by a CUDA Graph.
+constexpr int kFastllmPagedIntParamsMaxSmall = 64;
+
+template <int MaxPages>
+struct FastllmPagedIntParamsList {
+    int32_t qSizes[kFastllmPagedIntParamsMaxSmall];
+    int32_t pageSizes[kFastllmPagedIntParamsMaxSmall];
+    int32_t lastPageLens[kFastllmPagedIntParamsMaxSmall];
+    int32_t pageIdx[MaxPages];
+};
+
+template <int MaxPages>
+__global__ void FastllmUploadPagedIntParamsKernel(
+        int32_t *qSizes, int qSizesCount,
+        int32_t *pageSizes, int pageSizesCount,
+        int32_t *pageIndexs, int pageIndexsCount,
+        int32_t *lastPageLens, int lastPageLensCount,
+        FastllmPagedIntParamsList<MaxPages> values) {
+    const int total = qSizesCount + pageSizesCount + pageIndexsCount +
+                      lastPageLensCount;
+    for (int i = threadIdx.x; i < total; i += blockDim.x) {
+        if (i < qSizesCount) {
+            qSizes[i] = values.qSizes[i];
+        } else if (i < qSizesCount + pageSizesCount) {
+            const int j = i - qSizesCount;
+            pageSizes[j] = values.pageSizes[j];
+        } else if (i < qSizesCount + pageSizesCount + pageIndexsCount) {
+            const int j = i - qSizesCount - pageSizesCount;
+            pageIndexs[j] = values.pageIdx[j];
+        } else {
+            const int j = i - qSizesCount - pageSizesCount - pageIndexsCount;
+            lastPageLens[j] = values.lastPageLens[j];
+        }
+    }
+}
+
+template <int MaxPages>
+static bool UploadPagedIntParamsKernel(
+        int32_t *qSizes, int qSizesCount,
+        int32_t *pageSizes, int pageSizesCount,
+        int32_t *pageIndexs, int pageIndexsCount,
+        int32_t *lastPageLens, int lastPageLensCount,
+        const int *qSizesHost, const int *pageSizesHost,
+        const int *pageIndexsHost, const int *lastPageLensHost) {
+    FastllmPagedIntParamsList<MaxPages> values = {};
+    for (int i = 0; i < qSizesCount; i++) {
+        values.qSizes[i] = qSizesHost[i];
+    }
+    for (int i = 0; i < pageSizesCount; i++) {
+        values.pageSizes[i] = pageSizesHost[i];
+    }
+    for (int i = 0; i < pageIndexsCount; i++) {
+        values.pageIdx[i] = pageIndexsHost[i];
+    }
+    for (int i = 0; i < lastPageLensCount; i++) {
+        values.lastPageLens[i] = lastPageLensHost[i];
+    }
+    FastllmUploadPagedIntParamsKernel<MaxPages><<<1, 256>>>(
+        qSizes, qSizesCount, pageSizes, pageSizesCount,
+        pageIndexs, pageIndexsCount, lastPageLens, lastPageLensCount,
+        values);
+    // Mirror the single-kernel paged-params path, but skip the device sync
+    // while a stream is being captured (the sync would fail the capture).
+    cudaStreamCaptureStatus capture = cudaStreamCaptureStatusNone;
+    if (cudaStreamIsCapturing(cudaStreamPerThread, &capture) == cudaSuccess &&
+        capture == cudaStreamCaptureStatusNone) {
+        DeviceSync();
+    } else {
+        cudaGetLastError();
+    }
+    return true;
+}
+
+bool FastllmCudaUploadPagedIntParams(
+        int32_t *qSizes, int qSizesCount,
+        int32_t *pageSizes, int pageSizesCount,
+        int32_t *pageIndexs, int pageIndexsCount,
+        int32_t *lastPageLens, int lastPageLensCount,
+        const int *qSizesHost, const int *pageSizesHost,
+        const int *pageIndexsHost, const int *lastPageLensHost) {
+    if (qSizes == nullptr || pageSizes == nullptr || pageIndexs == nullptr ||
+        qSizesCount <= 0 ||
+        qSizesCount > kFastllmPagedIntParamsMaxSmall ||
+        pageSizesCount <= 0 ||
+        pageSizesCount > kFastllmPagedIntParamsMaxSmall ||
+        lastPageLensCount < 0 ||
+        lastPageLensCount > kFastllmPagedIntParamsMaxSmall ||
+        pageIndexsCount < 0 ||
+        (qSizesCount > 0 && qSizesHost == nullptr) ||
+        (pageSizesCount > 0 && pageSizesHost == nullptr) ||
+        (pageIndexsCount > 0 && pageIndexsHost == nullptr) ||
+        (lastPageLensCount > 0 &&
+         (lastPageLens == nullptr || lastPageLensHost == nullptr))) {
+        return false;
+    }
+    // Kernel parameter space is 32 KiB on sm_70+; the largest list
+    // (MaxPages=4096, ~17 KiB) leaves headroom for the small arrays.
+    if (pageIndexsCount <= 256) {
+        return UploadPagedIntParamsKernel<256>(
+            qSizes, qSizesCount, pageSizes, pageSizesCount, pageIndexs,
+            pageIndexsCount, lastPageLens, lastPageLensCount, qSizesHost,
+            pageSizesHost, pageIndexsHost, lastPageLensHost);
+    }
+    if (pageIndexsCount <= 512) {
+        return UploadPagedIntParamsKernel<512>(
+            qSizes, qSizesCount, pageSizes, pageSizesCount, pageIndexs,
+            pageIndexsCount, lastPageLens, lastPageLensCount, qSizesHost,
+            pageSizesHost, pageIndexsHost, lastPageLensHost);
+    }
+    if (pageIndexsCount <= 1024) {
+        return UploadPagedIntParamsKernel<1024>(
+            qSizes, qSizesCount, pageSizes, pageSizesCount, pageIndexs,
+            pageIndexsCount, lastPageLens, lastPageLensCount, qSizesHost,
+            pageSizesHost, pageIndexsHost, lastPageLensHost);
+    }
+    if (pageIndexsCount <= 2048) {
+        return UploadPagedIntParamsKernel<2048>(
+            qSizes, qSizesCount, pageSizes, pageSizesCount, pageIndexs,
+            pageIndexsCount, lastPageLens, lastPageLensCount, qSizesHost,
+            pageSizesHost, pageIndexsHost, lastPageLensHost);
+    }
+    if (pageIndexsCount <= 4096) {
+        return UploadPagedIntParamsKernel<4096>(
+            qSizes, qSizesCount, pageSizes, pageSizesCount, pageIndexs,
+            pageIndexsCount, lastPageLens, lastPageLensCount, qSizesHost,
+            pageSizesHost, pageIndexsHost, lastPageLensHost);
+    }
+    return false;
+}
+
 // CUDA kernel for batch copying data from input to paged KV cache
 // input: [batch, numHeads, headDim], pagedData: [maxPages, pageLen, numHeads, headDim]
 // Each batch has 1 token, so we copy [numHeads, headDim] for each batch

--- a/src/devices/cuda/cudadevice.cpp
+++ b/src/devices/cuda/cudadevice.cpp
@@ -11171,11 +11171,26 @@ namespace fastllm {
                 qSizesHost[1], lastPageLensHost[0]);
         }
         if (!singleBatchPrepared) {
-            FastllmCudaCopyFromHostToDevice(qSizes.cudaData, (void*)qSizesHost.data(), (batch + 1) * sizeof(int32_t));
-            FastllmCudaCopyFromHostToDevice(pageSizes.cudaData, (void*)pageSizesHost.data(), (batch + 1) * sizeof(int32_t));
-            FastllmCudaCopyFromHostToDevice(pageIndexs.cudaData, (void*)pageIndexsHost.data(), totalPageSlots * sizeof(int32_t));
-            if (!lastPageLensOnDevice) {
-                FastllmCudaCopyFromHostToDevice(lastPageLens.cudaData, (void*)lastPageLensHost.data(), batch * sizeof(int32_t));
+            // Upstream #722: the pageable H2D copies in the fallback below
+            // hold the CUDA driver lock; the kernel-parameter upload removes
+            // that window.
+            bool kernelUploaded = FastllmCudaUploadPagedIntParams(
+                    (int32_t*)qSizes.cudaData, batch + 1,
+                    (int32_t*)pageSizes.cudaData, batch + 1,
+                    (int32_t*)pageIndexs.cudaData, totalPageSlots,
+                    (int32_t*)lastPageLens.cudaData,
+                    lastPageLensOnDevice ? 0 : batch,
+                    (const int*)qSizesHost.data(),
+                    (const int*)pageSizesHost.data(),
+                    (const int*)pageIndexsHost.data(),
+                    (const int*)lastPageLensHost.data());
+            if (!kernelUploaded) {
+                FastllmCudaCopyFromHostToDevice(qSizes.cudaData, (void*)qSizesHost.data(), (batch + 1) * sizeof(int32_t));
+                FastllmCudaCopyFromHostToDevice(pageSizes.cudaData, (void*)pageSizesHost.data(), (batch + 1) * sizeof(int32_t));
+                FastllmCudaCopyFromHostToDevice(pageIndexs.cudaData, (void*)pageIndexsHost.data(), totalPageSlots * sizeof(int32_t));
+                if (!lastPageLensOnDevice) {
+                    FastllmCudaCopyFromHostToDevice(lastPageLens.cudaData, (void*)lastPageLensHost.data(), batch * sizeof(int32_t));
+                }
             }
         }
     }

--- a/src/devices/cuda/fastllm-cuda.cu
+++ b/src/devices/cuda/fastllm-cuda.cu
@@ -15715,6 +15715,252 @@ bool FastllmCudaDFlashRejectionSampling(
     return true;
 }
 
+// MTP distributional draft: sample the draft token from the filtered draft
+// distribution via Gumbel-max.  p <= 0 entries are outside the filtered
+// support and never win.
+__global__ void FastllmMtpDraftGumbelKernel(
+        const float *probs, int vocabSize, uint64_t seed, int *draftOut) {
+    const float negInf = -__int_as_float(0x7f800000u);
+    float bestScore = negInf;
+    int bestId = -1;
+    for (int i = threadIdx.x; i < vocabSize; i += blockDim.x) {
+        float p = probs[i];
+        if (p <= 0.0f) {
+            continue;
+        }
+        // splitmix64 finalizer per (seed, index): uniform, stateless.
+        uint64_t z = seed ^ ((uint64_t)i * 0x9E3779B97F4A7C15ULL);
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        z ^= z >> 31;
+        float u = (float)(z >> 11u) * (1.0f / 9007199254740992.0f);
+        float score = logf(p) + logf(u);
+        if (score > bestScore) {
+            bestScore = score;
+            bestId = i;
+        }
+    }
+    __shared__ float sBest[32];
+    __shared__ int sId[32];
+    int lane = threadIdx.x & 31;
+    int warp = threadIdx.x >> 5;
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        float other = __shfl_down_sync(0xffffffffu, bestScore, offset);
+        int otherId = __shfl_down_sync(0xffffffffu, bestId, offset);
+        if (other > bestScore) {
+            bestScore = other;
+            bestId = otherId;
+        }
+    }
+    if (lane == 0) {
+        sBest[warp] = bestScore;
+        sId[warp] = bestId;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        int warpCount = (int)(blockDim.x >> 5);
+        bestScore = (lane < warpCount) ? sBest[lane] : negInf;
+        bestId = (lane < warpCount) ? sId[lane] : -1;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            float other = __shfl_down_sync(0xffffffffu, bestScore, offset);
+            int otherId = __shfl_down_sync(0xffffffffu, bestId, offset);
+            if (other > bestScore) {
+                bestScore = other;
+                bestId = otherId;
+            }
+        }
+        if (lane == 0) {
+            *draftOut = bestId;
+        }
+    }
+}
+
+// Collect the filtered support (p > 0, guaranteed <= maxK by the upstream
+// top-K filter except pivot ties) into the fixed-stride candidate arrays.
+__global__ void FastllmMtpDraftCollectKernel(
+        const float *probs, int vocabSize, int maxK,
+        int *countPtr, int *idsOut, float *probsOut, float *sumPtr) {
+    if (threadIdx.x == 0) {
+        *countPtr = 0;
+        *sumPtr = 0.0f;
+    }
+    __syncthreads();
+    for (int i = threadIdx.x; i < vocabSize; i += blockDim.x) {
+        float p = probs[i];
+        if (p > 0.0f) {
+            int slot = atomicAdd(countPtr, 1);
+            if (slot >= maxK) {
+                atomicAdd(countPtr, -1);
+                continue;
+            }
+            idsOut[slot] = i;
+            probsOut[slot] = p;
+            atomicAdd(sumPtr, p);
+        }
+    }
+}
+
+bool FastllmCudaMtpDraftSpecSampling(
+                                  const float *logits,
+                                  float temperature, int topK, float topP,
+                                  uint64_t seed,
+                                  int *draftOut, int *candidateIdsOut,
+                                  float *candidateProbsOut,
+                                  int *candidateCountOut, int vocabSize) {
+    if (logits == nullptr || draftOut == nullptr ||
+        candidateIdsOut == nullptr || candidateProbsOut == nullptr ||
+        candidateCountOut == nullptr || topK <= 0 || vocabSize <= 0) {
+        return false;
+    }
+    const int K = topK;
+    float clampedTemperature = std::max(temperature, 1.0e-6f);
+    int clampedTopKValue = K;
+    float clampedTopP = std::max(1.0e-6f, std::min(topP, 1.0f));
+    const bool needTopP = clampedTopP < 1.0f;
+
+    // Same filter sequence as FastllmCudaDFlashRejectionSampling so the
+    // draft q and the verify-side target p live in one filtered space:
+    // temperature softmax -> top-K renorm -> top-p renorm (optional).
+    const size_t probBytes = (size_t)vocabSize * sizeof(float);
+    size_t scratchNeed = 0;
+    auto reserveAligned = [&](size_t bytes) {
+        size_t offset = scratchNeed;
+        scratchNeed += FastllmCudaAlignBytes(bytes, 256);
+        return offset;
+    };
+    size_t pAOffset = reserveAligned(probBytes);
+    size_t pBOffset = reserveAligned(probBytes);
+    size_t rowStatesOffset =
+        reserveAligned(sizeof(flashinfer::sampling::RadixRowState));
+    size_t temperatureOffset = reserveAligned(sizeof(float));
+    size_t topKOffset = reserveAligned(sizeof(int));
+    size_t topPOffset = reserveAligned(sizeof(float));
+    size_t draftOffset = reserveAligned(sizeof(int));
+    size_t countOffset = reserveAligned(sizeof(int));
+    size_t sumOffset = reserveAligned(sizeof(float));
+    size_t idsOffset = reserveAligned((size_t)K * sizeof(int));
+    size_t probsOffset = reserveAligned((size_t)K * sizeof(float));
+
+    size_t scratchBytes = 0;
+    bool scratchOwn = false;
+    uint8_t *scratch = (uint8_t*)FastllmBorrowDequantScratch(
+        scratchNeed, &scratchBytes, &scratchOwn);
+    if (scratch == nullptr || scratchBytes < scratchNeed) {
+        FastllmReleaseDequantScratch(scratch, scratchOwn);
+        printf("FastllmCudaMtpDraftSpecSampling: failed to borrow CUDA temp buffer.\n");
+        fflush(stdout);
+        return false;
+    }
+    float *pA = (float*)(scratch + pAOffset);
+    float *pB = (float*)(scratch + pBOffset);
+    auto *rowStates =
+        (flashinfer::sampling::RadixRowState*)(scratch + rowStatesOffset);
+    float *cudaTemperature = (float*)(scratch + temperatureOffset);
+    int *cudaTopK = (int*)(scratch + topKOffset);
+    float *cudaTopP = (float*)(scratch + topPOffset);
+    int *cudaDraft = (int*)(scratch + draftOffset);
+    int *cudaCount = (int*)(scratch + countOffset);
+    float *cudaSum = (float*)(scratch + sumOffset);
+    int *cudaIds = (int*)(scratch + idsOffset);
+    float *cudaProbs = (float*)(scratch + probsOffset);
+
+    cudaStream_t stream = cudaStreamPerThread;
+    cudaError_t state = cudaMemsetAsync(
+        rowStates, 0, sizeof(flashinfer::sampling::RadixRowState), stream);
+    FastllmCudaCopyFromHostToDevice(
+        cudaTemperature, &clampedTemperature, sizeof(float));
+    FastllmCudaCopyFromHostToDevice(cudaTopK, &clampedTopKValue, sizeof(int));
+    FastllmCudaCopyFromHostToDevice(cudaTopP, &clampedTopP, sizeof(float));
+
+    if (state == cudaSuccess) {
+        FastllmTemperatureSoftmaxKernel<1024>
+            <<<1, 1024, 0, stream>>>(
+                (float*)logits, pA, cudaTemperature, vocabSize);
+        state = cudaGetLastError();
+    }
+    float *filtered = pA;
+    if (state == cudaSuccess) {
+        state = flashinfer::sampling::RadixTopKRenormProbMultiCTA<float, int>(
+            pA, pB, cudaTopK, 1, 0, (uint32_t)vocabSize, rowStates, stream);
+        filtered = pB;
+    }
+    if (state == cudaSuccess && needTopP) {
+        state = flashinfer::sampling::TopPRenormProb<float>(
+            pB, pA, cudaTopP, 1, 1.0f, (uint32_t)vocabSize, stream);
+        filtered = pA;
+    }
+    if (state == cudaSuccess) {
+        FastllmMtpDraftGumbelKernel<<<1, 1024, 0, stream>>>(
+            filtered, vocabSize, seed, cudaDraft);
+        state = cudaGetLastError();
+    }
+    if (state == cudaSuccess) {
+        FastllmMtpDraftCollectKernel<<<1, 1024, 0, stream>>>(
+            filtered, vocabSize, K, cudaCount, cudaIds, cudaProbs, cudaSum);
+        state = cudaGetLastError();
+    }
+    if (state != cudaSuccess) {
+        FastllmReleaseDequantScratch(scratch, scratchOwn);
+        printf("FastllmCudaMtpDraftSpecSampling: sampling failed: %s\n",
+               cudaGetErrorString(state));
+        fflush(stdout);
+        return false;
+    }
+
+    int draft = -1;
+    int count = 0;
+    float sum = 0.0f;
+    std::vector<int> ids(K, -1);
+    std::vector<float> probs(K, 0.0f);
+    FastllmCudaCopyFromDeviceToHost(&draft, cudaDraft, sizeof(int));
+    FastllmCudaCopyFromDeviceToHost(&count, cudaCount, sizeof(int));
+    FastllmCudaCopyFromDeviceToHost(&sum, cudaSum, sizeof(float));
+    if (count > 0 && count <= K) {
+        FastllmCudaCopyFromDeviceToHost(
+            ids.data(), cudaIds, (size_t)count * sizeof(int));
+        FastllmCudaCopyFromDeviceToHost(
+            probs.data(), cudaProbs, (size_t)count * sizeof(float));
+    }
+    DeviceSync();
+    FastllmReleaseDequantScratch(scratch, scratchOwn);
+
+    if (draft < 0 || draft >= vocabSize || count <= 0 || sum <= 0.0f) {
+        printf("FastllmCudaMtpDraftSpecSampling: empty result (draft=%d count=%d).\n",
+               draft, count);
+        fflush(stdout);
+        return false;
+    }
+    // Pivot-tie edge: the sampled token can land outside the bounded
+    // candidate list; fall back to the strongest collected candidate so
+    // d stays inside the scatter support (q(d) > 0) by construction.
+    bool draftInCandidates = false;
+    for (int j = 0; j < count; j++) {
+        if (ids[j] == draft) {
+            draftInCandidates = true;
+            break;
+        }
+    }
+    if (!draftInCandidates) {
+        int best = 0;
+        for (int j = 1; j < count; j++) {
+            if (probs[j] > probs[best]) {
+                best = j;
+            }
+        }
+        draft = ids[best];
+    }
+    for (int j = 0; j < count; j++) {
+        probs[j] /= sum;
+    }
+    *draftOut = draft;
+    *candidateCountOut = count;
+    for (int j = 0; j < K; j++) {
+        candidateIdsOut[j] = (j < count) ? ids[j] : -1;
+        candidateProbsOut[j] = (j < count) ? probs[j] : 0.0f;
+    }
+    return true;
+}
+
 template <int BLOCK_THREADS>
 __global__ void FastllmRepeatPenaltyFactorsKernel(
         float *logits, const int *penaltyIds,

--- a/src/devices/multicuda/fastllm-custom-allreduce.cu
+++ b/src/devices/multicuda/fastllm-custom-allreduce.cu
@@ -893,6 +893,13 @@ struct CustomArState {
     int pendingCount = 0;
     int pendingType = -1;
     bool pendingMismatch = false;
+    // Per-rank call ordinals identify *which* tensor a peer is on.  The
+    // pointer tuple alone pairs ranks by arrival order, so any asymmetry in
+    // the ranks' collective call streams shifts every later round (silent
+    // wrong results, or an out-of-range read of a freed peer buffer).
+    uint64_t rankCallSequence[kCustomArMaxRanks]{};
+    uint64_t pendingSequences[kCustomArMaxRanks]{};
+    bool sequenceDesyncLogged = false;
     bool lastRegistrationOk = false;
     bool lastRegistrationMissDuringCapture = false;
     std::vector<void *> pendingInputs;
@@ -1158,6 +1165,7 @@ bool FindOrRegisterCustomArPointers(CustomArState &state, int rank,
     } else {
         state.pendingInputs[rank] = input;
         state.pendingCapturing[rank] = capturing ? 1 : 0;
+        state.pendingSequences[rank] = state.rankCallSequence[rank]++;
     }
     state.pendingMismatch = state.pendingMismatch || !captureQueryOk;
     state.arrived++;
@@ -1167,6 +1175,24 @@ bool FindOrRegisterCustomArPointers(CustomArState &state, int rank,
         bool inputsValid = !state.pendingMismatch;
         for (void *ptr : inputs) {
             inputsValid = inputsValid && ptr != nullptr;
+        }
+        // A desynchronised call stream shifts the arrival-order pairing by
+        // one; refuse the round so it falls back to NCCL instead of
+        // reducing the wrong peer tensor (or reading a freed buffer).
+        for (int other = 1; other < (int)state.devices.size() && inputsValid;
+             ++other) {
+            if (state.pendingSequences[other] != state.pendingSequences[0]) {
+                inputsValid = false;
+                state.pendingMismatch = true;
+                if (rank == 0 && !state.sequenceDesyncLogged) {
+                    state.sequenceDesyncLogged = true;
+                    std::fprintf(stderr,
+                                 "[Fastllm] custom all-reduce call "
+                                 "sequences desynchronized across ranks; "
+                                 "falling back to NCCL.\n");
+                    std::fflush(stderr);
+                }
+            }
         }
         std::vector<uintptr_t> key;
         key.reserve(inputs.size());
@@ -1453,6 +1479,11 @@ bool RunCustomArCandidate(void *data, void *dest, int count,
     if (data == nullptr || dest == nullptr || count <= 0) {
         return false;
     }
+    // The kernels access data/dest as 16-byte aligned packets; a misaligned
+    // view would fault on the device (cudaErrorMisalignedAddress, Xid 13).
+    if ((((uintptr_t)data | (uintptr_t)dest) & 15u) != 0) {
+        return false;  // fall back to NCCL
+    }
     size_t typeBytes = CustomArTypeBytes(dataType);
     size_t bytes = (size_t)count * typeBytes;
     if (typeBytes == 0 || bytes == 0 || bytes > CustomArMaxBytes() ||
@@ -1524,6 +1555,12 @@ bool RunCustomArPairAddCandidate(void *first, void *second, void *dest,
         count <= 0) {
         return false;
     }
+    // The kernel reads first/second and writes dest as 16-byte aligned
+    // packets; a misaligned view would fault on the device
+    // (cudaErrorMisalignedAddress, Xid 13).
+    if ((((uintptr_t)first | (uintptr_t)second | (uintptr_t)dest) & 15u) != 0) {
+        return false;  // fall back to NCCL
+    }
     const size_t typeBytes = CustomArTypeBytes(dataType);
     const size_t bytes = (size_t)count * typeBytes;
     if (typeBytes == 0 || bytes == 0 || bytes > CustomArMaxBytes() ||
@@ -1570,6 +1607,11 @@ bool RunCustomArAddCandidate(void *data, void *dest, int count,
                              bool requireEnabledPath = false) {
     if (data == nullptr || dest == nullptr || count <= 0) {
         return false;
+    }
+    // The kernel reads data/dest as 16-byte aligned packets; a misaligned
+    // view would fault on the device (cudaErrorMisalignedAddress, Xid 13).
+    if ((((uintptr_t)data | (uintptr_t)dest) & 15u) != 0) {
+        return false;  // fall back to NCCL
     }
     size_t typeBytes = CustomArTypeBytes(dataType);
     size_t bytes = (size_t)count * typeBytes;
@@ -2237,6 +2279,13 @@ void FastllmCudaCustomAllReduceReset() {
         state.pendingCount = 0;
         state.pendingType = -1;
         state.pendingMismatch = false;
+        for (uint64_t &sequence : state.rankCallSequence) {
+            sequence = 0;
+        }
+        for (uint64_t &sequence : state.pendingSequences) {
+            sequence = 0;
+        }
+        state.sequenceDesyncLogged = false;
         state.lastRegistrationOk = false;
         state.lastRegistrationMissDuringCapture = false;
         state.captureFallbackLogged = false;

--- a/src/devices/multicuda/fastllm-multicuda.cu
+++ b/src/devices/multicuda/fastllm-multicuda.cu
@@ -2261,9 +2261,12 @@ bool FastllmInitNccl(const std::vector<int>& devices) {
         
     g_ncclInitialized = true;
     g_ncclWorldSize = numGPUs;
-    // Odd TP sizes cannot use the custom all-reduce. Keep the established
-    // even-rank path unchanged, including its NCCL fallback.
-    if (numGPUs % 2 != 0) {
+    // Every multi-rank TP group meets around NCCL submission: even-rank
+    // collectives also fall back to NCCL for large tensors, and a rank
+    // entering the next GEMM/allocator while a peer is still submitting can
+    // deadlock on the CUDA driver lock (upstream #722: TP=2 + MTP long
+    // context prefill stalled at the 256-page boundary).
+    if (numGPUs > 1) {
         g_ncclSubmitRendezvous.reset(new fastllm::NcclSubmitRendezvous(numGPUs));
     }
     // Initialize the optional graph-safe small all-reduce before any captured

--- a/src/models/qwen3_5.cpp
+++ b/src/models/qwen3_5.cpp
@@ -803,6 +803,16 @@ namespace fastllm {
         return enabled;
     }
 
+    // MTP spec-rejection candidate-list width: the request top_k lower bound
+    // mirrors the verify-side max(1, top_k) clamps (typical path and DFlash
+    // rejection kernel both use it); the cap bounds the fixed-stride
+    // proposal arrays.
+    static int Qwen35MtpSpecRejectionK(int requestTopK) {
+        const int maxValue = 64;
+        int k = requestTopK > 0 ? requestTopK : 1;
+        return k > maxValue ? maxValue : k;
+    }
+
     static int Qwen35MtpProfileInterval() {
         static int interval = []() {
             const char *env = std::getenv("FASTLLM_QWEN35_MTP_PROFILE");
@@ -16943,14 +16953,23 @@ namespace fastllm {
                     "DFlash rejection sampling input shape mismatch.\n");
                 const float *verifyInput =
                     (const float*)verifyInputCpu.cpuData;
+                // MTP spec-rejection proposals reuse this DFlash rejection
+                // branch; their candidate width follows the request top_k,
+                // not the DFlash checkpoint selector.
+                const int effSelectorTopK =
+                    !HasDFlashWeights() &&
+                    (speculativeDFlashSamplingContext != nullptr ||
+                     !speculativeDFlashSamplingContexts.empty())
+                        ? Qwen35MtpSpecRejectionK(rowConfigs[0].top_k)
+                        : dflashSelectorTopK;
                 std::vector<int> proposalTokens;
                 std::vector<int> proposalCandidateIds;
                 std::vector<float> proposalCandidateProbs;
                 proposalTokens.reserve(batch * draftTokens);
                 proposalCandidateIds.reserve(
-                    batch * draftTokens * dflashSelectorTopK);
+                    batch * draftTokens * effSelectorTopK);
                 proposalCandidateProbs.reserve(
-                    batch * draftTokens * dflashSelectorTopK);
+                    batch * draftTokens * effSelectorTopK);
                 int rowOffset = 0;
                 for (int b = 0; b < batch; b++) {
                     DFlashContext *proposal = proposals[b];
@@ -16958,9 +16977,9 @@ namespace fastllm {
                         proposal != nullptr && seqLens[b] == draftTokens + 1 &&
                             (int)proposal->proposalTokens.size() >= draftTokens &&
                             (int)proposal->proposalCandidateIds.size() >=
-                                draftTokens * dflashSelectorTopK &&
+                                draftTokens * effSelectorTopK &&
                             (int)proposal->proposalCandidateProbs.size() >=
-                                draftTokens * dflashSelectorTopK,
+                                draftTokens * effSelectorTopK,
                         "DFlash rejection sampling is missing selector probabilities.\n");
                     for (int token = 0; token < draftTokens; token++) {
                         AssertInFastLLM(
@@ -16975,12 +16994,12 @@ namespace fastllm {
                         proposalCandidateIds.end(),
                         proposal->proposalCandidateIds.begin(),
                         proposal->proposalCandidateIds.begin() +
-                            draftTokens * dflashSelectorTopK);
+                            draftTokens * effSelectorTopK);
                     proposalCandidateProbs.insert(
                         proposalCandidateProbs.end(),
                         proposal->proposalCandidateProbs.begin(),
                         proposal->proposalCandidateProbs.begin() +
-                            draftTokens * dflashSelectorTopK);
+                            draftTokens * effSelectorTopK);
                     rowOffset += seqLens[b];
                 }
                 std::vector<float> temperatures(logitRows);
@@ -17000,7 +17019,7 @@ namespace fastllm {
                         proposalTokens.data(), proposalCandidateIds.data(),
                         proposalCandidateProbs.data(), sampled.data(),
                         acceptedDrafts.data(), batch, draftTokens,
-                        dflashSelectorTopK, vocabSize),
+                        effSelectorTopK, vocabSize),
                     "DFlash CUDA rejection sampling failed.\n");
                 speculativeDFlashAccepted.assign(logitRows, 0);
                 rowOffset = 0;
@@ -17300,6 +17319,15 @@ namespace fastllm {
         std::lock_guard<std::mutex> mtpCacheGuard(mtpCacheMutex);
         MtpKvCache &mtpCache = mtpCaches[context];
         DFlashContext &dflashContext = dflashContexts[context];
+        // MTP spec-rejection: distributional MTP drafts routed through the
+        // DFlash rejection verify branch.  Eligibility is per call (single
+        // request, non-greedy) and must be known before runTargetWithPast —
+        // on a validation call the verify forward runs before this call's own
+        // draft chain, reading the proposal the previous call's draft chain
+        // published into dflashContext.
+        const bool mtpSpecRejectionActive =
+            (int)generationConfigs.size() == 1 &&
+            !generationConfigs[0].IsSimpleGreedy();
         auto eraseDraftCache = [&]() {
             mtpCaches.erase(context);
             dflashContexts.erase(context);
@@ -18163,9 +18191,33 @@ namespace fastllm {
                 speculativeDFlashSamplingContext;
             speculativeCollectAllLogits = true;
             speculativeCaptureDFlashHiddenStates = useDFlash;
-            speculativeDFlashSamplingContext =
-                useDFlash && !generationConfigs[0].IsSimpleGreedy() ?
-                    &dflashContext : nullptr;
+            // The MTP long-prefill seeding path enqueues the first verify
+            // without ever publishing a spec proposal (see
+            // appendLongPrefillMtpCache: it drafts one token and touches
+            // only the MTP KV cache, never the DFlash context).  Keep the
+            // rejection branch inactive until the previous call's draft
+            // chain has actually filled the proposal; that single seeded
+            // verify then falls back to the classic MTP acceptance, and
+            // every later verify runs the spec-rejection path as designed.
+            {
+                const int verifyDraftTokens =
+                    std::max(0, curSeqLens[0] - 1);
+                const size_t requiredProposal =
+                    (size_t)verifyDraftTokens *
+                    (size_t)Qwen35MtpSpecRejectionK(
+                        generationConfigs[0].top_k);
+                speculativeDFlashSamplingContext =
+                    (useDFlash ||
+                     (mtpSpecRejectionActive &&
+                      (size_t)dflashContext.proposalTokens.size() >=
+                          (size_t)verifyDraftTokens &&
+                      (size_t)dflashContext.proposalCandidateIds.size() >=
+                          requiredProposal &&
+                      (size_t)dflashContext.proposalCandidateProbs.size() >=
+                          requiredProposal)) &&
+                        !generationConfigs[0].IsSimpleGreedy() ?
+                        &dflashContext : nullptr;
+            }
             if (useDFlash) {
                 speculativeDFlashHiddenStates.clear();
                 speculativeDFlashHiddenStates.resize(
@@ -18273,7 +18325,8 @@ namespace fastllm {
         auto countAcceptedDrafts = [&](const std::vector<int> &targetTokens,
                                        int draftTokenCount) {
             bool useDFlashRejection =
-                useDFlash && !generationConfigs[0].IsSimpleGreedy() &&
+                (useDFlash || mtpSpecRejectionActive) &&
+                !generationConfigs[0].IsSimpleGreedy() &&
                 (int)speculativeDFlashAccepted.size() >= draftTokenCount;
             bool useMtpAcceptance =
                 !useDFlash && !generationConfigs[0].IsSimpleGreedy() &&
@@ -18329,6 +18382,41 @@ namespace fastllm {
                                     int lastPositionRow) {
             std::vector<int> drafts;
             drafts.reserve(mtpDraftsPerStep);
+            // Distributional sampling for this chain; the per-position
+            // top-K candidates are published into dflashContext after the
+            // chain so the next call's verify forward (runTargetWithPast)
+            // can route them through the DFlash rejection branch.
+            std::vector<std::pair<std::vector<int>, std::vector<float>>> specCandidates;
+            if (mtpSpecRejectionActive) {
+                if (mtpSpecDraftSeedBase == 0) {
+                    mtpSpecDraftSeedBase = (unsigned long long)
+                        std::chrono::steady_clock::now().time_since_epoch().count();
+                }
+                const GenerationConfig &specCfg = generationConfigs[0];
+                mtpSpecDraftParams.active = true;
+                mtpSpecDraftParams.temperature = specCfg.temperature;
+                mtpSpecDraftParams.topK = Qwen35MtpSpecRejectionK(specCfg.top_k);
+                mtpSpecDraftParams.topP = specCfg.top_p;
+                mtpSpecDraftParams.seed = mtpSpecDraftSeedBase +
+                    (mtpSpecDraftSeedCounter++);
+                specCandidates.reserve(mtpDraftsPerStep);
+            } else {
+                mtpSpecDraftParams.active = false;
+            }
+            auto collectSpecCandidate = [&]() {
+                AssertInFastLLM(
+                    mtpSpecDraftLast.token >= 0 &&
+                        mtpSpecDraftLast.candidateIds.size() ==
+                            (size_t)mtpSpecDraftParams.topK &&
+                        mtpSpecDraftLast.candidateProbs.size() ==
+                            (size_t)mtpSpecDraftParams.topK,
+                    "MTP spec draft sampling returned an incomplete sample.\n");
+                specCandidates.emplace_back(
+                    std::move(mtpSpecDraftLast.candidateIds),
+                    std::move(mtpSpecDraftLast.candidateProbs));
+                mtpSpecDraftParams.seed = mtpSpecDraftSeedBase +
+                    (mtpSpecDraftSeedCounter++);
+            };
             Data draftHidden;
             auto firstDraftStart = mtpProfileEnabled ? std::chrono::steady_clock::now()
                                                      : std::chrono::steady_clock::time_point();
@@ -18338,6 +18426,9 @@ namespace fastllm {
                                           mtpDraftsPerStep > 1 ? &draftHidden : nullptr);
             mtpProfileAddSpan(mtpProfileDraftFirstUs, firstDraftStart);
             drafts.push_back(draft);
+            if (mtpSpecRejectionActive) {
+                collectSpecCandidate();
+            }
             if (mtpDraftsPerStep > 1) {
                 const int cacheTokens = mtpCache.tokens;
                 // 双缓冲保存上一轮 draft 的 hidden state, 避免每轮多一次 CopyFrom
@@ -18358,6 +18449,9 @@ namespace fastllm {
                                                           0, needNextHidden ? &extraHidden : nullptr);
                         mtpProfileAddSpan(mtpProfileDraftExtraUs, extraDraftStart);
                         drafts.push_back(nextDraft);
+                        if (mtpSpecRejectionActive) {
+                            collectSpecCandidate();
+                        }
                         if (needNextHidden) {
                             prevHidden = &extraHidden;
                         }
@@ -18365,9 +18459,24 @@ namespace fastllm {
                     }
                 } catch (...) {
                     mtpCache.Truncate(cacheTokens);
+                    mtpSpecDraftParams.active = false;
                     throw;
                 }
                 mtpCache.Truncate(cacheTokens);
+            }
+            if (mtpSpecRejectionActive) {
+                mtpSpecDraftParams.active = false;
+                dflashContext.proposalTokens = drafts;
+                dflashContext.proposalCandidateIds.clear();
+                dflashContext.proposalCandidateProbs.clear();
+                for (auto &cand : specCandidates) {
+                    dflashContext.proposalCandidateIds.insert(
+                        dflashContext.proposalCandidateIds.end(),
+                        cand.first.begin(), cand.first.end());
+                    dflashContext.proposalCandidateProbs.insert(
+                        dflashContext.proposalCandidateProbs.end(),
+                        cand.second.begin(), cand.second.end());
+                }
             }
             return drafts;
         };
@@ -29575,6 +29684,36 @@ namespace fastllm {
             }
         }
         std::vector<int> result(batch, -1);
+        if (mtpSpecDraftParams.active && batch == 1) {
+            // Distributional draft: gather the sharded draft logits to root
+            // and sample the draft + top-K candidates there, instead of the
+            // per-rank argmax merge below.
+            for (const auto &local : logits) {
+                AssertInFastLLM(local.dataDevice == DataDevice::CUDA &&
+                                    local.cudaData != nullptr && local.Count(0) > 0,
+                                "MTP TP spec draft requires non-empty logit shards "
+                                "on every rank.\n");
+            }
+            const int vocabSize = (int)weight["lm_head.weight"].dims[0];
+            Data &fullCudaLogits = Qwen35ThreadLocalCudaSamplingFullLogits();
+            Qwen35GatherShardLogitsToRootCuda(device, devices, threadTpLmHeadScheme,
+                                              logits, 1, vocabSize, fullCudaLogits);
+            const int specK = mtpSpecDraftParams.topK;
+            std::vector<int> specIds(specK, -1);
+            std::vector<float> specProbs(specK, 0.0f);
+            int specDraft = -1;
+            int specCount = 0;
+            bool specOk = FastllmCudaMtpDraftSpecSampling(
+                (float*)fullCudaLogits.cudaData, mtpSpecDraftParams.temperature,
+                specK, mtpSpecDraftParams.topP, mtpSpecDraftParams.seed,
+                &specDraft, specIds.data(), specProbs.data(), &specCount, vocabSize);
+            AssertInFastLLM(specOk, "MTP spec draft sampling failed.\n");
+            mtpSpecDraftLast.token = specDraft;
+            mtpSpecDraftLast.candidateIds = std::move(specIds);
+            mtpSpecDraftLast.candidateProbs = std::move(specProbs);
+            result[0] = specDraft;
+            return result;
+        }
         for (int b = 0; b < batch; ++b) {
             float best = -std::numeric_limits<float>::infinity();
             for (int rank = 0; rank < (int)devices.size(); ++rank) {
@@ -30564,10 +30703,35 @@ namespace fastllm {
             return draft;
         };
 
+        auto sampleDraftFromCudaLogits = [&](Data &cudaLogits) {
+            if (!mtpSpecDraftParams.active) {
+                return sampleGreedyFromCudaLogits(cudaLogits);
+            }
+            ToDataType(cudaLogits, DataType::FLOAT32);
+            AssertInFastLLM(cudaLogits.dataDevice == DataDevice::CUDA &&
+                            cudaLogits.cudaData != nullptr,
+                            "Qwen3.5 MTP spec draft logits must stay on CUDA.\n");
+            const int specK = mtpSpecDraftParams.topK;
+            std::vector<int> specIds(specK, -1);
+            std::vector<float> specProbs(specK, 0.0f);
+            int specDraft = -1;
+            int specCount = 0;
+            bool specOk = FastllmCudaMtpDraftSpecSampling(
+                (float*)cudaLogits.cudaData, mtpSpecDraftParams.temperature,
+                specK, mtpSpecDraftParams.topP, mtpSpecDraftParams.seed,
+                &specDraft, specIds.data(), specProbs.data(), &specCount,
+                (int)cudaLogits.dims.back());
+            AssertInFastLLM(specOk, "MTP spec draft sampling failed.\n");
+            mtpSpecDraftLast.token = specDraft;
+            mtpSpecDraftLast.candidateIds = std::move(specIds);
+            mtpSpecDraftLast.candidateProbs = std::move(specProbs);
+            return specDraft;
+        };
+
         Data &lmHead = weight["lm_head.weight"];
         if (!tensorParallelDraft) {
             Linear(*sampleHiddenPtr, lmHead, *GetEmptyData(), logits);
-            return sampleGreedyFromCudaLogits(logits);
+            return sampleDraftFromCudaLogits(logits);
         }
 
         AssertInFastLLM(threadTpWeightsPrepared.load(std::memory_order_acquire) &&
@@ -30637,6 +30801,36 @@ namespace fastllm {
             if (error) {
                 std::rethrow_exception(error);
             }
+        }
+        if (mtpSpecDraftParams.active) {
+            // Distributional draft: gather the sharded draft logits to root
+            // and sample the draft + top-K candidates there, instead of the
+            // per-rank argmax merge below.
+            for (const auto &local : localLogits) {
+                AssertInFastLLM(local.dataDevice == DataDevice::CUDA &&
+                                    local.cudaData != nullptr && local.Count(0) > 0,
+                                "MTP TP spec draft requires non-empty logit shards "
+                                "on every rank.\n");
+            }
+            Data &fullCudaLogits = Qwen35ThreadLocalCudaSamplingFullLogits();
+            Qwen35GatherShardLogitsToRootCuda(device, draftDevices, threadTpLmHeadScheme,
+                                              localLogits, 1, lmHead.dims[0],
+                                              fullCudaLogits);
+            const int specK = mtpSpecDraftParams.topK;
+            std::vector<int> specIds(specK, -1);
+            std::vector<float> specProbs(specK, 0.0f);
+            int specDraft = -1;
+            int specCount = 0;
+            bool specOk = FastllmCudaMtpDraftSpecSampling(
+                (float*)fullCudaLogits.cudaData, mtpSpecDraftParams.temperature,
+                specK, mtpSpecDraftParams.topP, mtpSpecDraftParams.seed,
+                &specDraft, specIds.data(), specProbs.data(), &specCount,
+                (int)lmHead.dims[0]);
+            AssertInFastLLM(specOk, "MTP spec draft sampling failed.\n");
+            mtpSpecDraftLast.token = specDraft;
+            mtpSpecDraftLast.candidateIds = std::move(specIds);
+            mtpSpecDraftLast.candidateProbs = std::move(specProbs);
+            return specDraft;
         }
         bool allBestReady = true;
         for (int ready : localBestReady) {


### PR DESCRIPTION

## PR1 摘要

> **问题 #722（死锁）**：双卡 TP（偶数 TP）+ MTP 长上下文 prefill 永久卡死。偶数 TP 的集合通信对大张量会回退 NCCL；一个 rank 在 peer 仍在提交 NCCL 时进入下一个 GEMM/分配器（持 CUDA 驱动锁并隐式同步），双方在驱动锁上互等 → 死锁。实测卡死点恰在 256 页分页参数边界。原代码仅 odd-TP 创建 `NcclSubmitRendezvous`（`numGPUs % 2 != 0`），偶数 TP 缺这道会合。
>
> **修复 A（`fastllm-multicuda.cu`）**：把会合创建条件从 `numGPUs % 2 != 0` 放宽为 `numGPUs > 1`——所有多 rank TP 组在 NCCL 提交前会合。`NcclSubmitRendezvous` 类为上游既有代码（`include/devices/multicuda/ncclsubmitrendezvous.h`），本修复不新增该类。
>
> **修复 B（`fastllm-attention.cu` + `cudadevice.cpp`）**：分页参数（qSizes/pageSizes/pageIndexs/lastPageLens）原先经 4 次 pageable H2D memcpy 上传，DMA 期间持 CUDA 驱动锁，正是死锁窗口之一。改为把参数值放进 kernel 参数空间由单线程 kernel 写入显存：无阻塞拷贝、可被 CUDA Graph 捕获；超过 kernel 参数预算（sm_70+ 为 32 KiB，最大档 MaxPages=4096 约 17 KiB）时返回 false，调用方保留原 memcpy 回退，行为不变。
>
> **问题 #724（设备 fault）**：custom all-reduce kernel 以 16 字节对齐包访问 data/dest，收到未对齐指针时设备侧 fault（`cudaErrorMisalignedAddress` / Xid 13）。另：custom AR 仅靠指针元组按到达顺序配对 rank，任一 rank 的集合通信调用流发生失步（例如某 rank 多调/漏调一次），后续每一轮都会配错 peer 张量——静默算错或越界读已释放的 peer buffer。
>
> **修复 C（`fastllm-custom-allreduce.cu`）**：① 三个候选函数（`RunCustomArCandidate`/`RunCustomArPairAddCandidate`/`RunCustomArAddCandidate`）入口加 16B 对齐守卫，未对齐返回 false 回退 NCCL；② `CustomArState` 增加 per-rank 调用序号（`rankCallSequence`/`pendingSequences`），到齐后比对各 rank 序号，失步则该轮拒绝（回退 NCCL）并一次性打日志；③ `FastllmCudaCustomAllReduceReset` 复位全部序号状态。
>
> 三处修复均为纯防御性：不改变任何数值路径；失败一律回退既有 NCCL/memcpy 路径。

## PR2 摘要
上游 #728
> **现状（`4b0f717d`）**：`2f457292` 已修掉 MTP 采样分布偏差，手段是**保留 one-hot 贪心草稿 + 精确接受**：草稿 `d = argmax`（源码注释明言 "The MTP head proposes greedy (one-hot) drafts."，`qwen3_5.cpp:17054`；单请求/非 TP 走 `sampleGreedyFromCudaLogits` `:30570`，TP 走 `RunMtpTpDraft` per-rank `FastllmCudaGreedySamplingWithScores` `:29544`），接受判据 `speculativeMtpAccepted[row] = sampled[row] == mtpDraftIds[i]`（`:17069`）。数学上这等价于**链拒绝 + one-hot 草稿分布 `q = δ_argmax`**：输出分布精确无偏，但单位置接受率上限被钉死在 `p(argmax)`——长思考高熵段 `p(argmax)` 仅 0.4–0.7，`2f457292` commit message 自报吞吐 **−16.2%**。
>
> **本 PR（S3）**：补上缺的一步——**把草稿从 one-hot 分布化**。每个草稿位在与验证侧**完全相同**的过滤链（temperature softmax → top-K renorm → top-P renorm，复用 `4b0f717d` 验证侧同一组 kernel）内做 Gumbel-max 采样得草稿 token `d`，并收集该位 top-K 候选；整条草稿链结束后把 `drafts + 逐位候选` 发布进既有的 `DFlashContext.proposal*`。验证前向复用 `4b0f717d` **保留下来的** `FastllmCudaDFlashRejectionSampling` 链拒绝分支（kernel 零改动）：`y == d` → 接受；`y ∈ 候选` → scatter 接受 `y`、链继续；否则 → 提交 `y` 残差、断链。
>
> **正确性**：链拒绝理论保证输出分布**精确等于目标 `p`**（Leviathan et al. 2023，与 `2f457292` 同级正确性）。
> **接受率**：单位置接受率从 `p(argmax)` 变为 `overlap(p,q) = Σ_v min(p(v), q(v))`，恒有 `overlap(p,q) ≥ min(p(argmax), q(argmax)) + Σ_{v≠argmax} min(p(v), q(v))`；当 `q` 为 `p` 的良近似（`q(argmax) ≥ p(argmax)` 且 `∃v≠argmax: p(v)q(v) > 0`）时**严格大于 `p(argmax)`**——S3 草稿与目标同过滤空间、MTP head 近似目标，条件成立。`2f457292` 的 one-hot 草稿即 `q = δ_argmax` 退化端点（第二项恒 0，接受率恰为 `p(argmax)`），故 S3 在良近似条件下严格优于现状。
>
> **启用条件**：单请求 && 非贪心（`generationConfigs.size() == 1 && !IsSimpleGreedy()`）时自动启用，无 env 开关；其余情形（贪心、多请求批处理、DFlash 权重模型）走原路径，代码路径不变。注意 `4b0f717d` 的 `Qwen35MtpSupportsGenerationConfig` 对 `repeat_penalty ≠ 1` 整体禁用 MTP，此类请求本就无 MTP 草稿，不受影响。
> **候选宽度**：`K = clamp(请求 top_k, 1, 64)`，与验证侧 `max(1, top_k)` 钳位一致。
> **回退**：git revert（本 PR 独立可摘；无运行时开关）。
>
> **实测（fork 同源实现，base 早于 `2f457292`，2×2080Ti / Qwen3.8-27B-FP8 / TP=2，非贪心 T=1.0/top_p=0.95/top_k=20）**：三位接受率 **89.37 / 77.24 / 66.17**（S3 前同模型基线 73.2/54.0/41.5），tok/step **3.328（+23.9%**），形态保持几何衰减（无准贪心锁定回归），32k–169k 长 prefill 播种 19 次全存活，0 Xid / 0 Assert。**在 `4b0f717d` 上的 A/B 重测为本 PR 落地前置验证**。

## PR2 机制图

```
草稿侧（每个草稿位一次，单请求且非贪心时启用）
  MTP head logits ──→ temperature softmax ──→ top-K renorm ──→ top-P renorm
      （与验证侧 target 完全相同的过滤链 → 草稿 q 与目标 p 同处一个过滤空间）
      ──→ Gumbel-max 采样 → 草稿 token d
          （score = log(p) + log(u)；u 由 splitmix64(seed, index) 无状态派生，
            seed = 首个草稿步 steady_clock 时间戳 + 每草稿位自增计数器，可复现）
      ──→ 收集该位 top-K（p>0）候选（ids + 归一化概率）
  整条草稿链结束：drafts + 逐位候选 → 发布到 dflashContext.proposal*
  落点：替换 4b0f717d 的 RunMtpGreedyDraft 非 TP argmax(:30570)、
        RunMtpTpDraft per-rank argmax 合并(:29577-:29600)、
        RunMtpGreedyDraft 自有 TP argmax 合并(:30641-:30673)

验证侧
  目标前向对扩展序列打分 → 目标采样 y ~ p（4b0f717d 既有采样，未改）
      复用 4b0f717d 保留的 FastllmCudaDFlashRejectionSampling(:16997) 做链拒绝：
        y == d           → 接受草稿 d（链继续）
        y ∈ 候选列表      → scatter 接受 y（链继续，提交 y）
        否则             → 提交 y 残差，断链
  落点：runTargetWithPast 的 speculativeDFlashSamplingContext 路由(:18166-:18168)
        + DFlash 拒绝分支候选宽度(:16944-:17003 处 effSelectorTopK)
        + countAcceptedDrafts 接受计数(:18275-:18277)
```

## 不足
1.PR1的具体影响机制仍缺乏直接证据，因此均采取防御性修复，如此一来可能会造成不必要的代码修改
